### PR TITLE
support multiple singing key types 

### DIFF
--- a/java-manta-client/src/main/java/com/joyent/manta/client/UriSigner.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/UriSigner.java
@@ -34,7 +34,7 @@ public class UriSigner {
     /**
      * HTTP signature generator instance.
      */
-    private final ThreadLocalSigner signer = new ThreadLocalSigner();
+    private final ThreadLocalSigner signer;
 
     /**
      * Cryptographic key pair used to sign URIs.
@@ -46,10 +46,12 @@ public class UriSigner {
      *
      * @param config Manta configuration context
      * @param keyPair cryptographic key pair used to sign URIs
+     * @param signer Signer configured to work with the the given keyPair
      */
-    public UriSigner(final ConfigContext config, final KeyPair keyPair) {
+    public UriSigner(final ConfigContext config, final KeyPair keyPair, final ThreadLocalSigner signer) {
         this.config = config;
         this.keyPair = keyPair;
+        this.signer = signer;
     }
 
     /**
@@ -74,7 +76,7 @@ public class UriSigner {
         }
 
         final String charset = "UTF-8";
-        final String algorithm = "RSA-SHA256";
+        final String algorithm = signer.get().getHttpHeaderAlgorithm().toUpperCase();
         final String keyId = String.format("/%s/keys/%s",
                 config.getMantaUser(), config.getMantaKeyId());
         final String keyIdEncoded = URLEncoder.encode(keyId, charset);

--- a/java-manta-client/src/test/java/com/joyent/manta/client/MantaClientConnectionFailuresIT.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/MantaClientConnectionFailuresIT.java
@@ -7,6 +7,8 @@
  */
 package com.joyent.manta.client;
 
+import com.joyent.http.signature.Signer;
+import com.joyent.http.signature.ThreadLocalSigner;
 import com.joyent.manta.config.ConfigContext;
 import com.joyent.manta.config.KeyPairFactory;
 import com.joyent.manta.config.TestConfigContext;
@@ -98,8 +100,8 @@ public class MantaClientConnectionFailuresIT {
     }
 
     private class NoHttpResponseMantaConnectionFactory extends MantaConnectionFactory {
-        public NoHttpResponseMantaConnectionFactory(ConfigContext config, KeyPair keyPair) {
-            super(config, keyPair);
+        public NoHttpResponseMantaConnectionFactory(ConfigContext config, KeyPair keyPair, ThreadLocalSigner signer) {
+            super(config, keyPair, signer);
         }
 
         @Override
@@ -113,8 +115,10 @@ public class MantaClientConnectionFailuresIT {
     public void canRetryOnNoHttpResponseException() throws IOException {
         final KeyPairFactory keyPairFactory = new KeyPairFactory(config);
         final KeyPair keyPair = keyPairFactory.createKeyPair();
+        final ThreadLocalSigner signer = new ThreadLocalSigner(new Signer.Builder(keyPair));
         MantaClient mantaClient = new MantaClient(config, keyPair,
-                new NoHttpResponseMantaConnectionFactory(config, keyPair));
+                                                  new NoHttpResponseMantaConnectionFactory(config, keyPair, signer),
+                                                  signer);
         String testPathPrefix = String.format("%s/stor/%s/",
                 config.getMantaHomeDirectory(), UUID.randomUUID());
 

--- a/java-manta-client/src/test/java/com/joyent/manta/client/multipart/EncryptedMultipartManagerTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/multipart/EncryptedMultipartManagerTest.java
@@ -7,6 +7,8 @@
  */
 package com.joyent.manta.client.multipart;
 
+import com.joyent.http.signature.Signer;
+import com.joyent.http.signature.ThreadLocalSigner;
 import com.joyent.manta.client.MantaMetadata;
 import com.joyent.manta.client.MantaObjectInputStream;
 import com.joyent.manta.client.MantaObjectMapper;
@@ -212,8 +214,9 @@ public class EncryptedMultipartManagerTest {
         } catch (GeneralSecurityException e) {
             throw new AssertionError(e);
         }
+        final ThreadLocalSigner signer = new ThreadLocalSigner(new Signer.Builder(keyPair));
 
-        final MantaConnectionFactory connectionFactory = new MantaConnectionFactory(config, keyPair);
+        final MantaConnectionFactory connectionFactory = new MantaConnectionFactory(config, keyPair, signer);
         final MantaConnectionContext connectionContext = mock(MantaConnectionContext.class);
 
         EncryptionHttpHelper httpHelper = new EncryptionHttpHelper(connectionContext, connectionFactory, config);

--- a/java-manta-client/src/test/java/com/joyent/manta/client/multipart/ServerSideMultipartManagerTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/multipart/ServerSideMultipartManagerTest.java
@@ -10,6 +10,8 @@ package com.joyent.manta.client.multipart;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.joyent.http.signature.Signer;
+import com.joyent.http.signature.ThreadLocalSigner;
 import com.joyent.manta.client.MantaClient;
 import com.joyent.manta.client.MantaMetadata;
 import com.joyent.manta.client.MantaObjectMapper;
@@ -360,8 +362,9 @@ public class ServerSideMultipartManagerTest {
         } catch (GeneralSecurityException e) {
             throw new AssertionError(e);
         }
+        final ThreadLocalSigner signer = new ThreadLocalSigner(new Signer.Builder(keyPair));
 
-        final MantaConnectionFactory connectionFactory = new MantaConnectionFactory(config, keyPair);
+        final MantaConnectionFactory connectionFactory = new MantaConnectionFactory(config, keyPair, signer);
         final MantaConnectionContext connectionContext = mock(MantaConnectionContext.class);
         final CloseableHttpResponse response = mock(CloseableHttpResponse.class);
 

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorIT.java
@@ -10,11 +10,7 @@ package com.joyent.manta.client;
 import com.joyent.manta.config.ConfigContext;
 import com.joyent.manta.config.IntegrationTestConfigContext;
 import com.joyent.manta.config.KeyPairFactory;
-import com.joyent.manta.http.HttpHelper;
 import com.joyent.manta.http.MantaApacheHttpClientContext;
-import com.joyent.manta.http.MantaConnectionContext;
-import com.joyent.manta.http.MantaConnectionFactory;
-import com.joyent.manta.http.StandardHttpHelper;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -43,12 +39,6 @@ public class MantaDirectoryListingIteratorIT {
 
     private ConfigContext config;
 
-    private MantaConnectionContext connectionContext;
-
-    private MantaConnectionFactory connectionFactory;
-
-    private HttpHelper httpHelper;
-
     @BeforeClass
     @Parameters({"usingEncryption"})
     public void beforeClass(@Optional Boolean usingEncryption) throws IOException {
@@ -63,10 +53,6 @@ public class MantaDirectoryListingIteratorIT {
 
         final KeyPairFactory keyPairFactory = new KeyPairFactory(config);
         final KeyPair keyPair = keyPairFactory.createKeyPair();
-        this.connectionFactory = new MantaConnectionFactory(config, keyPair);
-        this.connectionContext = new MantaApacheHttpClientContext(this.connectionFactory);
-        this.httpHelper = new StandardHttpHelper(connectionContext, connectionFactory,
-                config);
     }
 
     @AfterClass
@@ -92,10 +78,7 @@ public class MantaDirectoryListingIteratorIT {
             mantaClient.put(path, TEST_DATA);
         }
 
-        String url = config.getMantaURL();
-
-        try (MantaDirectoryListingIterator itr = new MantaDirectoryListingIterator(url,
-                dir, httpHelper, 5)) {
+        try (MantaDirectoryListingIterator itr = mantaClient.streamingIterator(dir, 5)) {
             // Make sure we can get the first element
             Assert.assertTrue(itr.hasNext(), "We should have the first element");
             Map<String, Object> first = itr.next();
@@ -144,11 +127,7 @@ public class MantaDirectoryListingIteratorIT {
             mantaClient.put(path, TEST_DATA);
         }
 
-        String url = config.getMantaURL();
-
-        try (MantaDirectoryListingIterator itr = new MantaDirectoryListingIterator(url,
-                dir, httpHelper, 10)) {
-
+        try (MantaDirectoryListingIterator itr = mantaClient.streamingIterator(dir, 10)) {
             Runnable search = () -> {
                 while (itr.hasNext()) {
                     try {
@@ -194,10 +173,7 @@ public class MantaDirectoryListingIteratorIT {
         String dir = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
         mantaClient.putDirectory(dir);
 
-        String url = config.getMantaURL();
-
-        try (MantaDirectoryListingIterator itr = new MantaDirectoryListingIterator(url,
-                dir, httpHelper, 10)) {
+        try (MantaDirectoryListingIterator itr = mantaClient.streamingIterator(dir, 10)) {
             Assert.assertFalse(itr.hasNext(), "There shouldn't be a next element");
 
             boolean failed = false;
@@ -227,11 +203,7 @@ public class MantaDirectoryListingIteratorIT {
             mantaClient.put(path, TEST_DATA);
         }
 
-        String url = config.getMantaURL();
-
-        try (MantaDirectoryListingIterator itr = new MantaDirectoryListingIterator(url,
-                dir, httpHelper, 2)) {
-
+        try (MantaDirectoryListingIterator itr = mantaClient.streamingIterator(dir, 2)) {
             for (int i = 1; i < MAX; i++) {
                 Assert.assertTrue(itr.hasNext(), "We should have the next element");
                 Map<String, Object> next = itr.next();

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <maven-error-prone-core.version>2.0.15</maven-error-prone-core.version>
 
         <!-- Dependency versions -->
-        <dependency.http-client-signature.version>3.0.2</dependency.http-client-signature.version>
+        <dependency.http-client-signature.version>4.0.1-SNAPSHOT</dependency.http-client-signature.version>
         <dependency.apache-http-client.version>4.5.3</dependency.apache-http-client.version>
         <dependency.bouncycastle.version>1.55</dependency.bouncycastle.version>
         <dependency.fasterxml-uuid>3.1.3</dependency.fasterxml-uuid>
@@ -252,6 +252,10 @@
                          only supports >=6 -->
                     <source>${java.min.version}</source>
                     <target>${java.min.version}</target>
+                    <compilerArgs>
+                        <arg>-Xdiags:verbose</arg>
+                        <arg>-Xlint:all</arg>
+                    </compilerArgs>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
Using the new support in java-http-signature 4.0.0, support DSA and
ECDSA keys.  A user can provide a key and the library will figure out
it's type and use sensible defaults.

As part of this I had to tease apart how `ThreadLocalSigner` objects
are managed by centralizing their creation in `MantaClient`.  It was
too easy to end up with multiple ones with different configuration
which only accidental worked when everything was RSA.  While several
class changed, the public api of `MantaClient` did not.