### PR TITLE
Fix the contributing link to work online on github. Case-sensitive.

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ mchmod +subusername /user/stor/my_directory
 
 ## Contributions
 
-Contributions welcome! Please read the [CONTRIBUTING.MD](CONTRIBUTING.MD) document for details
+Contributions welcome! Please read the [CONTRIBUTING.md](CONTRIBUTING.md) document for details
 on getting started.
 
 ### Testing


### PR DESCRIPTION
- Link to Contribute file is broken on git hub, due to case sensitive paths. 
- Fixes the link.