### PR TITLE
reenable canGetAllRanges test

### DIFF
--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientRangeIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientRangeIT.java
@@ -173,7 +173,7 @@ public class MantaClientRangeIT {
         }
     }
 
-    @Test (enabled = false)
+    @Test
     public final void canGetAllRanges() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;


### PR DESCRIPTION
This passes, and I don't see anything in comments or commit history to indicate why it was disabled.