### PR TITLE
[TravisCI] Require JDK 8u131 and Java Cryptography Extension Package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ cache:
   - $HOME/.m2
 sudo: false
 
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+
 before_install:
   - echo 'MAVEN_OPTS="-Dorg.slf4j.simpleLogger.defaultLogLevel=warn"' >~/.mavenrc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
   apt:
     packages:
       - oracle-java8-installer
+      - oracle-java8-unlimited-jce-policy
 
 before_install:
   - echo 'MAVEN_OPTS="-Dorg.slf4j.simpleLogger.defaultLogLevel=warn"' >~/.mavenrc


### PR DESCRIPTION
Fixes #240 in addition to requiring latest Oracle JDK 8 in TravisCI. OpenJDK is not affected by this change.