### PR TITLE
detect last MPU part to maintain min size

### DIFF
--- a/java-manta-client-kryo-serialization/src/main/java/com/joyent/manta/serialization/EncryptionStateSerializer.java
+++ b/java-manta-client-kryo-serialization/src/main/java/com/joyent/manta/serialization/EncryptionStateSerializer.java
@@ -45,6 +45,7 @@ public class EncryptionStateSerializer extends AbstractManualSerializer<Encrypti
     private Field lastPartNumberField = captureField("lastPartNumber");
     private Field multipartStreamField = captureField("multipartStream");
     private Field cipherStreamField = captureField("cipherStream");
+    private Field lastPartAuthWrittenField = captureField("lastPartAuthWritten");
 
     /**
      * Secret key to inject into encryption context.
@@ -119,6 +120,9 @@ public class EncryptionStateSerializer extends AbstractManualSerializer<Encrypti
         final int lastPartNumber = (int)readField(lastPartNumberField, object);
         output.writeInt(lastPartNumber, true);
 
+        final boolean lastPartAuthWritten = (boolean)readField(lastPartAuthWrittenField, object);
+        output.writeBoolean(lastPartAuthWritten);
+
         MultipartOutputStream multipartStream = (MultipartOutputStream)readField(multipartStreamField, object);
         ByteArrayOutputStream multipartStreamBuf;
 
@@ -153,12 +157,14 @@ public class EncryptionStateSerializer extends AbstractManualSerializer<Encrypti
     public EncryptionState read(final Kryo kryo, final Input input, final Class<EncryptionState> type) {
         final EncryptionContext encryptionContext = (EncryptionContext)kryo.readClassAndObject(input);
         final int lastPartNumber = input.readVarInt(true);
+        final boolean lastPartAuthWritten = input.readBoolean();
         encryptionContext.setKey(secretKey);
 
         final EncryptionState encryptionState = newInstance();
 
         writeField(encryptionContextField, encryptionState, encryptionContext);
         writeField(lastPartNumberField, encryptionState, lastPartNumber);
+        writeField(lastPartAuthWrittenField, encryptionState, lastPartAuthWritten);
 
         final int blockSize = encryptionContext.getCipherDetails().getBlockSizeInBytes();
         Object bufferObject = kryo.readClassAndObject(input);

--- a/java-manta-client-kryo-serialization/src/test/java/com/joyent/manta/serialization/EncryptionStateSerializerTest.java
+++ b/java-manta-client-kryo-serialization/src/test/java/com/joyent/manta/serialization/EncryptionStateSerializerTest.java
@@ -40,7 +40,7 @@ public class EncryptionStateSerializerTest {
 
     @BeforeClass
     public void setup() {
-        kryo.register(EncryptionStateSerializer.class,
+        kryo.register(EncryptionState.class,
                 new EncryptionStateSerializer(kryo, secretKey));
     }
 
@@ -77,6 +77,8 @@ public class EncryptionStateSerializerTest {
                 "multipartStream");
         Field cipherStreamField = ReflectionUtils.getField(EncryptionState.class,
                 "cipherStream");
+        Field lastPartAuthWrittenField = ReflectionUtils.getField(EncryptionState.class,
+                "lastPartAuthWritten");
 
         try {
             FieldUtils.writeField(multipartStreamField, encryptionState, multipartStream);
@@ -85,6 +87,7 @@ public class EncryptionStateSerializerTest {
                     multipartStream, encryptionContext);
 
             FieldUtils.writeField(cipherStreamField, encryptionState, cipherStream);
+            FieldUtils.writeField(lastPartAuthWrittenField, encryptionState, true);
         } catch (ReflectiveOperationException e) {
             throw new AssertionError(e);
         }

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/EncryptingPartEntity.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/EncryptingPartEntity.java
@@ -10,12 +10,15 @@ package com.joyent.manta.client.crypto;
 import com.joyent.manta.client.multipart.MultipartOutputStream;
 import com.joyent.manta.http.MantaContentTypes;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.output.CountingOutputStream;
 import org.apache.commons.lang3.Validate;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.http.message.BasicHeader;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -62,18 +65,26 @@ public class EncryptingPartEntity implements HttpEntity {
     private final MultipartOutputStream multipartStream;
 
     /**
+     * Callback function for for the "last" part.
+     */
+    private final LastPartCallback lastPartCallback;
+
+    /**
      * Creates a new instance based on the specified parameters.
      *
      * @param cipherStream encrypting stream
      * @param multipartStream multipart stream that allows to attaching / detaching streams
      * @param wrapped wrapped entity to encrypt and send
+     * @param lastPartCallback callback for the last part (nullable)
      */
     public EncryptingPartEntity(final OutputStream cipherStream,
                                 final MultipartOutputStream multipartStream,
-                                final HttpEntity wrapped) {
+                                final HttpEntity wrapped,
+                                final LastPartCallback lastPartCallback) {
         this.cipherStream = cipherStream;
         this.multipartStream = multipartStream;
         this.wrapped = wrapped;
+        this.lastPartCallback = lastPartCallback;
     }
 
     @Override
@@ -117,10 +128,17 @@ public class EncryptingPartEntity implements HttpEntity {
         final InputStream contentStream = getContent();
         Validate.notNull(contentStream, "Content input stream must not be null");
         Validate.notNull(cipherStream, "Cipher output stream must not be null");
+        final CountingOutputStream cout = new CountingOutputStream(cipherStream);
 
         try {
-            IOUtils.copy(getContent(), cipherStream, BUFFER_SIZE);
+            IOUtils.copy(getContent(), cout, BUFFER_SIZE);
             cipherStream.flush();
+            if (lastPartCallback != null) {
+                ByteArrayOutputStream remainderStream = lastPartCallback.call(cout.getByteCount());
+                if (remainderStream.size() > 0) {
+                    IOUtils.copy(new ByteArrayInputStream(remainderStream.toByteArray()), httpOut, BUFFER_SIZE);
+                }
+            }
         } finally {
             IOUtils.closeQuietly(httpOut);
         }
@@ -135,5 +153,28 @@ public class EncryptingPartEntity implements HttpEntity {
     @Override
     public void consumeContent() throws IOException {
         this.wrapped.consumeContent();
+    }
+
+    /**
+     * "Callback" function object.
+     */
+    public abstract static class LastPartCallback {
+
+        /**
+         * When a user has uploaded the last part some action will
+         * need to be taken, such as flushing a the buffer or writing
+         * an HMAC.  If the user uploads a part that is less than the
+         * minimum size then we can detect that it is the last part at
+         * that time and append the relevant bytes.  This callback
+         * allows a MultipartManager to check if the upload byte
+         * count, and then return whatever additional bytes need to be
+         * uploaded.
+         *
+         * @param uploadedBytes How many bytes have been uploaded for this part
+         * @return The remaining bytes to upload, or a zero length
+         * stream if there are none.
+         * @throws IOException If here was an error constructing the remainder stream.
+         */
+        public abstract ByteArrayOutputStream call(long uploadedBytes) throws IOException;
     }
 }

--- a/java-manta-client/src/main/java/com/joyent/manta/client/multipart/JobsMultipartManager.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/multipart/JobsMultipartManager.java
@@ -169,6 +169,11 @@ public class JobsMultipartManager extends AbstractMultipartManager
     }
 
     @Override
+    public int getMinimumPartSize() {
+        return 1;
+    }
+
+    @Override
     public Stream<MantaMultipartUpload> listInProgress() throws IOException {
         final List<Exception> exceptions = new ArrayList<>();
 

--- a/java-manta-client/src/main/java/com/joyent/manta/client/multipart/MantaMultipartManager.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/multipart/MantaMultipartManager.java
@@ -43,6 +43,11 @@ public interface MantaMultipartManager<UPLOAD extends MantaMultipartUpload,
      */
     int getMaxParts();
 
+      /**
+     * @return the minimum part size
+     */
+    int getMinimumPartSize();
+
     /**
      * Lists multipart uploads that are currently in progress.
      *

--- a/java-manta-client/src/test/java/com/joyent/manta/client/multipart/ServerSideMultipartManagerTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/multipart/ServerSideMultipartManagerTest.java
@@ -281,7 +281,7 @@ public class ServerSideMultipartManagerTest {
 
         Stream<MantaMultipartUploadTuple> partsStream = Arrays.stream(unsortedTuples);
 
-        byte[] jsonRequest = ServerSideMultipartManager.createCommitRequestBody(partsStream);
+        byte[] jsonRequest = ServerSideMultipartManager.createCommitRequestBody(partsStream).getLeft();
 
         ObjectNode objectNode = MantaObjectMapper.INSTANCE.readValue(jsonRequest, ObjectNode.class);
         @SuppressWarnings("unchecked")

--- a/java-manta-client/src/test/java/com/joyent/manta/client/multipart/TestMultipartManager.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/multipart/TestMultipartManager.java
@@ -54,6 +54,12 @@ public class TestMultipartManager
     }
 
     @Override
+    public int getMinimumPartSize() {
+        return 1;
+    }
+
+
+    @Override
     public Stream<MantaMultipartUpload> listInProgress() throws IOException {
         return null;
     }


### PR DESCRIPTION
Previously the buffer and HAMC bytes were always unconditionally
written as a final part.  This meant that if the last user generated
part was less than the minimum part size, two parts below the minimum
would be uploaded.

To avoid this, keep track of the bytes for uploaded for each part. If
less than the minimum bytes have been uploaded then this must be the
last part (otherwise there would be an error on completion).  If that
is the case append the remaining cipher bytes to the last part, and do
*not* create an additional part during completion.

ref #218