### PR TITLE
remove ~1 GiB upload during integration tests

### DIFF
--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/JobsMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/JobsMultipartManagerIT.java
@@ -260,10 +260,6 @@ public class JobsMultipartManagerIT {
         canUploadMultipartBinary(5, 10);
     }
 
-    public void canUpload5MbX200MultipartBinary() throws IOException {
-        canUploadMultipartBinary(5, 200);
-    }
-
     private void canUploadMultipartBinary(final long sizeInMb,
                                           final int noOfParts) throws IOException {
         final long size = sizeInMb * 1024L * 1024L;


### PR DESCRIPTION
I almost always have to disable this for, tests to finish in a
reasonable amount of time.  Larger scale tests like this could
potentially return as a set of a jenkins-only-with-fat-pipe if a there
is a class of bugs that only they can catch.