### PR TITLE
provide a get method with explicit range parameters

### DIFF
--- a/java-manta-client/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -418,6 +418,27 @@ public class MantaClient implements AutoCloseable {
     }
 
     /**
+     * @see #getAsInputStream(String, MantaHttpHeaders)
+     *
+     * @param rawPath The fully qualified path of the object. i.e. /user/stor/foo/bar/baz
+     * @param requestHeaders optional HTTP headers to include when getting an object
+     * @param startPosition @see MantaRequestHeaders.setByteRange(Long, Long)
+     * @param endPosition @see MantaRequestHeaders.setByteRange(Long, Long)
+     * @return {@link InputStream} that extends {@link MantaObjectResponse}.
+     * @throws IOException when there is a problem getting the object over the network
+     */
+    public MantaObjectInputStream getAsInputStream(final String rawPath,
+                                                   final MantaHttpHeaders requestHeaders,
+                                                   final Long startPosition,
+                                                   final Long endPosition) throws IOException {
+        if (requestHeaders.getRange() != null) {
+            throw new IllegalArgumentException("Ambiguous request, requestHeaders already has a Range");
+        }
+        requestHeaders.setByteRange(startPosition, endPosition);
+        return getAsInputStream(rawPath, requestHeaders);
+    }
+
+    /**
      * Get a Manta object's data as an {@link InputStream}. This method allows you to
      * stream data from the Manta storage service in a memory efficient manner to your
      * application.

--- a/java-manta-client/src/test/java/com/joyent/manta/http/MantaHttpHeadersByteRangeTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/http/MantaHttpHeadersByteRangeTest.java
@@ -1,0 +1,67 @@
+package com.joyent.manta.http;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+@Test
+public class MantaHttpHeadersByteRangeTest {
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void dualNullCheck() {
+        MantaHttpHeaders headers = new MantaHttpHeaders();
+        headers.setByteRange(null, null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void negativeStartCheck() {
+        MantaHttpHeaders headers = new MantaHttpHeaders();
+        headers.setByteRange(-7L, null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void negativeEndCheck() {
+        MantaHttpHeaders headers = new MantaHttpHeaders();
+        headers.setByteRange(null, 0L);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void cartBeforeHorse() {
+        MantaHttpHeaders headers = new MantaHttpHeaders();
+        headers.setByteRange(21L, 13L);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void negativeStart() {
+        MantaHttpHeaders headers = new MantaHttpHeaders();
+        headers.setByteRange(-2L, 2L);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void negativeEnd() {
+        MantaHttpHeaders headers = new MantaHttpHeaders();
+        headers.setByteRange(-22L, -2L);
+    }
+
+    public void happyPath() {
+        MantaHttpHeaders headers = new MantaHttpHeaders();
+        Assert.assertEquals(headers.setByteRange(0L, 11L).getRange(),
+                            "bytes=0-11");
+        Assert.assertEquals(headers.setByteRange(100L, 9999L).getRange(),
+                            "bytes=100-9999");
+        Assert.assertEquals(headers.setByteRange(50L, null).getRange(),
+                            "bytes=50-");
+        Assert.assertEquals(headers.setByteRange(null, 137L).getRange(),
+                            "bytes=-137");
+        // RFC 7233 Examples
+        Assert.assertEquals(headers.setByteRange(0L, 499L).getRange(),
+                            "bytes=0-499");
+        Assert.assertEquals(headers.setByteRange(500L, 999L).getRange(),
+                            "bytes=500-999");
+        Assert.assertEquals(headers.setByteRange(null, 500L).getRange(),
+                            "bytes=-500");
+        Assert.assertEquals(headers.setByteRange(9500L, null).getRange(),
+                            "bytes=9500-");
+        
+    }
+}

--- a/java-manta-client/src/test/java/com/joyent/manta/http/MantaHttpHeadersTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/http/MantaHttpHeadersTest.java
@@ -20,7 +20,7 @@ import java.util.Set;
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  */
-@Test(groups = { "headers" })
+@Test
 public class MantaHttpHeadersTest {
     private static final Header[] DIR_LIST_HEADERS = new Header[] {
         new BasicHeader("Last-Modified","Fri, 09 Dec 2016 22:09:44 GMT"),

--- a/java-manta-client/src/test/resources/testng.xml
+++ b/java-manta-client/src/test/resources/testng.xml
@@ -6,6 +6,11 @@
             <class name="com.joyent.manta.util.MantaVersionTest" />
         </classes>
     </test>
+    <test name="Manta HTTP Tests">
+        <packages>
+            <package name="com.joyent.manta.http.*" />
+        </packages>
+    </test>
     <test name="Configuration Context Tests">
         <groups>
             <define name="config" />

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
@@ -542,6 +542,20 @@ public class MantaClientIT {
         }
     }
 
+    @Test
+    public final void testCanGetWithComputedRangeHeader() throws IOException {
+        // see testCanGetWithRangeHeader above
+        final String name = UUID.randomUUID().toString();
+        final String path = testPathPrefix + name;
+        final String expected = TEST_DATA.substring(7, 18); // substring is inclusive, exclusive
+        mantaClient.put(path, TEST_DATA);
+
+        final MantaHttpHeaders headers = new MantaHttpHeaders();
+        try (final InputStream min = mantaClient.getAsInputStream(path, headers, 7L, 17L)) {
+            String actual = IOUtils.toString(min, Charset.defaultCharset());
+            Assert.assertEquals(actual, expected, "Didn't receive correct range value");
+        }
+    }
 
     @Test(groups = { "mtime" })
     public final void testGetLastModifiedDate() {


### PR DESCRIPTION
Users who want multiple ranges will still need to manipulate their own
headers.

NOTE: This also enables all of the `com.joyent.manta.http` tests which
were lying dormant.

ref #137