### PR TITLE
reduce test failure noise

### DIFF
--- a/java-manta-client/src/main/java/com/joyent/manta/client/multipart/EncryptedMultipartUpload.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/multipart/EncryptedMultipartUpload.java
@@ -99,6 +99,11 @@ public class EncryptedMultipartUpload<WRAPPED extends MantaMultipartUpload>
         return this.wrapped.compare(o1, o2);
     }
 
+    @Override
+    public String toString() {
+        return wrapped.toString();
+    }
+
     /**
      * NOTE: Upload object equality is based on the underlying wrapped
      * object and not the state of any ciphers, streams, or locks.

--- a/java-manta-client/src/main/java/com/joyent/manta/client/multipart/ServerSideMultipartUpload.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/multipart/ServerSideMultipartUpload.java
@@ -74,7 +74,9 @@ public class ServerSideMultipartUpload extends AbstractMultipartUpload {
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .append("partsDirectory", partsDirectory)
-                .toString();
+            .append("id", getId())
+            .append("path", getPath())
+            .append("partsDirectory", partsDirectory)
+            .toString();
     }
 }


### PR DESCRIPTION
Since async commits are not part of MPU, these theses do not need to
be so asynchronously clever.  Errors in the threadpool or abort code
lead to inconsistent failures.

Also add some missing toString methods to aid in test debugging.