### PR TITLE
Fixes #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ left are overridden by values on the right.
 The URL of the manta service endpoint to test against
 * `manta.user` ( **MANTA_USER** )
 The account name used to access the manta service. If accessing via a [subuser](https://docs.joyent.com/public-cloud/rbac/users),
-you will specify the username as "account/subuser".
+you will specify the account name as "user/subuser".
 * `manta.key_id`: ( **MANTA_KEY_ID**)
 The fingerprint for the public key used to access the manta service.
 * `manta.key_path` ( **MANTA_KEY_PATH** )
@@ -66,6 +66,22 @@ The name of the file that will be loaded for the account used to access the mant
 The number of milliseconds to wait after a request was made to Manta before failing.
  
 If you want to skip running of the test suite, use the `-DskipTests` property.
+
+## Accounts, Usernames and Subusers
+Joyent's SmartDataCenter account implementation is such that you can have a
+subuser as a dependency upon a user. This is part of SmartDataCenter's [RBAC
+implementation](https://docs.joyent.com/public-cloud/rbac/users). A subuser
+is a user with a unique username that is joined with the account holder's 
+username. Typically, this is in the format of "user/subuser".
+ 
+Within the Java Manta library, we refer to the account name as the entire
+string used to login - "user/subuser". When we use the term user it is in
+reference to the "user" portion of the account name and when we use the term
+subuser, it is in reference to the subuser portion of the account name.
+
+The notable exception is that in the configuration passed into the library,
+we have continued to use the terminology *Manta user* to refer to the
+account name because of historic compatibility concerns. 
 
 ## Usage
 
@@ -88,14 +104,14 @@ import java.util.Scanner;
 public class App {
     private static final String URL = "https://us-east.manta.joyent.com";
     // If there is no subuser, then just use the account name
-    private static final String LOGIN = "account/subuser";
+    private static final String LOGIN = "user/subuser";
     private static final String KEY_PATH = "src/test/java/data/id_rsa";
     private static final String KEY_FINGERPRINT = "04:92:7b:23:bc:08:4f:d7:3b:5a:38:9e:4a:17:2e:df";
 
     public static void main(String... args) throws IOException {
         MantaClient client = new MantaClient(URL, LOGIN, KEY_PATH, KEY_FINGERPRINT);
 
-        String mantaFile = "/account/stor/foo";
+        String mantaFile = "/user/stor/foo";
 
         // Print out every line from file streamed real-time from Manta
         try (InputStream is = client.getAsInputStream(mantaFile);
@@ -127,14 +143,16 @@ which can be configured
 
 ## Subuser Difficulties
 
-If you are using subusers, be sure to specify the Manta username as `account/subuser`.
+If you are using subusers, be sure to specify the Manta account name as `user/subuser`.
 Also, a common problem is that you haven't granted the subuser access to the
 path within Manta. Typically this is done via the [Manta CLI Tools](https://apidocs.joyent.com/manta/commands-reference.html)
-using the [`mchmod` command](https://github.com/joyent/node-manta/blob/master/docs/man/mchmod.md). 
+using the [`mchmod` command](https://github.com/joyent/node-manta/blob/master/docs/man/mchmod.md).
+This can also be done by adding roles on the `MantaHttpHeaders` object.
+
 For example:
 
 ```bash
-mchmod +subusername /account/stor/my_directory
+mchmod +subusername /user/stor/my_directory
 ```
 
 ## Contributions

--- a/java-manta-client/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -122,14 +122,14 @@ public class MantaClient implements AutoCloseable {
      * Creates a new instance of a Manta client.
      *
      * @param url         The url of the Manta endpoint.
-     * @param login       The user login name.
+     * @param account     The account used to login.
      * @param keyPath     The path to the user rsa private key on disk.
      * @param fingerPrint The fingerprint of the user rsa private key.
      * @throws IOException If unable to instantiate the client.
      */
-    public MantaClient(final String url, final String login, final String keyPath,
+    public MantaClient(final String url, final String account, final String keyPath,
                        final String fingerPrint) throws IOException {
-        this(url, login, keyPath, fingerPrint, DefaultsConfigContext.DEFAULT_HTTP_TIMEOUT);
+        this(url, account, keyPath, fingerPrint, DefaultsConfigContext.DEFAULT_HTTP_TIMEOUT);
     }
 
 
@@ -137,18 +137,18 @@ public class MantaClient implements AutoCloseable {
      * Creates a new instance of a Manta client.
      *
      * @param url               The url of the Manta endpoint.
-     * @param login             The user login name.
+     * @param account     The account used to login.
      * @param privateKeyContent The user's rsa private key as a string.
      * @param fingerPrint       The fingerprint of the user rsa private key.
      * @param password          The private key password (optional).
      * @throws IOException If unable to instantiate the client.
      */
     public MantaClient(final String url,
-                       final String login,
+                       final String account,
                        final String privateKeyContent,
                        final String fingerPrint,
                        final char[] password) throws IOException {
-        this(url, login, privateKeyContent, fingerPrint, password,
+        this(url, account, privateKeyContent, fingerPrint, password,
                 DefaultsConfigContext.DEFAULT_HTTP_TIMEOUT);
     }
 
@@ -157,19 +157,19 @@ public class MantaClient implements AutoCloseable {
      * Instantiates a new Manta client instance.
      *
      * @param url         The url of the Manta endpoint.
-     * @param login       The user login name.
+     * @param account     The account used to login.
      * @param keyPath     The path to the user rsa private key on disk.
      * @param fingerprint The fingerprint of the user rsa private key.
      * @param httpTimeout The HTTP timeout in milliseconds.
      * @throws IOException If unable to instantiate the client.
      */
     public MantaClient(final String url,
-                       final String login,
+                       final String account,
                        final String keyPath,
                        final String fingerprint,
                        final int httpTimeout) throws IOException {
-        if (login == null) {
-            throw new IllegalArgumentException("Manta username must be specified");
+        if (account == null) {
+            throw new IllegalArgumentException("Manta account name must be specified");
         }
         if (url == null) {
             throw new IllegalArgumentException("Manta URL must be specified");
@@ -186,7 +186,7 @@ public class MantaClient implements AutoCloseable {
 
         this.url = url;
         KeyPair keyPair = HttpSignerUtils.getKeyPair(new File(keyPath).toPath());
-        this.httpSigner = new HttpSigner(keyPair, login, fingerprint);
+        this.httpSigner = new HttpSigner(keyPair, account, fingerprint);
         this.httpRequestFactoryProvider = new HttpRequestFactoryProvider(httpSigner,
                 httpTimeout);
         this.httpTimeout = httpTimeout;
@@ -197,7 +197,7 @@ public class MantaClient implements AutoCloseable {
      * Instantiates a new Manta client instance.
      *
      * @param url               The url of the Manta endpoint.
-     * @param login             The user login name.
+     * @param account     The account used to login.
      * @param privateKeyContent The private key as a string.
      * @param fingerprint       The name of the key.
      * @param password          The private key password (optional).
@@ -205,12 +205,12 @@ public class MantaClient implements AutoCloseable {
      * @throws IOException If unable to instantiate the client.
      */
     public MantaClient(final String url,
-                       final String login,
+                       final String account,
                        final String privateKeyContent,
                        final String fingerprint,
                        final char[] password,
                        final int httpTimeout) throws IOException {
-        if (login == null) {
+        if (account == null) {
             throw new IllegalArgumentException("Manta username must be specified");
         }
         if (url == null) {
@@ -228,7 +228,7 @@ public class MantaClient implements AutoCloseable {
 
         this.url = url;
         KeyPair keyPair = HttpSignerUtils.getKeyPair(privateKeyContent, password);
-        this.httpSigner = new HttpSigner(keyPair, login, fingerprint);
+        this.httpSigner = new HttpSigner(keyPair, account, fingerprint);
         this.httpTimeout = httpTimeout;
         this.httpRequestFactoryProvider = new HttpRequestFactoryProvider(httpSigner,
                 httpTimeout);

--- a/java-manta-client/src/main/java/com/joyent/manta/client/MantaHttpHeaders.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/MantaHttpHeaders.java
@@ -34,7 +34,7 @@ public class MantaHttpHeaders {
     public static final String HTTP_DURABILITY_LEVEL = "Durability-Level";
 
     /**
-     * HTTP header for account roles.
+     * HTTP header for RBAC roles.
      */
     public static final String HTTP_ROLE_TAG = "Role-Tag";
 
@@ -273,7 +273,7 @@ public class MantaHttpHeaders {
 
 
     /**
-     * Sets the header defining account roles used for this object.
+     * Sets the header defining RBAC roles used for this object.
      *
      * @param roles roles associated with object
      */
@@ -288,7 +288,7 @@ public class MantaHttpHeaders {
 
 
     /**
-     * Gets the header defining account roles used for this object.
+     * Gets the header defining RBAC roles used for this object.
      *
      * @return roles associated with object
      */

--- a/java-manta-client/src/main/java/com/joyent/manta/config/BaseChainedConfigContext.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/config/BaseChainedConfigContext.java
@@ -17,9 +17,9 @@ public abstract class BaseChainedConfigContext implements ConfigContext {
     private String mantaURL;
 
     /**
-     * User account associated with the Manta service.
+     * Account associated with the Manta service.
      */
-    private String mantaUser;
+    private String account;
 
     /**
      * RSA key fingerprint of the private key used to access Manta.
@@ -64,7 +64,7 @@ public abstract class BaseChainedConfigContext implements ConfigContext {
 
     @Override
     public String getMantaUser() {
-        return this.mantaUser;
+        return this.account;
     }
 
     @Override
@@ -99,7 +99,7 @@ public abstract class BaseChainedConfigContext implements ConfigContext {
         }
 
         if (isPresent(context.getMantaUser())) {
-            this.mantaUser = context.getMantaUser();
+            this.account = context.getMantaUser();
         }
 
         if (isPresent(context.getMantaKeyId())) {
@@ -135,12 +135,12 @@ public abstract class BaseChainedConfigContext implements ConfigContext {
     }
 
     /**
-     * Sets the User account associated with the Manta service.
+     * Sets the account associated with the Manta service.
      * @param mantaUser Manta user account
      * @return the current instance of {@link BaseChainedConfigContext}
      */
     public BaseChainedConfigContext setMantaUser(final String mantaUser) {
-        this.mantaUser = mantaUser;
+        this.account = mantaUser;
         return this;
     }
 

--- a/java-manta-client/src/main/java/com/joyent/manta/config/ConfigContext.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/config/ConfigContext.java
@@ -18,7 +18,7 @@ public interface ConfigContext {
     String getMantaURL();
 
     /**
-     * @return User account associated with the Manta service.
+     * @return account associated with the Manta service.
      */
     String getMantaUser();
 

--- a/java-manta-client/src/main/java/com/joyent/manta/config/EnvVarConfigContext.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/config/EnvVarConfigContext.java
@@ -18,9 +18,9 @@ public class EnvVarConfigContext implements ConfigContext {
     public static final String MANTA_URL_ENV_KEY = "MANTA_URL";
 
     /**
-     * Environment variable for looking up a Manta user account.
+     * Environment variable for looking up a Manta account.
      */
-    public static final String MANTA_USER_ENV_KEY = "MANTA_USER";
+    public static final String MANTA_ACCOUNT_ENV_KEY = "MANTA_USER";
 
     /**
      * Environment variable for looking up a RSA fingerprint.
@@ -41,7 +41,7 @@ public class EnvVarConfigContext implements ConfigContext {
      * Array of all environment variable names used.
      */
     public static final String[] ALL_PROPERTIES = {
-            MANTA_URL_ENV_KEY, MANTA_USER_ENV_KEY, MANTA_KEY_ID_ENV_KEY,
+            MANTA_URL_ENV_KEY, MANTA_ACCOUNT_ENV_KEY, MANTA_KEY_ID_ENV_KEY,
             MANTA_KEY_PATH_ENV_KEY, MANTA_TIMEOUT_ENV_KEY
     };
 
@@ -70,7 +70,7 @@ public class EnvVarConfigContext implements ConfigContext {
 
     @Override
     public String getMantaUser() {
-        return getEnv(MANTA_USER_ENV_KEY);
+        return getEnv(MANTA_ACCOUNT_ENV_KEY);
     }
 
     @Override

--- a/java-manta-client/src/main/java/com/joyent/manta/config/MapConfigContext.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/config/MapConfigContext.java
@@ -8,7 +8,7 @@ import static com.joyent.manta.config.EnvVarConfigContext.MANTA_KEY_ID_ENV_KEY;
 import static com.joyent.manta.config.EnvVarConfigContext.MANTA_KEY_PATH_ENV_KEY;
 import static com.joyent.manta.config.EnvVarConfigContext.MANTA_TIMEOUT_ENV_KEY;
 import static com.joyent.manta.config.EnvVarConfigContext.MANTA_URL_ENV_KEY;
-import static com.joyent.manta.config.EnvVarConfigContext.MANTA_USER_ENV_KEY;
+import static com.joyent.manta.config.EnvVarConfigContext.MANTA_ACCOUNT_ENV_KEY;
 
 /**
  * {@link ConfigContext} implementation that is used for configuring instances
@@ -23,7 +23,7 @@ public class MapConfigContext implements ConfigContext {
     public static final String MANTA_URL_KEY = "manta.url";
 
     /**
-     * Property key for looking up a Manta user account.
+     * Property key for looking up a Manta account.
      */
     public static final String MANTA_USER_KEY = "manta.user";
 
@@ -75,7 +75,7 @@ public class MapConfigContext implements ConfigContext {
 
     @Override
     public String getMantaUser() {
-        return normalizeEmptyAndNullAndDefaultToStringValue(MANTA_USER_KEY, MANTA_USER_ENV_KEY);
+        return normalizeEmptyAndNullAndDefaultToStringValue(MANTA_USER_KEY, MANTA_ACCOUNT_ENV_KEY);
     }
 
     @Override

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
@@ -34,7 +34,7 @@ import static com.joyent.manta.exception.MantaErrorCode.RESOURCE_NOT_FOUND_ERROR
 /**
  * @author Yunong Xiao
  */
-//@Test(dependsOnGroups = { "directory" })
+@Test(dependsOnGroups = { "directory" })
 public class MantaClientIT {
 
     private static final String TEST_DATA = "EPISODEII_IS_BEST_EPISODE";

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
@@ -34,7 +34,7 @@ import static com.joyent.manta.exception.MantaErrorCode.RESOURCE_NOT_FOUND_ERROR
 /**
  * @author Yunong Xiao
  */
-@Test(dependsOnGroups = { "directory" })
+//@Test(dependsOnGroups = { "directory" })
 public class MantaClientIT {
 
     private static final String TEST_DATA = "EPISODEII_IS_BEST_EPISODE";
@@ -311,6 +311,39 @@ public class MantaClientIT {
                 (MantaFunction<Object>) () -> mantaClient.get(testPathPrefix + name));
     }
 
+
+    @Test
+    public final void testFileExists() throws IOException {
+        final String name = UUID.randomUUID().toString();
+        final String path = testPathPrefix + name;
+
+        mantaClient.put(path, TEST_DATA);
+
+        final boolean actual = mantaClient.existsAndIsAccessible(path);
+        Assert.assertTrue(actual, "File object should exist");
+    }
+
+
+    @Test
+    public final void testDirectoryExists() throws IOException {
+        final String name = UUID.randomUUID().toString();
+        final String dir = testPathPrefix + name;
+
+        mantaClient.putDirectory(dir);
+
+        final boolean actual = mantaClient.existsAndIsAccessible(dir);
+        Assert.assertTrue(actual, "File object should exist");
+    }
+
+
+    @Test
+    public final void testFileDoesntExist() throws IOException {
+        final String name = UUID.randomUUID().toString();
+        final String path = testPathPrefix + name;
+
+        final boolean actual = mantaClient.existsAndIsAccessible(path);
+        Assert.assertFalse(actual, "File object shouldn't exist");
+    }
 
     @Test(groups = { "mtime" })
     public final void testGetLastModifiedDate() {


### PR DESCRIPTION
@phillipross Please review when you have a moment.

The key part of this change is reflected in the readme:

Joyent's SmartDataCenter account implementation is such that you can have a
subuser as a dependency upon a user. This is part of SmartDataCenter's [RBAC
implementation](https://docs.joyent.com/public-cloud/rbac/users). A subuser
is a user with a unique username that is joined with the account holder's 
username. Typically, this is in the format of "user/subuser".
 
Within the Java Manta library, we refer to the account name as the entire
string used to login - "user/subuser". When we use the term user it is in
reference to the "user" portion of the account name and when we use the term
subuser, it is in reference to the subuser portion of the account name.

The notable exception is that in the configuration passed into the library,
we have continued to use the terminology *Manta user* to refer to the
account name because of historic compatibility concerns.

I did my best to change how we used the terms so that they were consistent.