### PR TITLE
consistently urlencode paths correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 All notable changes to this project will be documented in this file.
 This project aims to adhere to [Semantic Versioning](http://semver.org/).
 
+## [x.x.x] - YYYY-MM-DD
+
+Several related URL encoding bugs have been fixed.  Objects with
+non-alphanumeric characters created by java-manta may have been
+created with unexpected encoding characters.  Only the object names
+were affected, not the content.
+
+### Changed
+ - Paths with URL unsafe characters are now encoded correctly.
+   Previously the
+   [space character was being transformed](https://github.com/joyent/java-manta/issues/229)
+   into a plus (`+`) character.  So a PUT to the Manta object
+   `/user/stor/Hello World.txt`, would instead create
+   `/user/stor/Hello+World.txt`.
+ - All `MantaClient` operations now
+   [consistently encode](https://github.com/joyent/java-manta/issues/230),
+   and `MantaObject.getPath` always returns the original (not encoded)
+   path.
+ - Recursive directory creation will no longer
+   [encode the path twice](https://github.com/joyent/java-manta/issues/231).
+
 ## [3.0.0] - 2017-04-06
 ### Changed
  - Upgraded HTTP Signatures library to 4.0.1.

--- a/java-manta-client/pom.xml
+++ b/java-manta-client/pom.xml
@@ -163,6 +163,13 @@
             </exclusions>
         </dependency>
 
+        <!-- url encoding utility -->
+        <dependency>
+            <groupId>io.mikael</groupId>
+            <artifactId>urlbuilder</artifactId>
+            <version>${dependency.urlbuilder.version}</version>
+        </dependency>
+
         <!-- These dependencies are declared at the module level because we can not
              inherit exclusions from the parent. -->
         <dependency>
@@ -226,6 +233,10 @@
                         <relocation>
                             <pattern>com.fasterxml</pattern>
                             <shadedPattern>com.joyent.manta.com.fasterxml</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>io.mikael.urlbuilder</pattern>
+                            <shadedPattern>com.joyent.manta.io.mikael.urlbuilder</shadedPattern>
                         </relocation>
                     </relocations>
                     <filters>

--- a/java-manta-client/src/main/java/com/joyent/manta/client/MantaObject.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/MantaObject.java
@@ -30,7 +30,8 @@ public interface MantaObject extends Serializable {
     String MANTA_OBJECT_TYPE_DIRECTORY = "directory";
 
     /**
-     * Returns the path value.
+     * Returns the (decoded) path value.  In other words, the path as
+     * given by the user.
      *
      * @return the path
      */

--- a/java-manta-client/src/main/java/com/joyent/manta/client/MantaObjectResponse.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/MantaObjectResponse.java
@@ -8,6 +8,7 @@
 package com.joyent.manta.client;
 
 import com.joyent.manta.http.MantaHttpHeaders;
+import com.joyent.manta.util.MantaUtils;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.Validate;
@@ -113,7 +114,8 @@ public class MantaObjectResponse implements MantaObject {
     /**
      * Creates a MantaObject.
      *
-     * @param path The fully qualified path of the object in Manta. i.e. "/user/stor/path/to/some/file/or/dir".
+     * @param path The (encoded) fully qualified path of the object in
+     * Manta. i.e. "/user/stor/path/to/some/file/or/dir".
      */
     public MantaObjectResponse(final String path) {
         Validate.notNull(path, "Path must not be null");
@@ -125,7 +127,8 @@ public class MantaObjectResponse implements MantaObject {
     /**
      * Creates a MantaObject.
      *
-     * @param path The fully qualified path of the object in Manta. i.e. "/user/stor/path/to/some/file/or/dir".
+     * @param path The (encoded) fully qualified path of the object in
+     * Manta. i.e. "/user/stor/path/to/some/file/or/dir".
      * @param headers Optional {@link MantaHttpHeaders}. Use this to set any additional headers on the Manta object.
      *                For the full list of Manta headers see the
      *                <a href="http://apidocs.joyent.com/manta/manta/">Manta API</a>.
@@ -137,7 +140,8 @@ public class MantaObjectResponse implements MantaObject {
     /**
      * Creates a MantaObject.
      *
-     * @param path The fully qualified path of the object in Manta. i.e. "/user/stor/path/to/some/file/or/dir".
+     * @param path The (encoded) fully qualified path of the object in
+     * Manta. i.e. "/user/stor/path/to/some/file/or/dir".
      * @param headers Optional {@link MantaHttpHeaders}. Use this to set any additional headers on the Manta object.
      *                For the full list of Manta headers see the
      *                <a href="http://apidocs.joyent.com/manta/manta/">Manta API</a>.
@@ -179,7 +183,7 @@ public class MantaObjectResponse implements MantaObject {
 
     @Override
     public final String getPath() {
-        return this.path;
+        return MantaUtils.decodePath(this.path);
     }
 
     /**

--- a/java-manta-client/src/main/java/com/joyent/manta/http/StandardHttpHelper.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/http/StandardHttpHelper.java
@@ -281,7 +281,11 @@ public class StandardHttpHelper implements HttpHelper {
 
             final MantaHttpHeaders responseHeaders = new MantaHttpHeaders(response.getAllHeaders());
             final String path = request.getURI().getPath();
-            final MantaObjectResponse metadata = new MantaObjectResponse(path, responseHeaders);
+            // MantaObjectResponse expects to be constructed with the
+            // encoded path, which it then decodes when a caller does
+            // getPath.  However, here the HttpUriRequest has already
+            // decoded.
+            final MantaObjectResponse metadata = new MantaObjectResponse(MantaUtils.formatPath(path), responseHeaders);
 
             if (metadata.isDirectory()) {
                 final String msg = "Directories do not have data, so data streams "

--- a/java-manta-client/src/main/java/com/joyent/manta/util/MantaUtils.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/util/MantaUtils.java
@@ -7,6 +7,8 @@
  */
 package com.joyent.manta.util;
 
+import io.mikael.urlbuilder.util.Encoder;
+import io.mikael.urlbuilder.util.Decoder;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -17,10 +19,9 @@ import org.apache.http.client.utils.DateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.net.InetAddress;
-import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -45,6 +46,18 @@ public final class MantaUtils {
      * Logger instance.
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(MantaUtils.class);
+
+
+    /**
+     * Shared url encoder instance.
+     */
+    private static final Encoder UTF8_URL_ENCODER = new Encoder(StandardCharsets.UTF_8);
+
+    /**
+     * Shared url decoder instance.
+     */
+
+    private static final Decoder UTF8_URL_DECODER = new Decoder(StandardCharsets.UTF_8);
 
     /**
      * Default no-args constructor.
@@ -203,23 +216,25 @@ public final class MantaUtils {
     }
 
     /**
-     * Format the path according to RFC3986.
+     * Format the manta path for inclusion in a URI path according to
+     * RFC3986.  Note that the encoding rules vary for each part of
+     * the url
      *
      * @param path the raw path string.
      * @return the URI formatted string with the exception of '/' which is special in manta.
-     * @throws UnsupportedEncodingException If UTF-8 is not supported on this system.
      */
-    public static String formatPath(final String path) throws UnsupportedEncodingException {
-        // first split the path by slashes.
-        final String[] elements = path.split("/");
-        final StringBuilder encodedPath = new StringBuilder();
-        for (final String string : elements) {
-            if (string.equals("")) {
-                continue;
-            }
-            encodedPath.append("/").append(URLEncoder.encode(string, "UTF-8"));
-        }
-        return encodedPath.toString();
+    public static String formatPath(final String path) {
+        return UTF8_URL_ENCODER.encodePath(path);
+    }
+
+    /**
+     * Decodes a percent encoded manta path.
+     *
+     * @param encodedPath The percent encoded path
+     * @return The percent decoded path
+     */
+    public static String decodePath(final String encodedPath) {
+        return UTF8_URL_DECODER.decodePath(encodedPath);
     }
 
     /**

--- a/java-manta-client/src/test/java/com/joyent/manta/util/MantaUtilsTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/util/MantaUtilsTest.java
@@ -62,6 +62,41 @@ public class MantaUtilsTest {
         Assert.assertFalse(actual, "Matched last character in StringBuilder when we shouldn't have because it was empty");
     }
 
+    public void testFormatPath() throws Exception {
+        Assert.assertEquals(MantaUtils.formatPath("/foo"), "/foo");
+        Assert.assertEquals(MantaUtils.formatPath("/foo/bar"), "/foo/bar");
+        Assert.assertEquals(MantaUtils.formatPath("/foo/bar.txt"), "/foo/bar.txt");
+        // Generall speaking encoding characters that do not strctly
+        // need to be is harmless
+        Assert.assertEquals(MantaUtils.formatPath("/foo/!@#$%^&*().txt"),
+                            "/foo/!@%23$%25%5E&*().txt");
+        Assert.assertEquals(MantaUtils.formatPath("/foo\\/bar"), "/foo%5C/bar");
+        Assert.assertEquals(MantaUtils.formatPath("/foo+bar"), "/foo+bar");
+        Assert.assertEquals(MantaUtils.formatPath("/foo bar"), "/foo%20bar");
+    }
+
+    public void testDecodePath() throws Exception {
+        Assert.assertEquals(MantaUtils.decodePath("/foo"), "/foo");
+        Assert.assertEquals(MantaUtils.decodePath("/foo/bar"), "/foo/bar");
+        Assert.assertEquals(MantaUtils.decodePath("/foo/bar.txt"), "/foo/bar.txt");
+        Assert.assertEquals(MantaUtils.decodePath("/foo/!@%23$%25%5E&*().txt"),
+                            "/foo/!@#$%^&*().txt");
+        Assert.assertEquals(MantaUtils.decodePath("/foo/%21%40%23%24%25%5E%26%2A%28%29.txt"),
+                            "/foo/!@#$%^&*().txt");
+        Assert.assertEquals(MantaUtils.decodePath("/foo%5C/bar"), "/foo\\/bar");
+        Assert.assertEquals(MantaUtils.decodePath("/foo+%2Bbar"), "/foo++bar");
+        Assert.assertEquals(MantaUtils.decodePath("/foo%20bar"), "/foo bar");
+    }
+
+    public void testEncodeDecodeCycle() {
+        Assert.assertEquals(MantaUtils.decodePath(MantaUtils.formatPath("/foo")),
+                                                  "/foo");
+        Assert.assertEquals(MantaUtils.decodePath(MantaUtils.formatPath("/foo/!@#$%^&*().txt")),
+                                                  "/foo/!@#$%^&*().txt");
+        Assert.assertEquals(MantaUtils.decodePath(MantaUtils.formatPath("/foo bar")),
+                                                  "/foo bar");
+    }
+
     public final void canParseAccountWithNoSubuser() {
         final String account = "username";
         final String[] parts = MantaUtils.parseAccount(account);

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
@@ -400,12 +400,9 @@ public class MantaClientIT {
             + path);
     }
 
-    @Test
-    public final void canMoveDirectoryWithContents() throws IOException {
-        final String name = "source-" + UUID.randomUUID().toString();
-        final String source = testPathPrefix + name + MantaClient.SEPARATOR;
+
+    public void moveDirectoryWithContents(final String source, final String destination) throws IOException {
         mantaClient.putDirectory(source);
-        final String destination = testPathPrefix + "dest-" + UUID.randomUUID() + "/";
 
         mantaClient.putDirectory(source + "dir1");
         mantaClient.putDirectory(source + "dir2");
@@ -444,6 +441,24 @@ public class MantaClientIT {
         Assert.assertTrue(sourceIsDeleted, "Source directory didn't get deleted: "
                 + source);
     }
+
+
+    @Test
+    public final void canMoveDirectoryWithContents() throws IOException {
+        final String name = "source-" + UUID.randomUUID().toString();
+        final String source = testPathPrefix + name + MantaClient.SEPARATOR;
+        final String destination = testPathPrefix + "dest-" + UUID.randomUUID() + "/";
+        moveDirectoryWithContents(source, destination);
+    }
+
+    @Test(enabled = false) // Triggers server side bug: MANTA-2409
+    public final void canMoveDirectoryWithContentsAndErrorProneCharacters() throws IOException {
+        final String name = "source-" + UUID.randomUUID().toString() + "- -!@#$%^&*()";
+        final String source = testPathPrefix + name + MantaClient.SEPARATOR;
+        final String destination = testPathPrefix + "dest-" + UUID.randomUUID() + "- -!@#$%^&*" + "/";
+        moveDirectoryWithContents(source, destination);
+    }
+
 
     @Test
     public final void testList() throws IOException {

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorIT.java
@@ -188,10 +188,8 @@ public class MantaDirectoryListingIteratorIT {
         }
     }
 
-    @Test
-    public void canListDirectoryUsingSmallPagingSize() throws IOException {
-        String dir = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
-        mantaClient.putDirectory(dir);
+    public void listDirectoryUsingSmallPagingSize(final String dir) throws IOException {
+        mantaClient.putDirectory(dir, true);
 
         final int MAX = 5;
 
@@ -210,5 +208,17 @@ public class MantaDirectoryListingIteratorIT {
                 Assert.assertEquals(next.get("name").toString(), String.format("%05d", i));
             }
         }
+    }
+
+    @Test
+    public void canListDirectoryUsingSmallPagingSize() throws IOException {
+        String dir = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+        listDirectoryUsingSmallPagingSize(dir);
+    }
+
+    @Test(enabled = false) // Triggers server side bug: MANTA-2409
+    public void canListDirectoryUsingSmallPagingSizeAndErrorProneName() throws IOException {
+        String dir = String.format("%s/%s/%s", testPathPrefix, UUID.randomUUID(), "- -!@#$%^&*()");
+        listDirectoryUsingSmallPagingSize(dir);
     }
 }

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaObjectOutputStreamIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaObjectOutputStreamIT.java
@@ -78,6 +78,22 @@ public class MantaObjectOutputStreamIT {
                 "Uploaded bytes don't match");
     }
 
+    public void canUploadSmallStringWithErrorProneName() throws IOException {
+        String path = testPathPrefix + "uploaded-" + UUID.randomUUID() + "- -~!@#$%^&*().txt";
+        MantaObjectOutputStream out = mantaClient.putAsOutputStream(path);
+
+        try {
+            out.write(TEST_DATA.getBytes());
+        } finally {
+            out.close();
+        }
+
+        MantaObject uploaded = out.getObjectResponse();
+
+        Assert.assertTrue(mantaClient.existsAndIsAccessible(path),
+                "File wasn't uploaded: " + path);
+    }
+
     public void canUploadMuchLargerFile() throws IOException {
         String path = testPathPrefix + "uploaded-" + UUID.randomUUID() + ".txt";
         MantaObjectOutputStream out = mantaClient.putAsOutputStream(path);

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,7 @@
         <dependency.fasterxml-uuid>3.1.3</dependency.fasterxml-uuid>
         <dependency.jackson.version>2.6.3</dependency.jackson.version>
         <dependency.jnagmp.version>2.0.0</dependency.jnagmp.version>
+        <dependency.urlbuilder.version>2.0.8</dependency.urlbuilder.version>
 
         <dependency.checkstyle.version>7.5.1</dependency.checkstyle.version>
         <dependency.logback.version>1.1.7</dependency.logback.version>


### PR DESCRIPTION
When Manta paths appear as part of the of a url (which they do on most
api requests), reserved characters must be encoded just like in any
other url.

Paths were encoded inconsistently (in that they were sometimes
encoded, sometimes not, and sometimes encoded twice).  When paths were
encoded, spaces were not encoded correctly (turned to `+`) because
despite the tantalizing name `java.net.URLEncoder` does does not
encode strings for inclusion in a url.

The contract for `MantaObject.getPath` has been clarified. It should
always return the "real" (un-encoded) path.

ref #229 #230 231