### PR TITLE
Add setRoles() and setDurabilityLevel() to MantaHttpHeaders

### DIFF
--- a/java-manta-client/pom.xml
+++ b/java-manta-client/pom.xml
@@ -21,7 +21,6 @@
         <!-- Dependency versions -->
         <dependency.apache-http-client.version>4.5.1</dependency.apache-http-client.version>
         <dependency.bouncycastle.version>1.53</dependency.bouncycastle.version>
-        <dependency.commons-collections.version>4.0</dependency.commons-collections.version>
         <dependency.google-http-client.version>1.20.0</dependency.google-http-client.version>
         <dependency.google-http-client-signature.version>1.0.0</dependency.google-http-client-signature.version>
     </properties>

--- a/java-manta-client/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -843,6 +843,23 @@ public class MantaClient implements AutoCloseable {
 
 
     /**
+     * Appends metadata derived from HTTP headers to an existing Manta object.
+     *
+     * @param path     The fully qualified path of the object. i.e. /user/stor/foo/bar/baz
+     * @param headers  HTTP headers to include when copying the object
+     * @return Manta response object
+     * @throws IOException when there is a problem sending the metadata over the wire
+     */
+    public MantaObjectResponse putMetadata(final String path, final MantaHttpHeaders headers)
+            throws IOException {
+        Objects.requireNonNull(headers, "Headers must be present");
+
+        final MantaMetadata metadata = new MantaMetadata(headers.metadataAsStrings());
+        return putMetadata(path, headers, metadata);
+    }
+
+
+    /**
      * Appends the specified metadata to an existing Manta object using the
      * specified HTTP headers.
      *

--- a/java-manta-client/src/main/java/com/joyent/manta/client/MantaHttpHeaders.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/MantaHttpHeaders.java
@@ -27,6 +27,10 @@ import static com.joyent.http.signature.HttpSignerUtils.X_REQUEST_ID_HEADER;
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  */
 public class MantaHttpHeaders {
+    /**
+     * HTTP header for Manta durability level.
+     */
+    public static final String HTTP_DURABILITY_LEVEL = "Durability-Level";
 
     /**
      * HttpHeaders delegate which is wrapped by this class.
@@ -280,6 +284,36 @@ public class MantaHttpHeaders {
         }
 
         return itr.next();
+    }
+
+
+    /**
+     * Sets the number of replicated copies of the object in Manta.
+     *
+     * @param copies number of copies
+     */
+    public void setDurabilityLevel(final int copies) {
+        if (copies < 1) {
+            throw new IllegalArgumentException("Copies must be 1 or greater");
+        }
+
+        set(HTTP_DURABILITY_LEVEL, String.valueOf(copies));
+    }
+
+
+    /**
+     * Gets the number of replicated copies of the object in Manta.
+     *
+     * @return copies number of copies
+     */
+    public Integer getDurabilityLevel() {
+        final String value = getFirstHeaderStringValue(HTTP_DURABILITY_LEVEL);
+
+        if (value == null) {
+            return null;
+        }
+
+        return Integer.parseInt(value);
     }
 
 

--- a/java-manta-client/src/main/java/com/joyent/manta/client/MantaHttpHeaders.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/MantaHttpHeaders.java
@@ -322,11 +322,10 @@ public class MantaHttpHeaders {
     public void setRoles(final Set<String> roles) {
         Objects.requireNonNull(roles, "Roles must be present");
 
-        if (roles.isEmpty()) {
-            return;
-        }
-
-        set(HTTP_ROLE_TAG, roles);
+        /* Set roles as a single HTTP header with each role delineated by
+         * a comma.
+         */
+        set(HTTP_ROLE_TAG, asString(roles));
     }
 
 
@@ -342,7 +341,7 @@ public class MantaHttpHeaders {
             return Collections.emptySet();
         }
 
-        final HashSet roles = new HashSet<>();
+        final HashSet<String> roles = new HashSet<>();
 
         if (value instanceof Iterable<?>) {
             ((Iterable<?>)value).forEach(o -> {
@@ -354,6 +353,22 @@ public class MantaHttpHeaders {
             for (Object o : (Object[])value) {
                 if (o != null) {
                     roles.add(o.toString());
+                }
+            }
+        }
+
+        /* The result may come to us as a CSV. In that case we treat each
+         * value separated by a comma as a single role.
+         */
+        if (roles.size() == 1) {
+            String line = roles.iterator().next();
+
+            if (line.contains(",")) {
+                String[] parts = line.split(",\\s*");
+                roles.clear();
+
+                for (String part : parts) {
+                    roles.add(part);
                 }
             }
         }

--- a/java-manta-client/src/main/java/com/joyent/manta/client/MantaHttpHeaders.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/MantaHttpHeaders.java
@@ -7,7 +7,16 @@ import org.apache.http.Header;
 import org.apache.http.HeaderElement;
 import org.apache.http.message.BasicHeader;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 import static com.joyent.http.signature.HttpSignerUtils.X_REQUEST_ID_HEADER;
 

--- a/java-manta-client/src/main/java/com/joyent/manta/client/MantaHttpHeaders.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/MantaHttpHeaders.java
@@ -7,15 +7,7 @@ import org.apache.http.Header;
 import org.apache.http.HeaderElement;
 import org.apache.http.message.BasicHeader;
 
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 
 import static com.joyent.http.signature.HttpSignerUtils.X_REQUEST_ID_HEADER;
 
@@ -31,6 +23,11 @@ public class MantaHttpHeaders {
      * HTTP header for Manta durability level.
      */
     public static final String HTTP_DURABILITY_LEVEL = "Durability-Level";
+
+    /**
+     * HTTP header for account roles.
+     */
+    public static final String HTTP_ROLE_TAG = "Role-Tag";
 
     /**
      * HttpHeaders delegate which is wrapped by this class.
@@ -205,7 +202,7 @@ public class MantaHttpHeaders {
                 }
 
                 if (i < array.length - 1) {
-                    sb.append("; ");
+                    sb.append(", ");
                 }
             }
 
@@ -314,6 +311,54 @@ public class MantaHttpHeaders {
         }
 
         return Integer.parseInt(value);
+    }
+
+
+    /**
+     * Sets the header defining account roles used for this object.
+     *
+     * @param roles roles associated with object
+     */
+    public void setRoles(final Set<String> roles) {
+        Objects.requireNonNull(roles, "Roles must be present");
+
+        if (roles.isEmpty()) {
+            return;
+        }
+
+        set(HTTP_ROLE_TAG, roles);
+    }
+
+
+    /**
+     * Gets the header defining account roles used for this object.
+     *
+     * @return roles associated with object
+     */
+    public Set<String> getRoles() {
+        final Object value = get(HTTP_ROLE_TAG);
+
+        if (value == null) {
+            return Collections.emptySet();
+        }
+
+        final HashSet roles = new HashSet<>();
+
+        if (value instanceof Iterable<?>) {
+            ((Iterable<?>)value).forEach(o -> {
+                if (o != null) {
+                    roles.add(o.toString());
+                }
+            });
+        } else if (value.getClass().isArray()) {
+            for (Object o : (Object[])value) {
+                if (o != null) {
+                    roles.add(o.toString());
+                }
+            }
+        }
+
+        return Collections.unmodifiableSet(roles);
     }
 
 

--- a/java-manta-client/src/main/java/com/joyent/manta/client/MantaHttpHeaders.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/MantaHttpHeaders.java
@@ -137,11 +137,11 @@ public class MantaHttpHeaders {
 
             if (value instanceof Iterable<?> || valueClass.isArray()) {
                 for (Object multiple : Types.iterableOf(value)) {
-                    final Header header = new BasicHeader(displayName, asString(multiple));
+                    final Header header = new BasicHeader(displayName, MantaUtils.asString(multiple));
                     headers.add(header);
                 }
             } else {
-                final Header header = new BasicHeader(displayName, asString(value));
+                final Header header = new BasicHeader(displayName, MantaUtils.asString(value));
                 headers.add(header);
             }
         }
@@ -159,57 +159,6 @@ public class MantaHttpHeaders {
      */
     HttpHeaders asGoogleClientHttpHeaders() {
         return wrappedHeaders;
-    }
-
-
-    /**
-     * Serializes a specified value to a {@link java.lang.String}.
-     * @param value the value to be serialized
-     * @return a serialized value as a {@link java.lang.String}
-     */
-    private static String asString(final Object value) {
-        if (value == null) {
-            return null;
-        } else if (value instanceof Enum<?>) {
-            return FieldInfo.of((Enum<?>) value).getName();
-        } else if (value instanceof Iterable<?>) {
-            StringBuilder sb = new StringBuilder();
-
-            Iterator<?> itr = ((Iterable<?>) value).iterator();
-            while (itr.hasNext()) {
-                Object next = itr.next();
-
-                if (next != null) {
-                    sb.append(next.toString());
-                }
-
-                if (itr.hasNext()) {
-                    sb.append(",");
-                }
-            }
-
-            return sb.toString();
-        } else if (value.getClass().isArray()) {
-            Object[] array = (Object[])value;
-
-            StringBuilder sb = new StringBuilder();
-
-            for (int i = 0; i < array.length; i++) {
-                Object next = array[i];
-
-                if (next != null) {
-                    sb.append(next.toString());
-                }
-
-                if (i < array.length - 1) {
-                    sb.append(", ");
-                }
-            }
-
-            return sb.toString();
-        }
-
-        return value.toString();
     }
 
 
@@ -241,7 +190,7 @@ public class MantaHttpHeaders {
         final Map<String, String> metadata = new HashMap<>();
         for (Map.Entry<String, Object> entry : wrappedHeaders.entrySet()) {
             if (entry.getKey().startsWith("m-")) {
-                metadata.put(entry.getKey(), asString(entry.getValue()));
+                metadata.put(entry.getKey(), MantaUtils.asString(entry.getValue()));
             }
         }
 
@@ -325,7 +274,7 @@ public class MantaHttpHeaders {
         /* Set roles as a single HTTP header with each role delineated by
          * a comma.
          */
-        set(HTTP_ROLE_TAG, asString(roles));
+        set(HTTP_ROLE_TAG, MantaUtils.asString(roles));
     }
 
 
@@ -355,6 +304,9 @@ public class MantaHttpHeaders {
                     roles.add(o.toString());
                 }
             }
+        } else {
+            String line = value.toString();
+            roles.addAll(MantaUtils.fromCsv(line));
         }
 
         /* The result may come to us as a CSV. In that case we treat each
@@ -362,15 +314,8 @@ public class MantaHttpHeaders {
          */
         if (roles.size() == 1) {
             String line = roles.iterator().next();
-
-            if (line.contains(",")) {
-                String[] parts = line.split(",\\s*");
-                roles.clear();
-
-                for (String part : parts) {
-                    roles.add(part);
-                }
-            }
+            roles.clear();
+            roles.addAll(MantaUtils.fromCsv(line));
         }
 
         return Collections.unmodifiableSet(roles);
@@ -1178,7 +1123,7 @@ public class MantaHttpHeaders {
      * @return the value serialized to a {@code java.lang.String}
      */
     public String getAsString(final Object name) {
-        return asString(wrappedHeaders.get(name));
+        return MantaUtils.asString(wrappedHeaders.get(name));
     }
 
 

--- a/java-manta-client/src/main/java/com/joyent/manta/client/MantaUtils.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/MantaUtils.java
@@ -3,6 +3,7 @@
  */
 package com.joyent.manta.client;
 
+import com.google.api.client.util.FieldInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,6 +14,10 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Objects;
 import java.util.Scanner;
 
@@ -221,5 +226,81 @@ public final class MantaUtils {
         final String subuser = account.substring(slashPos + 1);
 
         return new String[] {username, subuser};
+    }
+
+    /**
+     * Serializes a specified value to a {@link String}.
+     * @param value the value to be serialized
+     * @return a serialized value as a {@link String}
+     */
+    public static String asString(final Object value) {
+        if (value == null) {
+            return null;
+        } else if (value instanceof Enum<?>) {
+            return FieldInfo.of((Enum<?>) value).getName();
+        } else if (value instanceof Iterable<?>) {
+            StringBuilder sb = new StringBuilder();
+
+            Iterator<?> itr = ((Iterable<?>) value).iterator();
+            while (itr.hasNext()) {
+                Object next = itr.next();
+
+                if (next != null) {
+                    sb.append(next.toString());
+                }
+
+                if (itr.hasNext()) {
+                    sb.append(",");
+                }
+            }
+
+            return sb.toString();
+        } else if (value.getClass().isArray()) {
+            Object[] array = (Object[])value;
+
+            StringBuilder sb = new StringBuilder();
+
+            for (int i = 0; i < array.length; i++) {
+                Object next = array[i];
+
+                if (next != null) {
+                    sb.append(next.toString());
+                }
+
+                if (i < array.length - 1) {
+                    sb.append(", ");
+                }
+            }
+
+            return sb.toString();
+        }
+
+        return value.toString();
+    }
+
+
+    /**
+     * Converts a naive CSV string to a collection.
+     *
+     * @param line CSV string
+     * @return collection containing each value between each comma
+     */
+    public static Collection<String> fromCsv(final String line) {
+        Objects.requireNonNull(line, "Line must be present");
+
+        final List<String> list = new ArrayList<>();
+
+        if (line.contains(",")) {
+            String[] parts = line.split(",\\s*");
+
+            for (String part : parts) {
+                list.add(part);
+            }
+        } else {
+            list.add(line);
+        }
+
+
+        return list;
     }
 }

--- a/java-manta-client/src/main/java/com/joyent/manta/exception/MantaClientHttpResponseException.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/exception/MantaClientHttpResponseException.java
@@ -132,7 +132,7 @@ public class MantaClientHttpResponseException extends IOException {
     public String getMessage() {
         if (serverCode.equals(MantaErrorCode.NO_CODE_ERROR)) {
             return innerException.getMessage();
-        } else if (serverCode.equals(MantaErrorCode.UNKNOWN_ERROR)){
+        } else if (serverCode.equals(MantaErrorCode.UNKNOWN_ERROR)) {
             return String.format("%d %s - Unknown error content: %s",
                     innerException.getStatusCode(),
                     innerException.getStatusMessage(),

--- a/java-manta-client/src/main/java/com/joyent/manta/exception/MantaErrorCode.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/exception/MantaErrorCode.java
@@ -33,6 +33,7 @@ public enum MantaErrorCode {
     INVALID_JOB_ERROR("InvalidJob"),
     INVALID_LINK_ERROR("InvalidLink"),
     INVALID_LIMIT_ERROR("InvalidLimit"),
+    INVALID_ROLE_TAG_ERROR("InvalidRoleTag"),
     INVALID_SIGNATURE_ERROR("InvalidSignature"),
     INVALID_UPDATE_ERROR("InvalidUpdate"),
     DIRECTORY_DOES_NOT_EXIST_ERROR("DirectoryDoesNotExist"),

--- a/java-manta-client/src/test/java/com/joyent/manta/client/MantaHttpHeadersTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/MantaHttpHeadersTest.java
@@ -1,0 +1,33 @@
+package com.joyent.manta.client;
+
+import junit.framework.Assert;
+import org.apache.commons.collections4.CollectionUtils;
+import org.testng.annotations.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Tests for verifying the behavior of HTTP header assignment.
+ *
+ * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ */
+public class MantaHttpHeadersTest {
+    @Test
+    public void canSetRoleTags() {
+        final MantaHttpHeaders headers = new MantaHttpHeaders();
+        final Set<String> roles = new HashSet<>();
+        roles.add("admin");
+        roles.add("read-only");
+        roles.add("reporting");
+
+        headers.setRoles(roles);
+
+        Set<String> actual = headers.getRoles();
+
+        if (!CollectionUtils.isEqualCollection(actual, roles)) {
+            Assert.failNotEquals("Input and output roles, should be equal",
+                    actual, roles);
+        }
+    }
+}

--- a/java-manta-client/src/test/java/com/joyent/manta/client/MantaHttpHeadersTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/MantaHttpHeadersTest.java
@@ -27,8 +27,7 @@ public class MantaHttpHeadersTest {
         Set<String> actual = headers.getRoles();
 
         if (!CollectionUtils.isEqualCollection(actual, roles)) {
-            Assert.failNotEquals("Input and output roles, should be equal",
-                    actual, roles);
+            Assert.fail("Input and output roles, should be equal");
         }
     }
 }

--- a/java-manta-client/src/test/java/com/joyent/manta/client/MantaHttpHeadersTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/MantaHttpHeadersTest.java
@@ -12,6 +12,7 @@ import java.util.Set;
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  */
+@Test(groups = { "headers" })
 public class MantaHttpHeadersTest {
     @Test
     public void canSetRoleTags() {

--- a/java-manta-it/pom.xml
+++ b/java-manta-it/pom.xml
@@ -49,6 +49,12 @@
             <version>${dependency.slfj.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>${dependency.commons-collections.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>com.google.http-client</groupId>

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaHttpHeadersIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaHttpHeadersIT.java
@@ -1,0 +1,236 @@
+package com.joyent.manta.client;
+
+import com.joyent.manta.client.config.TestConfigContext;
+import com.joyent.manta.config.ConfigContext;
+import com.joyent.manta.exception.MantaClientHttpResponseException;
+import com.joyent.test.util.MantaAssert;
+import com.joyent.test.util.MantaFunction;
+import junit.framework.Assert;
+import org.apache.commons.collections4.CollectionUtils;
+import org.testng.SkipException;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.joyent.manta.exception.MantaErrorCode.INVALID_ROLE_TAG_ERROR;
+
+/**
+ * Integration tests for verifying the behavior of HTTP header assignment.
+ *
+ * For the role tests to work properly, you will need to add a <pre>manta</pre>
+ * role and a <pre>role2</pre> role.
+ *
+ * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ */
+@SuppressWarnings("Duplicates")
+@Test(groups = { "headers" })
+public class MantaHttpHeadersIT {
+    private static final String TEST_DATA = "EPISODEII_IS_BEST_EPISODE";
+
+    private MantaClient mantaClient;
+
+    private String testPathPrefix;
+
+
+    @BeforeClass
+    @Parameters({"manta.url", "manta.user", "manta.key_path", "manta.key_id", "manta.timeout"})
+    public void beforeClass(@Optional String mantaUrl,
+                            @Optional String mantaUser,
+                            @Optional String mantaKeyPath,
+                            @Optional String mantaKeyId,
+                            @Optional Integer mantaTimeout)
+            throws IOException {
+
+        // Let TestNG configuration take precedence over environment variables
+        ConfigContext config = new TestConfigContext(
+                mantaUrl, mantaUser, mantaKeyPath, mantaKeyId, mantaTimeout);
+
+        mantaClient = new MantaClient(config);
+        testPathPrefix = String.format("/%s/stor/%s/",
+                config.getMantaHomeDirectory(), UUID.randomUUID());
+        mantaClient.putDirectory(testPathPrefix, null);
+    }
+
+
+    @AfterClass
+    public void cleanup() throws IOException {
+        if (mantaClient != null) {
+            mantaClient.deleteRecursive(testPathPrefix);
+            mantaClient.closeQuietly();
+        }
+    }
+
+
+    @Test
+    public void cantSetUnknownTags() throws IOException {
+        final MantaHttpHeaders headers = new MantaHttpHeaders();
+        final Set<String> roles = new HashSet<>();
+        roles.add("thistestprobablydoesntexist");
+        headers.setRoles(roles);
+
+        String path = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+
+        MantaAssert.assertResponseFailureStatusCode(409, INVALID_ROLE_TAG_ERROR,
+                (MantaFunction<Object>) () -> mantaClient.put(path, TEST_DATA, headers));
+    }
+
+
+    @Test
+    public void canSetSingleRoleTag() throws IOException {
+        final MantaHttpHeaders headers = new MantaHttpHeaders();
+        final Set<String> roles = new HashSet<>();
+        roles.add("manta");
+        headers.setRoles(roles);
+
+        String path = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+
+        try {
+            mantaClient.put(path, TEST_DATA, headers);
+        } catch (MantaClientHttpResponseException e) {
+            if (e.getServerCode().equals(INVALID_ROLE_TAG_ERROR)) {
+                String msg = "You will need to add roles [manta] in "
+                        + "order for this test to work";
+                throw new SkipException(msg, e);
+            }
+
+            throw e;
+        }
+
+        MantaObject object = mantaClient.get(path);
+        MantaHttpHeaders actualHeaders = object.getHttpHeaders();
+        Set<String> actual = actualHeaders.getRoles();
+
+        if (!CollectionUtils.isEqualCollection(actual, roles)) {
+            Assert.failNotEquals("Input and output roles, should be equal",
+                    roles, actual);
+        }
+    }
+
+
+    @Test
+    public void canSetMultipleRoleTags() throws IOException {
+        final MantaHttpHeaders headers = new MantaHttpHeaders();
+        final Set<String> roles = new HashSet<>();
+        roles.add("manta");
+        roles.add("role2");
+        headers.setRoles(roles);
+
+        String path = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+
+        try {
+            mantaClient.put(path, TEST_DATA, headers);
+        } catch (MantaClientHttpResponseException e) {
+            if (e.getServerCode().equals(INVALID_ROLE_TAG_ERROR)) {
+                String msg = "You will need to add roles [manta, role2] in "
+                             + "order for this test to work";
+                throw new SkipException(msg, e);
+            }
+
+            throw e;
+        }
+
+        MantaObject object = mantaClient.get(path);
+        MantaHttpHeaders actualHeaders = object.getHttpHeaders();
+        Set<String> actual = actualHeaders.getRoles();
+
+        if (!CollectionUtils.isEqualCollection(actual, roles)) {
+            Assert.failNotEquals("Input and output roles, should be equal",
+                    roles, actual);
+        }
+    }
+
+    @Test
+    public void canOverwriteRoleTags() throws IOException {
+        final MantaHttpHeaders headers = new MantaHttpHeaders();
+        final Set<String> roles = new HashSet<>();
+        roles.add("manta");
+        roles.add("role2");
+        headers.setRoles(roles);
+
+        String path = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+
+        try {
+            mantaClient.put(path, TEST_DATA, headers);
+        } catch (MantaClientHttpResponseException e) {
+            if (e.getServerCode().equals(INVALID_ROLE_TAG_ERROR)) {
+                String msg = "You will need to add roles [manta, role2] in "
+                        + "order for this test to work";
+                throw new SkipException(msg, e);
+            }
+        }
+
+        // Verify that we initially added two roles
+        {
+            MantaObject object = mantaClient.get(path);
+            MantaHttpHeaders actualHeaders = object.getHttpHeaders();
+            Set<String> actual = actualHeaders.getRoles();
+
+            if (!CollectionUtils.isEqualCollection(actual, roles)) {
+                Assert.failNotEquals("Input and output roles, should be equal",
+                        roles, actual);
+            }
+        }
+
+        final Set<String> updatedRoles = new HashSet<>();
+        updatedRoles.add("manta");
+
+        final MantaHttpHeaders updatedHeaders = new MantaHttpHeaders();
+        updatedHeaders.setRoles(updatedRoles);
+
+        mantaClient.putMetadata(path, updatedHeaders);
+
+        MantaObject object = mantaClient.get(path);
+        MantaHttpHeaders actualUpdatedHeaders = object.getHttpHeaders();
+        Set<String> actualUpdatedRoles = actualUpdatedHeaders.getRoles();
+
+        if (!CollectionUtils.isEqualCollection(actualUpdatedRoles, updatedRoles)) {
+            Assert.failNotEquals("Roles should have been updated",
+                    roles, actualUpdatedRoles);
+        }
+    }
+
+    @Test
+    public void canClearRoles() throws IOException {
+        final MantaHttpHeaders headers = new MantaHttpHeaders();
+        final Set<String> roles = new HashSet<>();
+        roles.add("manta");
+        roles.add("role2");
+        headers.setRoles(roles);
+
+        String path = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+
+        try {
+            mantaClient.put(path, TEST_DATA, headers);
+        } catch (MantaClientHttpResponseException e) {
+            if (e.getServerCode().equals(INVALID_ROLE_TAG_ERROR)) {
+                String msg = "You will need to add roles [manta, role2] in "
+                        + "order for this test to work";
+                throw new SkipException(msg, e);
+            }
+        }
+
+        final Set<String> updatedRoles = new HashSet<>();
+
+        final MantaHttpHeaders updatedHeaders = new MantaHttpHeaders();
+        updatedHeaders.setRoles(updatedRoles);
+
+        mantaClient.putMetadata(path, updatedHeaders);
+
+        MantaObject object = mantaClient.get(path);
+        MantaHttpHeaders actualUpdatedHeaders = object.getHttpHeaders();
+        Set<String> actualUpdatedRoles = actualUpdatedHeaders.getRoles();
+
+        if (!actualUpdatedRoles.isEmpty()) {
+            Assert.failNotEquals("Roles weren't removed", Collections.emptySet(),
+                    actualUpdatedRoles);
+        }
+    }
+}

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaHttpHeadersIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaHttpHeadersIT.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
+import static com.joyent.manta.client.MantaUtils.asString;
 import static com.joyent.manta.exception.MantaErrorCode.INVALID_ROLE_TAG_ERROR;
 
 /**
@@ -108,7 +109,11 @@ public class MantaHttpHeadersIT {
         Set<String> actual = actualHeaders.getRoles();
 
         if (!CollectionUtils.isEqualCollection(actual, roles)) {
-            Assert.fail("Input and output roles, should be equal");
+            String msg = String.format("Input and output roles, should be equal.\n" +
+                                       "Actual:   [%s]\nExpected: [%s]",
+                                       asString(actual),
+                                       asString(roles));
+            Assert.fail(msg);
         }
     }
 
@@ -140,7 +145,11 @@ public class MantaHttpHeadersIT {
         Set<String> actual = actualHeaders.getRoles();
 
         if (!CollectionUtils.isEqualCollection(actual, roles)) {
-            Assert.fail("Input and output roles, should be equal");
+            String msg = String.format("Input and output roles, should be equal.\n" +
+                            "Actual:   [%s]\nExpected: [%s]",
+                    asString(actual),
+                    asString(roles));
+            Assert.fail(msg);
         }
     }
 
@@ -188,7 +197,11 @@ public class MantaHttpHeadersIT {
         Set<String> actualUpdatedRoles = actualUpdatedHeaders.getRoles();
 
         if (!CollectionUtils.isEqualCollection(actualUpdatedRoles, updatedRoles)) {
-            Assert.fail("Roles should have been updated");
+            String msg = String.format("Roles should have been updated.\n" +
+                                       "Actual:   [%s]\nExpected: [%s]",
+                                       asString(actualUpdatedRoles),
+                                       asString(updatedRoles));
+            Assert.fail(msg);
         }
     }
 
@@ -224,7 +237,10 @@ public class MantaHttpHeadersIT {
         Set<String> actualUpdatedRoles = actualUpdatedHeaders.getRoles();
 
         if (!actualUpdatedRoles.isEmpty()) {
-            Assert.fail("Roles weren't removed");
+            String msg = String.format("Roles weren't removed.\n" +
+                                       "Actual:   [%s]\nExpected: []",
+                                       asString(actualUpdatedRoles));
+            Assert.fail(msg);
         }
     }
 

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaHttpHeadersIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaHttpHeadersIT.java
@@ -5,8 +5,8 @@ import com.joyent.manta.config.ConfigContext;
 import com.joyent.manta.exception.MantaClientHttpResponseException;
 import com.joyent.test.util.MantaAssert;
 import com.joyent.test.util.MantaFunction;
-import junit.framework.Assert;
 import org.apache.commons.collections4.CollectionUtils;
+import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -15,7 +15,6 @@ import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -109,8 +108,7 @@ public class MantaHttpHeadersIT {
         Set<String> actual = actualHeaders.getRoles();
 
         if (!CollectionUtils.isEqualCollection(actual, roles)) {
-            Assert.failNotEquals("Input and output roles, should be equal",
-                    roles, actual);
+            Assert.fail("Input and output roles, should be equal");
         }
     }
 
@@ -142,8 +140,7 @@ public class MantaHttpHeadersIT {
         Set<String> actual = actualHeaders.getRoles();
 
         if (!CollectionUtils.isEqualCollection(actual, roles)) {
-            Assert.failNotEquals("Input and output roles, should be equal",
-                    roles, actual);
+            Assert.fail("Input and output roles, should be equal");
         }
     }
 
@@ -174,8 +171,7 @@ public class MantaHttpHeadersIT {
             Set<String> actual = actualHeaders.getRoles();
 
             if (!CollectionUtils.isEqualCollection(actual, roles)) {
-                Assert.failNotEquals("Input and output roles, should be equal",
-                        roles, actual);
+                Assert.fail("Input and output roles, should be equal");
             }
         }
 
@@ -192,8 +188,7 @@ public class MantaHttpHeadersIT {
         Set<String> actualUpdatedRoles = actualUpdatedHeaders.getRoles();
 
         if (!CollectionUtils.isEqualCollection(actualUpdatedRoles, updatedRoles)) {
-            Assert.failNotEquals("Roles should have been updated",
-                    roles, actualUpdatedRoles);
+            Assert.fail("Roles should have been updated");
         }
     }
 
@@ -229,8 +224,23 @@ public class MantaHttpHeadersIT {
         Set<String> actualUpdatedRoles = actualUpdatedHeaders.getRoles();
 
         if (!actualUpdatedRoles.isEmpty()) {
-            Assert.failNotEquals("Roles weren't removed", Collections.emptySet(),
-                    actualUpdatedRoles);
+            Assert.fail("Roles weren't removed");
         }
+    }
+
+    @Test
+    public void canSetDurability() throws IOException {
+        final int durability = 4;
+        final MantaHttpHeaders headers = new MantaHttpHeaders();
+        headers.setDurabilityLevel(durability);
+
+        String path = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+
+        mantaClient.put(path, TEST_DATA, headers);
+
+        MantaObject object = mantaClient.get(path);
+        MantaHttpHeaders actualHeaders = object.getHttpHeaders();
+        Assert.assertEquals(actualHeaders.getDurabilityLevel().intValue(), durability,
+                "Durability not set to value on put");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
         <dependency.mockito.version>2.0.2-beta</dependency.mockito.version>
         <dependency.slfj.version>1.7.13</dependency.slfj.version>
         <dependency.testng.version>6.9.9</dependency.testng.version>
+        <dependency.commons-collections.version>4.0</dependency.commons-collections.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Fixes #74 
Fixes #76

This PR allows for you to set roles for manta objects (mchod) and it allows for you to set DurabilityLevel as well. No work was done for ContentMD5 because that header already existed in the wrapped delagate.

@phillipross Please review at your leisure.