### PR TITLE
Minor pom fixes and plugin/dependency version updates

### DIFF
--- a/java-manta-benchmark/pom.xml
+++ b/java-manta-benchmark/pom.xml
@@ -32,8 +32,8 @@
             <version>${dependency.logback.version}</version>
             <exclusions>
                 <exclusion>
-                    <artifactId>org.slf4j</artifactId>
-                    <groupId>slf4j-api</groupId>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/java-manta-client/pom.xml
+++ b/java-manta-client/pom.xml
@@ -151,8 +151,8 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <artifactId>org.slf4j</artifactId>
-                    <groupId>slf4j-api</groupId>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/java-manta-it/pom.xml
+++ b/java-manta-it/pom.xml
@@ -87,8 +87,8 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <artifactId>org.slf4j</artifactId>
-                    <groupId>slf4j-api</groupId>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -87,29 +87,29 @@
         <!-- Plugin versions -->
         <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
         <maven-clean-plugin.version>3.0.0</maven-clean-plugin.version>
-        <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>2.10</maven-dependency-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
-        <maven-extra-enforcer-rules.version>1.0-beta-4</maven-extra-enforcer-rules.version>
+        <maven-extra-enforcer-rules.version>1.0-beta-5</maven-extra-enforcer-rules.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
-        <maven-jar-plugin.version>2.6</maven-jar-plugin.version>
+        <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
         <maven-jarsigner-plugin.version>1.4</maven-jarsigner-plugin.version>
-        <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
         <maven-jxr-plugin.version>2.5</maven-jxr-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
-        <maven-resources-plugin.version>2.7</maven-resources-plugin.version>
-        <maven-shade-plugin.version>2.4.2</maven-shade-plugin.version>
-        <maven-source-plugin.version>2.4</maven-source-plugin.version>
-        <maven-surefire-plugin.version>2.19</maven-surefire-plugin.version>
-        <maven-failsafe-plugin.version>2.19</maven-failsafe-plugin.version>
+        <maven-resources-plugin.version>3.0.1</maven-resources-plugin.version>
+        <maven-shade-plugin.version>2.4.3</maven-shade-plugin.version>
+        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+        <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
+        <maven-failsafe-plugin.version>2.19.1</maven-failsafe-plugin.version>
         <!-- Dependency versions -->
-        <dependency.checkstyle.version>6.17</dependency.checkstyle.version>
-        <dependency.logback.version>1.1.3</dependency.logback.version>
+        <dependency.checkstyle.version>7.1.1</dependency.checkstyle.version>
+        <dependency.logback.version>1.1.7</dependency.logback.version>
         <dependency.mockito.version>2.0.2-beta</dependency.mockito.version>
-        <dependency.slfj.version>1.7.7</dependency.slfj.version>
-        <dependency.testng.version>6.9.9</dependency.testng.version>
+        <dependency.slfj.version>1.7.21</dependency.slfj.version>
+        <dependency.testng.version>6.9.10</dependency.testng.version>
         <dependency.commons-collections.version>4.1</dependency.commons-collections.version>
         <dependency.commons-lang>3.4</dependency.commons-lang>
     </properties>


### PR DESCRIPTION
- fixed logback dependency declaration in pom files to correctly specify slf4j exclusion
- updated maven compiler plugin from v3.3 to v3.5.1
- updated maven extra enforcer rules from v1.0-beta-4 to v1.0-beta5
- updated maven jar plugin from v2.6 to v3.0.2
- updated maven javadoc plugin from v2.10.3 to v2.10.4
- updated maven resources plugin from v2.7 to v.3.0.1
- updated maven shade plugin from v2.4.2 to v2.4.3
- updated maven source plugin from v2.4 to v.3.0.1
- updated maven surefire and failsafe plugins from v2.19 to v2.19.1
- updated checkstyle from v6.17 to v7.1.1
- updated logback from v1.1.3 to v1.1.7
- updated slf4j from v1.7.7 to v1.7.21
- updated testng from v6.9.9 to v6.9.10