### PR TITLE
include exception context on listObjects failures

### DIFF
--- a/java-manta-client/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -47,7 +47,6 @@ import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
 import org.apache.http.NoHttpResponseException;
 import org.apache.http.StatusLine;
-import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
@@ -703,10 +702,7 @@ public class MantaClient implements AutoCloseable {
             }
         } catch (UncheckedIOException e) {
             if (e.getCause() instanceof MantaClientHttpResponseException) {
-                MantaClientHttpResponseException cause = (MantaClientHttpResponseException)e.getCause();
-                @SuppressWarnings("unchecked")
-                HttpResponseException innerCause = (HttpResponseException)cause.getCause();
-                throw new MantaClientHttpResponseException(innerCause);
+                throw e.getCause();
             } else {
                 throw e;
             }


### PR DESCRIPTION
listObjects retained an exception handling style from pre-3.0.0 code
that had the side effect of throwing away all context (url, status
code, etc).  Letting the UncheckedIOException fall through would
preserve context, but could break existing catch blocks, and throwing
an UncheckedIOException from a method that is declared to throw
IOException is at best surprising.  Rethrowing the unchecked cause
retains existing error types and preserves most of the context.

ref #232