### PR TITLE
upgrade java-http-signature and generated fingerprints

### DIFF
--- a/java-manta-client/src/main/java/com/joyent/manta/client/UriSigner.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/UriSigner.java
@@ -7,6 +7,7 @@
  */
 package com.joyent.manta.client;
 
+import com.joyent.http.signature.KeyFingerprinter;
 import com.joyent.http.signature.ThreadLocalSigner;
 import com.joyent.manta.config.ConfigContext;
 import org.apache.commons.lang3.StringUtils;
@@ -78,7 +79,9 @@ public class UriSigner {
         final String charset = "UTF-8";
         final String algorithm = signer.get().getHttpHeaderAlgorithm().toUpperCase();
         final String keyId = String.format("/%s/keys/%s",
-                config.getMantaUser(), config.getMantaKeyId());
+                                           config.getMantaUser(),
+                                           KeyFingerprinter.md5Fingerprint(keyPair));
+
         final String keyIdEncoded = URLEncoder.encode(keyId, charset);
 
         StringBuilder sigText = new StringBuilder();
@@ -93,7 +96,7 @@ public class UriSigner {
         StringBuilder request = new StringBuilder();
         final byte[] sigBytes = sigText.toString().getBytes();
         final byte[] signed = signer.get().sign(config.getMantaUser(),
-                config.getMantaKeyId(), keyPair, sigBytes);
+                                                keyPair, sigBytes);
         final String encoded = new String(Base64.encode(signed), charset);
         final String urlEncoded = URLEncoder.encode(encoded, charset);
 

--- a/java-manta-client/src/main/java/com/joyent/manta/config/ConfigContext.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/config/ConfigContext.java
@@ -255,11 +255,6 @@ public interface ConfigContext {
             }
         }
 
-        if (StringUtils.startsWith(config.getMantaKeyId(), "SHA256:")) {
-            failureMessages.add("We don't support SHA256 "
-                    + "fingerprints yet. Change fingerprint to MD5 format.");
-        }
-
         if (config.getMantaKeyPath() == null && config.getPrivateKeyContent() == null) {
             failureMessages.add("Either the Manta key path must be set or the private "
                     + "key content must be set. Both can't be null.");

--- a/java-manta-client/src/main/java/com/joyent/manta/http/MantaConnectionFactory.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/http/MantaConnectionFactory.java
@@ -428,10 +428,7 @@ public class MantaConnectionFactory implements Closeable {
         final String user = config.getMantaUser();
         Validate.notNull(user, "User must not be null");
 
-        final String keyId = config.getMantaKeyId();
-        Validate.notNull(keyId, "Key id must not be null");
-
-        return new UsernamePasswordCredentials(user, keyId);
+        return new UsernamePasswordCredentials(user, null);
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <maven-error-prone-core.version>2.0.15</maven-error-prone-core.version>
 
         <!-- Dependency versions -->
-        <dependency.http-client-signature.version>4.0.2</dependency.http-client-signature.version>
+        <dependency.http-client-signature.version>4.0.3</dependency.http-client-signature.version>
         <dependency.apache-http-client.version>4.5.3</dependency.apache-http-client.version>
         <dependency.bouncycastle.version>1.56</dependency.bouncycastle.version>
         <dependency.fasterxml-uuid>3.1.3</dependency.fasterxml-uuid>


### PR DESCRIPTION
 * Removes restrictions in SHA256 fingerprints, any input is
   supported.
 * User supplied fingerprint is only used for verification instead of
   being sent to the server.
 * Adjust logic in `createKeyPair` to prefer explicit key content over
   the key path.  The avoids subtle bugs, such as unit tests using the
   key id from environment variables instead of the test fixture.
   This issue did not appear before because there was no verification
   that fingerprints and keys matched.