### PR TITLE
bind checkstyle to compile instead of validate phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
                 <executions>
                     <execution>
                         <id>checkstyle</id>
-                        <phase>validate</phase>
+                        <phase>compile</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>


### PR DESCRIPTION
The `validate` phase occurs *before* compilation, which means that if
there was a syntax error checkstyle would die trying to parse the file
instead of javac just telling you what the syntax error is. Binding it
to `compile` (instead of the perhaps more descriptive `verify`)
preserves the aggressive & early nature of the check.