### PR TITLE
Make MantaClientHttpResponseException extend IOException for better back...

### DIFF
--- a/src/main/java/com/joyent/manta/exception/MantaClientHttpResponseException.java
+++ b/src/main/java/com/joyent/manta/exception/MantaClientHttpResponseException.java
@@ -6,13 +6,15 @@ package com.joyent.manta.exception;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
 
+import java.io.IOException;
+
 /**
  * Convenience wrapper over {@link HttpResponseException} so that consumers of this library don't have to depend on the
  * underlying HTTP client implementation.
  *
  * @author Yunong Xiao
  */
-public class MantaClientHttpResponseException extends MantaClientException {
+public class MantaClientHttpResponseException extends IOException {
 
     private static final long serialVersionUID = -7189613417468699L;
 


### PR DESCRIPTION
...wards compatibility.

Previously, where clients didn't need access to specific HTTP fields contained in HttpResponseException, they have been catching HttpResponseException as IOException (because former is a subclass of latter), for example in recursive delete logic:

```
try { 
    client.delete(blah);
} catch (IOException e) {
    client.deleteRecursively(blah);
} 
```

Now that we switched to MantaClientHttpResponseException, this is no longer possible, and two exceptions need to be handled in the same way:

```
boolean deleteRecursively = false;
try { 
    client.delete(blah);
} catch (IOException e) {
   deleteRecursively = true;
} catch (MantaClientHttpResponseException e) {
   deleteRecursively = true;
}
if (deleteRecursively) {
    client.deleteRecursively(blah);
}
```

However, the old logic may be achieved if MantaClientHttpResponseException extends IOException instead of MantaClientException.
