### PR TITLE
AES-CTR Returning Incorrect Byte Range (#207)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,13 @@ tmp/
 local.properties
 .settings/
 .loadpath
+.project
+.classpath
+.checkstyle
+workbench.xmi
+
+### Netbeans ###
+nbactions.xml
 
 # External tool builders
 .externalToolBuilders/

--- a/java-manta-client/src/main/java/com/joyent/manta/http/EncryptionHttpHelper.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/http/EncryptionHttpHelper.java
@@ -411,9 +411,18 @@ public class EncryptionHttpHelper extends StandardHttpHelper {
             binaryEndPositionInclusive = ciphertextSize;
         // This is the typical case like: bytes=3-44
         } else {
+
+            long scaledPlaintextEnd = plaintextEnd;
+
+            // interpret maximum plaintext value as unbounded end
+            if (plaintextEnd == cipherDetails.getMaximumPlaintextSizeInBytes()) {
+
+                scaledPlaintextEnd--;
+            }
+
             // calculates the ciphertext byte range
             final ByteRangeConversion computedRanges = this.cipherDetails.translateByteRange(
-                    plaintextStart, plaintextEnd);
+                    plaintextStart, scaledPlaintextEnd);
 
             binaryStartPositionInclusive = computedRanges.getCiphertextStartPositionInclusive();
             initialSkipBytes = computedRanges.getPlaintextBytesToSkipInitially()
@@ -425,7 +434,7 @@ public class EncryptionHttpHelper extends StandardHttpHelper {
                 binaryEndPositionInclusive = 0;
             }
 
-            plaintextRangeLength = (plaintextEnd - plaintextStart) + 1;
+            plaintextRangeLength = (scaledPlaintextEnd - plaintextStart) + 1;
         }
 
         // We don't know the ending position

--- a/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesCtrCipherDetailsTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesCtrCipherDetailsTest.java
@@ -117,6 +117,7 @@ public class AesCtrCipherDetailsTest extends AbstractCipherDetailsTest {
         Assert.assertEquals(byteRange3.getCiphertextStartPositionInclusive(), 32);
         Assert.assertEquals(byteRange3.getCiphertextEndPositionInclusive(), 47);
         Assert.assertEquals(byteRange3.getPlaintextBytesToSkipInitially(), 0);
+        Assert.assertEquals(byteRange3.getLengthOfPlaintextIncludingSkipBytes(), 4);
 
     }
 

--- a/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesCtrCipherDetailsTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesCtrCipherDetailsTest.java
@@ -103,21 +103,21 @@ public class AesCtrCipherDetailsTest extends AbstractCipherDetailsTest {
     public void translateByteRangeReturnsCorrectRange() throws Exception {
         ByteRangeConversion byteRange1 = AesCtrCipherDetails.INSTANCE_128_BIT.translateByteRange(5, 10);
         Assert.assertEquals(byteRange1.getCiphertextStartPositionInclusive(), 0);
-        Assert.assertEquals(byteRange1.getCiphertextEndPositionInclusive(), 17);
+        Assert.assertEquals(byteRange1.getCiphertextEndPositionInclusive(), 15);
         Assert.assertEquals(byteRange1.getPlaintextBytesToSkipInitially(), 5);
-        Assert.assertEquals(byteRange1.getLengthOfPlaintextIncludingSkipBytes(), 6);
+        Assert.assertEquals(byteRange1.getLengthOfPlaintextIncludingSkipBytes(), 11);
 
         ByteRangeConversion byteRange2 = AesCtrCipherDetails.INSTANCE_128_BIT.translateByteRange(5, 22);
         Assert.assertEquals(byteRange2.getCiphertextStartPositionInclusive(), 0);
-        Assert.assertEquals(byteRange2.getCiphertextEndPositionInclusive(), 33);
+        Assert.assertEquals(byteRange2.getCiphertextEndPositionInclusive(), 31);
         Assert.assertEquals(byteRange2.getPlaintextBytesToSkipInitially(), 5);
-        Assert.assertEquals(byteRange2.getLengthOfPlaintextIncludingSkipBytes(), 18);
+        Assert.assertEquals(byteRange2.getLengthOfPlaintextIncludingSkipBytes(), 23);
 
         ByteRangeConversion byteRange3 = AesCtrCipherDetails.INSTANCE_128_BIT.translateByteRange(32, 35);
         Assert.assertEquals(byteRange3.getCiphertextStartPositionInclusive(), 32);
-        Assert.assertEquals(byteRange3.getCiphertextEndPositionInclusive(), 49);
+        Assert.assertEquals(byteRange3.getCiphertextEndPositionInclusive(), 47);
         Assert.assertEquals(byteRange3.getPlaintextBytesToSkipInitially(), 0);
-        Assert.assertEquals(byteRange3.getLengthOfPlaintextIncludingSkipBytes(), 4);
+
     }
 
     protected void canRandomlyReadPlaintextPositionFromCiphertext(final SecretKey secretKey,
@@ -176,15 +176,15 @@ public class AesCtrCipherDetailsTest extends AbstractCipherDetailsTest {
                 decryptor.init(Cipher.DECRYPT_MODE, secretKey, cipherDetails.getEncryptionParameterSpec(iv));
                 long adjustedPlaintextRange = cipherDetails.updateCipherToPosition(decryptor, startPlaintextRange);
 
-                byte[] adjustedCipherText = Arrays.copyOfRange(ciphertext, (int) startCipherTextRange, (int) endCipherTextRange);
+                byte[] adjustedCipherText = Arrays.copyOfRange(ciphertext, (int) startCipherTextRange, (int) Math.min(ciphertext.length, endCipherTextRange + 1));
                 byte[] out = decryptor.doFinal(adjustedCipherText);
                 byte[] decrypted = Arrays.copyOfRange(out, (int) adjustedPlaintextRange,
-                        (int) adjustedPlaintextLength + (int) adjustedPlaintextRange);
+                        (int) Math.min(out.length, adjustedPlaintextLength));
 
                 String decryptedText = new String(decrypted);
                 String adjustedText = new String(adjustedPlaintext);
 
-                Assert.assertEquals(decryptedText, adjustedText,
+                Assert.assertEquals(adjustedText, decryptedText,
                         "Random read output from ciphertext doesn't match expectation " +
                                 "[cipher=" + cipherDetails.getCipherId() + "]");
             }


### PR DESCRIPTION
Fixes #207.

Exposes bug with MACs (MantaEncryptedObjectInputStreamTest).