### PR TITLE
Add JCE Policy Key Size Check (#242)

### DIFF
--- a/java-manta-client-kryo-serialization/src/test/java/com/joyent/manta/serialization/CipherSerializerTest.java
+++ b/java-manta-client-kryo-serialization/src/test/java/com/joyent/manta/serialization/CipherSerializerTest.java
@@ -41,45 +41,81 @@ public class CipherSerializerTest {
 
     private Kryo kryo = new Kryo();
 
+    // AES-CBC
+    private AesCbcCipherDetails AES_CBC_128;
+
+    private AesCbcCipherDetails AES_CBC_192;
+
+    private AesCbcCipherDetails AES_CBC_256;
+
+    // AES-CTR
+    private AesCtrCipherDetails AES_CTR_128;
+
+    private AesCtrCipherDetails AES_CTR_192;
+
+    private AesCtrCipherDetails AES_CTR_256;
+
+    // AES-GCM
+    private AesGcmCipherDetails AES_GCM_128;
+
+    private AesGcmCipherDetails AES_GCM_192;
+
+    private AesGcmCipherDetails AES_GCM_256;
+
     @BeforeClass
     public void setup() throws Exception {
         kryo.register(Cipher.class, new CipherSerializer(kryo));
+
+        // AES-CBC
+        AES_CBC_128 = AesCbcCipherDetails.aesCbc128();
+        AES_CBC_192 = AesCbcCipherDetails.aesCbc192();
+        AES_CBC_256 = AesCbcCipherDetails.aesCbc256();
+
+        // AES-CTR
+        AES_CTR_128 = AesCtrCipherDetails.aesCtr128();
+        AES_CTR_192 = AesCtrCipherDetails.aesCtr192();
+        AES_CTR_256 = AesCtrCipherDetails.aesCtr256();
+
+        // AES-GCM
+        AES_GCM_128 = AesGcmCipherDetails.aesGcm128();
+        AES_GCM_192 = AesGcmCipherDetails.aesGcm192();
+        AES_GCM_256 = AesGcmCipherDetails.aesGcm256();
     }
 
     public void canSerializeAesGcm128() throws Exception {
-        canSerializeCipher(AesGcmCipherDetails.INSTANCE_128_BIT);
+        canSerializeCipher(AES_GCM_128);
     }
 
     public void canSerializeAesGcm192() throws Exception {
-        canSerializeCipher(AesGcmCipherDetails.INSTANCE_192_BIT);
+        canSerializeCipher(AES_GCM_192);
     }
 
     public void canSerializeAesGcm256() throws Exception {
-        canSerializeCipher(AesGcmCipherDetails.INSTANCE_256_BIT);
+        canSerializeCipher(AES_GCM_256);
     }
 
     public void canSerializeAesCtr128() throws Exception {
-        canSerializeCipher(AesCtrCipherDetails.INSTANCE_128_BIT);
+        canSerializeCipher(AES_CTR_128);
     }
 
     public void canSerializeAesCtr192() throws Exception {
-        canSerializeCipher(AesCtrCipherDetails.INSTANCE_192_BIT);
+        canSerializeCipher(AES_CTR_192);
     }
 
     public void canSerializeAesCtr256() throws Exception {
-        canSerializeCipher(AesCtrCipherDetails.INSTANCE_256_BIT);
+        canSerializeCipher(AES_CTR_256);
     }
 
     public void canSerializeAesCbc128() throws Exception {
-        canSerializeCipher(AesCbcCipherDetails.INSTANCE_128_BIT);
+        canSerializeCipher(AES_CBC_128);
     }
 
     public void canSerializeAesCbc192() throws Exception {
-        canSerializeCipher(AesCbcCipherDetails.INSTANCE_192_BIT);
+        canSerializeCipher(AES_CBC_192);
     }
 
     public void canSerializeAesCbc256() throws Exception {
-        canSerializeCipher(AesCbcCipherDetails.INSTANCE_256_BIT);
+        canSerializeCipher(AES_CBC_256);
     }
 
     private void canSerializeCipher(final SupportedCipherDetails cipherDetails)

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCbcCipherDetails.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCbcCipherDetails.java
@@ -9,6 +9,8 @@ package com.joyent.manta.client.crypto;
 
 import org.apache.commons.lang3.Validate;
 
+import java.security.NoSuchAlgorithmException;
+
 import javax.crypto.Cipher;
 
 /**
@@ -22,24 +24,101 @@ public final class AesCbcCipherDetails extends AbstractAesCipherDetails {
     /**
      * Instance of AES128-CBC cipher.
      */
-    public static final AesCbcCipherDetails INSTANCE_128_BIT = new AesCbcCipherDetails(128);
+    private static volatile AesCbcCipherDetails instance128Bit;
 
     /**
      * Instance of AES192-CBC cipher.
      */
-    public static final AesCbcCipherDetails INSTANCE_192_BIT = new AesCbcCipherDetails(192);
+    private static volatile AesCbcCipherDetails instance192Bit;
 
     /**
      * Instance of AES256-CBC cipher.
      */
-    public static final AesCbcCipherDetails INSTANCE_256_BIT = new AesCbcCipherDetails(256);
+    private static volatile AesCbcCipherDetails instance256Bit;
+
+    /**
+     * Method to retrieve AES-CBC-128 cipher details.
+     *
+     * @return AES-CBC-128 cipher details
+     *
+     * @throws NoSuchAlgorithmException if no provider implements AES-CBC-128
+     */
+    public static AesCbcCipherDetails aesCbc128() throws NoSuchAlgorithmException {
+
+        // use double-checked lock to minimize parallel contention
+
+        if (instance128Bit == null) {
+
+            synchronized (AesCbcCipherDetails.class) {
+
+                if (instance128Bit == null) {
+
+                    instance128Bit = new AesCbcCipherDetails(128);
+                }
+            }
+        }
+
+        return instance128Bit;
+    }
+
+    /**
+     * Method to retrieve AES-CBC-192 cipher details.
+     *
+     * @return AES-CBC-192 cipher details
+     *
+     * @throws NoSuchAlgorithmException if no provider implements AES-CBC-192
+     */
+    public static AesCbcCipherDetails aesCbc192() throws NoSuchAlgorithmException {
+
+        // use double-checked lock to minimize parallel contention
+
+        if (instance192Bit == null) {
+
+            synchronized (AesCbcCipherDetails.class) {
+
+                if (instance192Bit == null) {
+
+                    instance192Bit = new AesCbcCipherDetails(192);
+                }
+            }
+        }
+
+        return instance192Bit;
+    }
+
+    /**
+     * Method to retrieve AES-CBC-256 cipher details.
+     *
+     * @return AES-CBC-256 cipher details
+     *
+     * @throws NoSuchAlgorithmException if no provider implements AES-CBC-256
+     */
+    public static AesCbcCipherDetails aesCbc256() throws NoSuchAlgorithmException {
+
+        // use double-checked lock to minimize parallel contention
+
+        if (instance256Bit == null) {
+
+            synchronized (AesCbcCipherDetails.class) {
+
+                if (instance256Bit == null) {
+
+                    instance256Bit = new AesCbcCipherDetails(256);
+                }
+            }
+        }
+
+        return instance256Bit;
+    }
 
     /**
      * Creates a new instance of a AES-CBC cipher for the static instance.
      *
      * @param keyLengthBits size of the private key - which determines the AES algorithm type
+     *
+     * @throws NoSuchAlgorithmException if no provider implements the requested algorithm
      */
-    private AesCbcCipherDetails(final int keyLengthBits) {
+    private AesCbcCipherDetails(final int keyLengthBits) throws NoSuchAlgorithmException {
         super(keyLengthBits, "AES/CBC/PKCS5Padding", DEFAULT_HMAC_ALGORITHM);
     }
 

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCtrCipherDetails.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCtrCipherDetails.java
@@ -9,6 +9,8 @@ package com.joyent.manta.client.crypto;
 
 import org.apache.commons.lang3.Validate;
 
+import java.security.NoSuchAlgorithmException;
+
 import javax.crypto.Cipher;
 
 /**
@@ -22,24 +24,101 @@ public final class AesCtrCipherDetails extends AbstractAesCipherDetails {
     /**
      * Instance of AES128-CTR cipher.
      */
-    public static final AesCtrCipherDetails INSTANCE_128_BIT = new AesCtrCipherDetails(128);
+    private static volatile AesCtrCipherDetails instance128Bit;
 
     /**
      * Instance of AES192-CTR cipher.
      */
-    public static final AesCtrCipherDetails INSTANCE_192_BIT = new AesCtrCipherDetails(192);
+    private static volatile AesCtrCipherDetails instance192Bit;
 
     /**
      * Instance of AES256-CTR cipher.
      */
-    public static final AesCtrCipherDetails INSTANCE_256_BIT = new AesCtrCipherDetails(256);
+    private static volatile AesCtrCipherDetails instance256Bit;
+
+    /**
+     * Method to retrieve AES-CTR-128 cipher details.
+     *
+     * @return AES-CTR-128 cipher details
+     *
+     * @throws NoSuchAlgorithmException if no provider implements AES-CTR-128
+     */
+    public static AesCtrCipherDetails aesCtr128() throws NoSuchAlgorithmException {
+
+        // use double-checked lock to minimize parallel contention
+
+        if (instance128Bit == null) {
+
+            synchronized (AesCtrCipherDetails.class) {
+
+                if (instance128Bit == null) {
+
+                    instance128Bit = new AesCtrCipherDetails(128);
+                }
+            }
+        }
+
+        return instance128Bit;
+    }
+
+    /**
+     * Method to retrieve AES-CTR-192 cipher details.
+     *
+     * @return AES-CTR-192 cipher details
+     *
+     * @throws NoSuchAlgorithmException if no provider implements AES-CTR-192
+     */
+    public static AesCtrCipherDetails aesCtr192() throws NoSuchAlgorithmException {
+
+        // use double-checked lock to minimize parallel contention
+
+        if (instance192Bit == null) {
+
+            synchronized (AesCtrCipherDetails.class) {
+
+                if (instance192Bit == null) {
+
+                    instance192Bit = new AesCtrCipherDetails(192);
+                }
+            }
+        }
+
+        return instance192Bit;
+    }
+
+    /**
+     * Method to retrieve AES-CTR-256 cipher details.
+     *
+     * @return AES-CTR-256 cipher details
+     *
+     * @throws NoSuchAlgorithmException if no provider implements AES-CTR-256
+     */
+    public static AesCtrCipherDetails aesCtr256() throws NoSuchAlgorithmException {
+
+        // use double-checked lock to minimize parallel contention
+
+        if (instance256Bit == null) {
+
+            synchronized (AesCtrCipherDetails.class) {
+
+                if (instance256Bit == null) {
+
+                    instance256Bit = new AesCtrCipherDetails(256);
+                }
+            }
+        }
+
+        return instance256Bit;
+    }
 
     /**
      * Creates a new instance of a AES-CTR cipher for the static instance.
      *
      * @param keyLengthBits size of the private key - which determines the AES algorithm type
+     *
+     * @throws NoSuchAlgorithmException if no provider implements the requested algorithm
      */
-    private AesCtrCipherDetails(final int keyLengthBits) {
+    private AesCtrCipherDetails(final int keyLengthBits) throws NoSuchAlgorithmException {
         super(keyLengthBits, "AES/CTR/NoPadding", DEFAULT_HMAC_ALGORITHM);
     }
 

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesGcmCipherDetails.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesGcmCipherDetails.java
@@ -11,6 +11,8 @@ import org.apache.commons.lang3.Validate;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
+
+import java.security.NoSuchAlgorithmException;
 import java.security.spec.AlgorithmParameterSpec;
 
 /**
@@ -35,24 +37,101 @@ public final class AesGcmCipherDetails  extends AbstractAesCipherDetails {
     /**
      * Instance of AES128-GCM cipher.
      */
-    public static final AesGcmCipherDetails INSTANCE_128_BIT = new AesGcmCipherDetails(128);
+    private static volatile AesGcmCipherDetails instance128Bit;
 
     /**
      * Instance of AES192-GCM cipher.
      */
-    public static final AesGcmCipherDetails INSTANCE_192_BIT = new AesGcmCipherDetails(192);
+    private static volatile AesGcmCipherDetails instance192Bit;
 
     /**
      * Instance of AES256-GCM cipher.
      */
-    public static final AesGcmCipherDetails INSTANCE_256_BIT = new AesGcmCipherDetails(256);
+    private static volatile AesGcmCipherDetails instance256Bit;
+
+    /**
+     * Method to retrieve AES-GCM-128 cipher details.
+     *
+     * @return AES-GCM-128 cipher details
+     *
+     * @throws NoSuchAlgorithmException if no provider implements AES-GCM-128
+     */
+    public static AesGcmCipherDetails aesGcm128() throws NoSuchAlgorithmException {
+
+        // use double-checked lock to minimize parallel contention
+
+        if (instance128Bit == null) {
+
+            synchronized (AesGcmCipherDetails.class) {
+
+                if (instance128Bit == null) {
+
+                    instance128Bit = new AesGcmCipherDetails(128);
+                }
+            }
+        }
+
+        return instance128Bit;
+    }
+
+    /**
+     * Method to retrieve AES-GCM-192 cipher details.
+     *
+     * @return AES-GCM-192 cipher details
+     *
+     * @throws NoSuchAlgorithmException if no provider implements AES-GCM-192
+     */
+    public static AesGcmCipherDetails aesGcm192() throws NoSuchAlgorithmException {
+
+        // use double-checked lock to minimize parallel contention
+
+        if (instance192Bit == null) {
+
+            synchronized (AesGcmCipherDetails.class) {
+
+                if (instance192Bit == null) {
+
+                    instance192Bit = new AesGcmCipherDetails(192);
+                }
+            }
+        }
+
+        return instance192Bit;
+    }
+
+    /**
+     * Method to retrieve AES-GCM-256 cipher details.
+     *
+     * @return AES-GCM-256 cipher details
+     *
+     * @throws NoSuchAlgorithmException if no provider implements AES-GCM-256
+     */
+    public static AesGcmCipherDetails aesGcm256() throws NoSuchAlgorithmException {
+
+        // use double-checked lock to minimize parallel contention
+
+        if (instance256Bit == null) {
+
+            synchronized (AesGcmCipherDetails.class) {
+
+                if (instance256Bit == null) {
+
+                    instance256Bit = new AesGcmCipherDetails(256);
+                }
+            }
+        }
+
+        return instance256Bit;
+    }
 
     /**
      * Creates a new instance of a AES-GCM cipher for the static instance.
      *
      * @param keyLengthBits size of the private key - which determines the AES algorithm type
+     *
+     * @throws NoSuchAlgorithmException if no provider implements the requested algorithm
      */
-    private AesGcmCipherDetails(final int keyLengthBits) {
+    private AesGcmCipherDetails(final int keyLengthBits) throws NoSuchAlgorithmException {
         // Use 128-bit AEAD tag
         super(keyLengthBits, "AES/GCM/NoPadding", 16);
     }

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/SupportedCiphersLookupMap.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/SupportedCiphersLookupMap.java
@@ -10,6 +10,7 @@ package com.joyent.manta.client.crypto;
 import com.joyent.manta.util.LookupMap;
 import com.joyent.manta.util.MantaUtils;
 
+import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 
 /**
@@ -30,18 +31,41 @@ public final class SupportedCiphersLookupMap extends LookupMap<String, Supported
      * Package default constructor because interface is through {@link SupportedCipherDetails}.
      */
     private SupportedCiphersLookupMap() {
-        super(MantaUtils.unmodifiableMap(
-                AesGcmCipherDetails.INSTANCE_128_BIT.getCipherId(), AesGcmCipherDetails.INSTANCE_128_BIT,
-                AesGcmCipherDetails.INSTANCE_192_BIT.getCipherId(), AesGcmCipherDetails.INSTANCE_192_BIT,
-                AesGcmCipherDetails.INSTANCE_256_BIT.getCipherId(), AesGcmCipherDetails.INSTANCE_256_BIT,
 
-                AesCtrCipherDetails.INSTANCE_128_BIT.getCipherId(), AesCtrCipherDetails.INSTANCE_128_BIT,
-                AesCtrCipherDetails.INSTANCE_192_BIT.getCipherId(), AesCtrCipherDetails.INSTANCE_192_BIT,
-                AesCtrCipherDetails.INSTANCE_256_BIT.getCipherId(), AesCtrCipherDetails.INSTANCE_256_BIT,
+        super(supportedCipherMap());
+    }
 
-                AesCbcCipherDetails.INSTANCE_128_BIT.getCipherId(), AesCbcCipherDetails.INSTANCE_128_BIT,
-                AesCbcCipherDetails.INSTANCE_192_BIT.getCipherId(), AesCbcCipherDetails.INSTANCE_192_BIT,
-                AesCbcCipherDetails.INSTANCE_256_BIT.getCipherId(), AesCbcCipherDetails.INSTANCE_256_BIT
-        ));
+    /**
+     * Method to construct a map of supported ciphers.
+     *
+     * @return map of supported ciphers
+     */
+    private static Map<String, SupportedCipherDetails> supportedCipherMap() {
+
+        final Map<String, SupportedCipherDetails> map;
+
+        try {
+
+            map = MantaUtils.unmodifiableMap(
+                        AesGcmCipherDetails.aesGcm128().getCipherId(), AesGcmCipherDetails.aesGcm128(),
+                        AesGcmCipherDetails.aesGcm192().getCipherId(), AesGcmCipherDetails.aesGcm192(),
+                        AesGcmCipherDetails.aesGcm256().getCipherId(), AesGcmCipherDetails.aesGcm256(),
+
+                        AesCtrCipherDetails.aesCtr128().getCipherId(), AesCtrCipherDetails.aesCtr128(),
+                        AesCtrCipherDetails.aesCtr192().getCipherId(), AesCtrCipherDetails.aesCtr192(),
+                        AesCtrCipherDetails.aesCtr256().getCipherId(), AesCtrCipherDetails.aesCtr256(),
+
+                        AesCbcCipherDetails.aesCbc128().getCipherId(), AesCbcCipherDetails.aesCbc128(),
+                        AesCbcCipherDetails.aesCbc192().getCipherId(), AesCbcCipherDetails.aesCbc192(),
+                        AesCbcCipherDetails.aesCbc256().getCipherId(), AesCbcCipherDetails.aesCbc256()
+                );
+
+        } catch (NoSuchAlgorithmException nsae) {
+
+            final String msg = "unable to instantiate supported cipher details map";
+            throw new Error(msg, nsae);
+        }
+
+        return map;
     }
 }

--- a/java-manta-client/src/main/java/com/joyent/manta/config/DefaultsConfigContext.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/config/DefaultsConfigContext.java
@@ -7,7 +7,7 @@
  */
 package com.joyent.manta.config;
 
-import com.joyent.manta.client.crypto.AesCtrCipherDetails;
+import com.joyent.manta.client.crypto.AbstractAesCipherDetails;
 import com.joyent.manta.client.crypto.SupportedCipherDetails;
 
 import java.io.File;
@@ -70,7 +70,7 @@ public class DefaultsConfigContext implements ConfigContext {
      * Default client-side encryption cipher algorithm.
      */
     public static final SupportedCipherDetails DEFAULT_CIPHER =
-            AesCtrCipherDetails.INSTANCE_128_BIT;
+            AbstractAesCipherDetails.DEFAULT_CIPHER_AES;
 
     /**
      * Default TLS cipher suites.

--- a/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesCbcCipherDetailsTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesCbcCipherDetailsTest.java
@@ -8,86 +8,104 @@
 package com.joyent.manta.client.crypto;
 
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import java.security.NoSuchAlgorithmException;
 
 import javax.crypto.SecretKey;
 
 @Test
 public class AesCbcCipherDetailsTest extends AbstractCipherDetailsTest {
+
+    private AesCbcCipherDetails AES_CBC_128;
+
+    private AesCbcCipherDetails AES_CBC_192;
+
+    private AesCbcCipherDetails AES_CBC_256;
+
+    @BeforeClass
+    private void init() throws NoSuchAlgorithmException {
+
+        AES_CBC_128 = AesCbcCipherDetails.aesCbc128();
+        AES_CBC_192 = AesCbcCipherDetails.aesCbc192();
+        AES_CBC_256 = AesCbcCipherDetails.aesCbc256();
+    }
+
     public void size1024bCalculationWorksRoundTripAes128() {
         final long size = 1024;
-        sizeCalculationWorksRoundTrip(AesCbcCipherDetails.INSTANCE_128_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_CBC_128, size);
     }
 
     public void size1024bCalculationWorksRoundTripAes192() {
         final long size = 1024;
-        sizeCalculationWorksRoundTrip(AesCbcCipherDetails.INSTANCE_192_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_CBC_192, size);
     }
 
     public void size1024bCalculationWorksRoundTripAes256() {
         final long size = 1024;
-        sizeCalculationWorksRoundTrip(AesCbcCipherDetails.INSTANCE_256_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_CBC_256, size);
     }
 
     public void size0bCalculationWorksRoundTripAes128() {
         final long size = 0;
-        sizeCalculationWorksRoundTrip(AesCbcCipherDetails.INSTANCE_128_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_CBC_128, size);
     }
 
     public void size0bCalculationWorksRoundTripAes192() {
         final long size = 0;
-        sizeCalculationWorksRoundTrip(AesCbcCipherDetails.INSTANCE_192_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_CBC_192, size);
     }
 
     public void size0bCalculationWorksRoundTripAes256() {
         final long size = 0;
-        sizeCalculationWorksRoundTrip(AesCbcCipherDetails.INSTANCE_256_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_CBC_256, size);
     }
 
     public void size2009125bCalculationWorksRoundTripAes128() {
         final long size = 2009125;
-        sizeCalculationWorksRoundTrip(AesCbcCipherDetails.INSTANCE_128_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_CBC_128, size);
     }
 
     public void size2009125bCalculationWorksRoundTripAes192() {
         final long size = 2009125;
-        sizeCalculationWorksRoundTrip(AesCbcCipherDetails.INSTANCE_192_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_CBC_192, size);
     }
 
     public void size2009125bCalculationWorksRoundTripAes256() {
         final long size = 2009125;
-        sizeCalculationWorksRoundTrip(AesCbcCipherDetails.INSTANCE_256_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_CBC_256, size);
     }
 
     public void ciphertextSizeCalculationWorksForAes128() throws Exception {
-        sizeCalculationWorksComparedToActualCipher(AesCbcCipherDetails.INSTANCE_128_BIT);
+        sizeCalculationWorksComparedToActualCipher(AES_CBC_128);
     }
 
     public void ciphertextSizeCalculationWorksForAes192() throws Exception {
-        sizeCalculationWorksComparedToActualCipher(AesCbcCipherDetails.INSTANCE_192_BIT);
+        sizeCalculationWorksComparedToActualCipher(AES_CBC_192);
     }
 
     public void ciphertextSizeCalculationWorksForAes256() throws Exception {
-        sizeCalculationWorksComparedToActualCipher(AesCbcCipherDetails.INSTANCE_256_BIT);
+        sizeCalculationWorksComparedToActualCipher(AES_CBC_256);
     }
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void canQueryCiphertextByteRangeAes128() throws Exception {
-        SupportedCipherDetails cipherDetails = AesCbcCipherDetails.INSTANCE_128_BIT;
+        SupportedCipherDetails cipherDetails = AES_CBC_128;
         SecretKey secretKey = SecretKeyUtils.generate(cipherDetails);
         cipherDetails.translateByteRange(0, 128);
     }
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void canQueryCiphertextByteRangeAes192() throws Exception {
-        SupportedCipherDetails cipherDetails = AesCbcCipherDetails.INSTANCE_192_BIT;
+        SupportedCipherDetails cipherDetails = AES_CBC_192;
         SecretKey secretKey = SecretKeyUtils.generate(cipherDetails);
         cipherDetails.translateByteRange(0, 128);
     }
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void canQueryCiphertextByteRangeAes256() throws Exception {
-        SupportedCipherDetails cipherDetails = AesCbcCipherDetails.INSTANCE_256_BIT;
+        SupportedCipherDetails cipherDetails = AES_CBC_256;
         SecretKey secretKey = SecretKeyUtils.generate(cipherDetails);
         cipherDetails.translateByteRange(0, 128);
     }

--- a/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesCtrCipherDetailsTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesCtrCipherDetailsTest.java
@@ -10,110 +10,128 @@ package com.joyent.manta.client.crypto;
 import com.joyent.manta.http.entity.ExposedByteArrayEntity;
 import org.apache.http.entity.ContentType;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 
 @Test
 public class AesCtrCipherDetailsTest extends AbstractCipherDetailsTest {
+
+    private AesCtrCipherDetails AES_CTR_128;
+
+    private AesCtrCipherDetails AES_CTR_192;
+
+    private AesCtrCipherDetails AES_CTR_256;
+
+    @BeforeClass
+    private void init() throws NoSuchAlgorithmException {
+
+        AES_CTR_128 = AesCtrCipherDetails.aesCtr128();
+        AES_CTR_192 = AesCtrCipherDetails.aesCtr192();
+        AES_CTR_256 = AesCtrCipherDetails.aesCtr256();
+    }
+
     public void size1024bCalculationWorksRoundTripAes128() {
         final long size = 1024;
-        sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_128_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_CTR_128, size);
     }
 
     public void size1024bCalculationWorksRoundTripAes192() {
         final long size = 1024;
-        sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_192_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_CTR_192, size);
     }
 
     public void size1024bCalculationWorksRoundTripAes256() {
         final long size = 1024;
-        sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_256_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_CTR_256, size);
     }
 
     public void size0bCalculationWorksRoundTripAes128() {
         final long size = 0;
-        sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_128_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_CTR_128, size);
     }
 
     public void size0bCalculationWorksRoundTripAes192() {
         final long size = 0;
-        sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_192_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_CTR_192, size);
     }
 
     public void size0bCalculationWorksRoundTripAes256() {
         final long size = 0;
-        sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_256_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_CTR_256, size);
     }
 
     public void size2009125bCalculationWorksRoundTripAes128() {
         final long size = 2009125;
-        sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_128_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_CTR_128, size);
     }
 
     public void size2009125bCalculationWorksRoundTripAes192() {
         final long size = 2009125;
-        sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_192_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_CTR_192, size);
     }
 
     public void size2009125bCalculationWorksRoundTripAes256() {
         final long size = 2009125;
-        sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_256_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_CTR_256, size);
     }
 
     public void ciphertextSizeCalculationWorksForAes128() throws Exception {
-        sizeCalculationWorksComparedToActualCipher(AesCtrCipherDetails.INSTANCE_128_BIT);
+        sizeCalculationWorksComparedToActualCipher(AES_CTR_128);
     }
 
     public void ciphertextSizeCalculationWorksForAes192() throws Exception {
-        sizeCalculationWorksComparedToActualCipher(AesCtrCipherDetails.INSTANCE_192_BIT);
+        sizeCalculationWorksComparedToActualCipher(AES_CTR_192);
     }
 
     public void ciphertextSizeCalculationWorksForAes256() throws Exception {
-        sizeCalculationWorksComparedToActualCipher(AesCtrCipherDetails.INSTANCE_256_BIT);
+        sizeCalculationWorksComparedToActualCipher(AES_CTR_256);
     }
 
     public void canQueryCiphertextByteRangeAes256() throws Exception {
-        SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_256_BIT;
+        SupportedCipherDetails cipherDetails = AES_CTR_256;
         SecretKey secretKey = SecretKeyUtils.generate(cipherDetails);
         canRandomlyReadPlaintextPositionFromCiphertext(secretKey, cipherDetails);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void translateByteRangeThrowsWithoutStartInclusive() {
-        AesCtrCipherDetails.INSTANCE_128_BIT.translateByteRange(-1, 0);
+        AES_CTR_128.translateByteRange(-1, 0);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void translateByteRangeThrowsWithLargeStartInclusive() {
-        AesCtrCipherDetails.INSTANCE_128_BIT.translateByteRange(Long.MAX_VALUE, 0);
+        AES_CTR_128.translateByteRange(Long.MAX_VALUE, 0);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void translateByteRangeThrowsWithoutEndInclusive() {
-        AesCtrCipherDetails.INSTANCE_128_BIT.translateByteRange(1, -1);
+        AES_CTR_128.translateByteRange(1, -1);
     }
 
     public void translateByteRangeReturnsCorrectRange() throws Exception {
-        ByteRangeConversion byteRange1 = AesCtrCipherDetails.INSTANCE_128_BIT.translateByteRange(5, 10);
+        ByteRangeConversion byteRange1 = AES_CTR_128.translateByteRange(5, 10);
         Assert.assertEquals(byteRange1.getCiphertextStartPositionInclusive(), 0);
         Assert.assertEquals(byteRange1.getCiphertextEndPositionInclusive(), 15);
         Assert.assertEquals(byteRange1.getPlaintextBytesToSkipInitially(), 5);
         Assert.assertEquals(byteRange1.getLengthOfPlaintextIncludingSkipBytes(), 11);
 
-        ByteRangeConversion byteRange2 = AesCtrCipherDetails.INSTANCE_128_BIT.translateByteRange(5, 22);
+        ByteRangeConversion byteRange2 = AES_CTR_128.translateByteRange(5, 22);
         Assert.assertEquals(byteRange2.getCiphertextStartPositionInclusive(), 0);
         Assert.assertEquals(byteRange2.getCiphertextEndPositionInclusive(), 31);
         Assert.assertEquals(byteRange2.getPlaintextBytesToSkipInitially(), 5);
         Assert.assertEquals(byteRange2.getLengthOfPlaintextIncludingSkipBytes(), 23);
 
-        ByteRangeConversion byteRange3 = AesCtrCipherDetails.INSTANCE_128_BIT.translateByteRange(32, 35);
+        ByteRangeConversion byteRange3 = AES_CTR_128.translateByteRange(32, 35);
         Assert.assertEquals(byteRange3.getCiphertextStartPositionInclusive(), 32);
         Assert.assertEquals(byteRange3.getCiphertextEndPositionInclusive(), 47);
         Assert.assertEquals(byteRange3.getPlaintextBytesToSkipInitially(), 0);

--- a/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesGcmCipherDetailsTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesGcmCipherDetailsTest.java
@@ -7,87 +7,105 @@
  */
 package com.joyent.manta.client.crypto;
 
+import java.security.NoSuchAlgorithmException;
+
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Test
 public class AesGcmCipherDetailsTest extends AbstractCipherDetailsTest {
+
+    private AesGcmCipherDetails AES_GCM_128;
+
+    private AesGcmCipherDetails AES_GCM_192;
+
+    private AesGcmCipherDetails AES_GCM_256;
+
+    @BeforeClass
+    private void init() throws NoSuchAlgorithmException {
+
+        AES_GCM_128 = AesGcmCipherDetails.aesGcm128();
+        AES_GCM_192 = AesGcmCipherDetails.aesGcm192();
+        AES_GCM_256 = AesGcmCipherDetails.aesGcm256();
+    }
+
     public void doesntCalculateHmac() throws Exception {
-        Assert.assertEquals(AesGcmCipherDetails.INSTANCE_256_BIT.getAuthenticationHmac(), null);
+        Assert.assertEquals(AES_GCM_256.getAuthenticationHmac(), null);
     }
 
     public void size1024bCalculationWorksRoundTripAes128() {
         final long size = 1024;
-        sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_128_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_GCM_128, size);
     }
 
     public void size1024bCalculationWorksRoundTripAes192() {
         final long size = 1024;
-        sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_192_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_GCM_192, size);
     }
 
     public void size1024bCalculationWorksRoundTripAes256() {
         final long size = 1024;
-        sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_256_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_GCM_256, size);
     }
 
     public void size0bCalculationWorksRoundTripAes128() {
         final long size = 0;
-        sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_128_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_GCM_128, size);
     }
 
     public void size0bCalculationWorksRoundTripAes192() {
         final long size = 0;
-        sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_192_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_GCM_192, size);
     }
 
     public void size0bCalculationWorksRoundTripAes256() {
         final long size = 0;
-        sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_256_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_GCM_256, size);
     }
 
     public void size2009125bCalculationWorksRoundTripAes128() {
         final long size = 2009125;
-        sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_128_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_GCM_128, size);
     }
 
     public void size2009125bCalculationWorksRoundTripAes192() {
         final long size = 2009125;
-        sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_192_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_GCM_192, size);
     }
 
     public void size2009125bCalculationWorksRoundTripAes256() {
         final long size = 2009125;
-        sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_256_BIT, size);
+        sizeCalculationWorksRoundTrip(AES_GCM_256, size);
     }
 
     public void ciphertextSizeCalculationWorksForAes128() throws Exception {
-        sizeCalculationWorksComparedToActualCipher(AesGcmCipherDetails.INSTANCE_128_BIT);
+        sizeCalculationWorksComparedToActualCipher(AES_GCM_128);
     }
 
     public void ciphertextSizeCalculationWorksForAes192() throws Exception {
-        sizeCalculationWorksComparedToActualCipher(AesGcmCipherDetails.INSTANCE_192_BIT);
+        sizeCalculationWorksComparedToActualCipher(AES_GCM_192);
     }
 
     public void ciphertextSizeCalculationWorksForAes256() throws Exception {
-        sizeCalculationWorksComparedToActualCipher(AesGcmCipherDetails.INSTANCE_256_BIT);
+        sizeCalculationWorksComparedToActualCipher(AES_GCM_256);
     }
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void canQueryCiphertextByteRangeAes128() throws Exception {
-        SupportedCipherDetails cipherDetails = AesGcmCipherDetails.INSTANCE_128_BIT;
+        SupportedCipherDetails cipherDetails = AES_GCM_128;
         cipherDetails.translateByteRange(0, 128);
     }
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void canQueryCiphertextByteRangeAes192() throws Exception {
-        SupportedCipherDetails cipherDetails = AesGcmCipherDetails.INSTANCE_192_BIT;
+        SupportedCipherDetails cipherDetails = AES_GCM_192;
         cipherDetails.translateByteRange(0, 128);
     }
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void canQueryCiphertextByteRangeAes256() throws Exception {
-        SupportedCipherDetails cipherDetails = AesGcmCipherDetails.INSTANCE_256_BIT;
+        SupportedCipherDetails cipherDetails = AES_GCM_256;
         cipherDetails.translateByteRange(0, 128);
     }
 }

--- a/java-manta-client/src/test/java/com/joyent/manta/client/crypto/EncryptingEntityTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/crypto/EncryptingEntityTest.java
@@ -16,10 +16,12 @@ import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.http.HttpEntity;
 import org.bouncycastle.jcajce.io.CipherInputStream;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -28,16 +30,31 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.function.Predicate;
 
 @Test
 public class EncryptingEntityTest {
+
+    private AesCbcCipherDetails AES_CBC_128;
+
+    private AesCtrCipherDetails AES_CTR_128;
+
+    private AesGcmCipherDetails AES_GCM_128;
+
+    @BeforeClass
+    private void init() throws NoSuchAlgorithmException {
+
+        AES_CBC_128 = AesCbcCipherDetails.aesCbc128();
+        AES_CTR_128 = AesCtrCipherDetails.aesCtr128();
+        AES_GCM_128 = AesGcmCipherDetails.aesGcm128();
+    }
     /* Constructor Tests */
 
     @Test(expectedExceptions = MantaClientEncryptionException.class)
     public void throwsWithTooLargeContentLength() {
-        SupportedCipherDetails cipherDetails = AesGcmCipherDetails.INSTANCE_128_BIT;
+        SupportedCipherDetails cipherDetails = AES_GCM_128;
         byte[] keyBytes = SecretKeyUtils.generate(cipherDetails).getEncoded();
 
         SecretKey key = SecretKeyUtils.loadKey(Arrays.copyOfRange(keyBytes, 2, 10), cipherDetails);
@@ -51,43 +68,43 @@ public class EncryptingEntityTest {
     /* AES-GCM-NoPadding Tests */
 
     public void canEncryptAndDecryptToAndFromFileInAesGcm() throws Exception {
-        verifyEncryptionWorksRoundTrip(AesGcmCipherDetails.INSTANCE_128_BIT);
+        verifyEncryptionWorksRoundTrip(AES_GCM_128);
     }
 
     public void canEncryptAndDecryptToAndFromFileWithManySizesInAesGcm() throws Exception {
-        canEncryptAndDecryptToAndFromFileWithManySizes(AesGcmCipherDetails.INSTANCE_128_BIT);
+        canEncryptAndDecryptToAndFromFileWithManySizes(AES_GCM_128);
     }
 
     public void canCountBytesFromStreamWithUnknownLengthInAesGcm() throws Exception {
-        canCountBytesFromStreamWithUnknownLength(AesGcmCipherDetails.INSTANCE_128_BIT);
+        canCountBytesFromStreamWithUnknownLength(AES_GCM_128);
     }
 
     /* AES-CTR-NoPadding Tests */
 
     public void canEncryptAndDecryptToAndFromFileInAesCtr() throws Exception {
-        verifyEncryptionWorksRoundTrip(AesCtrCipherDetails.INSTANCE_128_BIT);
+        verifyEncryptionWorksRoundTrip(AES_CTR_128);
     }
 
     public void canEncryptAndDecryptToAndFromFileWithManySizesInAesCtr() throws Exception {
-        canEncryptAndDecryptToAndFromFileWithManySizes(AesCtrCipherDetails.INSTANCE_128_BIT);
+        canEncryptAndDecryptToAndFromFileWithManySizes(AES_CTR_128);
     }
 
     public void canCountBytesFromStreamWithUnknownLengthInAesCtr() throws Exception {
-        canCountBytesFromStreamWithUnknownLength(AesCtrCipherDetails.INSTANCE_128_BIT);
+        canCountBytesFromStreamWithUnknownLength(AES_CTR_128);
     }
 
     /* AES-CBC-PKCS5Padding Tests */
 
     public void canEncryptAndDecryptToAndFromFileInAesCbc() throws Exception {
-        verifyEncryptionWorksRoundTrip(AesCbcCipherDetails.INSTANCE_128_BIT);
+        verifyEncryptionWorksRoundTrip(AES_CBC_128);
     }
 
     public void canEncryptAndDecryptToAndFromFileWithManySizesInAesCbc() throws Exception {
-        canEncryptAndDecryptToAndFromFileWithManySizes(AesCbcCipherDetails.INSTANCE_128_BIT);
+        canEncryptAndDecryptToAndFromFileWithManySizes(AES_CBC_128);
     }
 
     public void canCountBytesFromStreamWithUnknownLengthInAesCbc() throws Exception {
-        canCountBytesFromStreamWithUnknownLength(AesCbcCipherDetails.INSTANCE_128_BIT);
+        canCountBytesFromStreamWithUnknownLength(AES_CBC_128);
     }
 
     /* Test helper methods */

--- a/java-manta-client/src/test/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStreamTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStreamTest.java
@@ -21,10 +21,12 @@ import org.apache.http.conn.EofSensorInputStream;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -40,6 +42,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.UUID;
@@ -53,6 +56,46 @@ public class MantaEncryptedObjectInputStreamTest {
     private final URL testURL;
     private final int plaintextSize;
     private final byte[] plaintextBytes;
+
+    // AES-CBC
+    private AesCbcCipherDetails AES_CBC_128;
+
+    private AesCbcCipherDetails AES_CBC_192;
+
+    private AesCbcCipherDetails AES_CBC_256;
+
+    // AES-CTR
+    private AesCtrCipherDetails AES_CTR_128;
+
+    private AesCtrCipherDetails AES_CTR_192;
+
+    private AesCtrCipherDetails AES_CTR_256;
+
+    // AES-GCM
+    private AesGcmCipherDetails AES_GCM_128;
+
+    private AesGcmCipherDetails AES_GCM_192;
+
+    private AesGcmCipherDetails AES_GCM_256;
+
+    @BeforeClass
+    private void init() throws NoSuchAlgorithmException {
+
+        // AES-CBC
+        AES_CBC_128 = AesCbcCipherDetails.aesCbc128();
+        AES_CBC_192 = AesCbcCipherDetails.aesCbc192();
+        AES_CBC_256 = AesCbcCipherDetails.aesCbc256();
+
+        // AES-CTR
+        AES_CTR_128 = AesCtrCipherDetails.aesCtr128();
+        AES_CTR_192 = AesCtrCipherDetails.aesCtr192();
+        AES_CTR_256 = AesCtrCipherDetails.aesCtr256();
+
+        // AES-GCM
+        AES_GCM_128 = AesGcmCipherDetails.aesGcm128();
+        AES_GCM_192 = AesGcmCipherDetails.aesGcm192();
+        AES_GCM_256 = AesGcmCipherDetails.aesGcm256();
+    }
 
     public MantaEncryptedObjectInputStreamTest() {
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
@@ -74,375 +117,375 @@ public class MantaEncryptedObjectInputStreamTest {
     }
 
     public void canDecryptEntireObjectAuthenticatedAesCbc128() throws IOException {
-        canDecryptEntireObjectAllReadModes(AesCbcCipherDetails.INSTANCE_128_BIT, true);
+        canDecryptEntireObjectAllReadModes(AES_CBC_128, true);
     }
 
     public void canDecryptEntireObjectAuthenticatedAesCbc192() throws IOException {
-        canDecryptEntireObjectAllReadModes(AesCbcCipherDetails.INSTANCE_192_BIT, true);
+        canDecryptEntireObjectAllReadModes(AES_CBC_192, true);
     }
 
     public void canDecryptEntireObjectAuthenticatedAesCbc256() throws IOException {
-        canDecryptEntireObjectAllReadModes(AesCbcCipherDetails.INSTANCE_256_BIT, true);
+        canDecryptEntireObjectAllReadModes(AES_CBC_256, true);
     }
 
     public void canDecryptEntireObjectAuthenticatedAesCtr128() throws IOException {
-        canDecryptEntireObjectAllReadModes(AesCtrCipherDetails.INSTANCE_128_BIT, true);
+        canDecryptEntireObjectAllReadModes(AES_CTR_128, true);
     }
 
     public void canDecryptEntireObjectAuthenticatedAesCtr192() throws IOException {
-        canDecryptEntireObjectAllReadModes(AesCtrCipherDetails.INSTANCE_192_BIT, true);
+        canDecryptEntireObjectAllReadModes(AES_CTR_192, true);
     }
 
     public void canDecryptEntireObjectAuthenticatedAesCtr256() throws IOException {
-        canDecryptEntireObjectAllReadModes(AesCtrCipherDetails.INSTANCE_256_BIT, true);
+        canDecryptEntireObjectAllReadModes(AES_CTR_256, true);
     }
 
     public void canDecryptEntireObjectAuthenticatedAesGcm128() throws IOException {
-        canDecryptEntireObjectAllReadModes(AesGcmCipherDetails.INSTANCE_128_BIT, true);
+        canDecryptEntireObjectAllReadModes(AES_GCM_128, true);
     }
 
     public void canDecryptEntireObjectAuthenticatedAesGcm192() throws IOException {
-        canDecryptEntireObjectAllReadModes(AesGcmCipherDetails.INSTANCE_192_BIT, true);
+        canDecryptEntireObjectAllReadModes(AES_GCM_192, true);
     }
 
     public void canDecryptEntireObjectAuthenticatedAesGcm256() throws IOException {
-        canDecryptEntireObjectAllReadModes(AesGcmCipherDetails.INSTANCE_256_BIT, true);
+        canDecryptEntireObjectAllReadModes(AES_GCM_256, true);
     }
 
 
     public void canDecryptEntireObjectUnauthenticatedAesCbc128() throws IOException {
-        canDecryptEntireObjectAllReadModes(AesCbcCipherDetails.INSTANCE_128_BIT, false);
+        canDecryptEntireObjectAllReadModes(AES_CBC_128, false);
     }
 
     public void canDecryptEntireObjectUnauthenticatedAesCbc192() throws IOException {
-        canDecryptEntireObjectAllReadModes(AesCbcCipherDetails.INSTANCE_192_BIT, false);
+        canDecryptEntireObjectAllReadModes(AES_CBC_192, false);
     }
 
     public void canDecryptEntireObjectUnauthenticatedAesCbc256() throws IOException {
-        canDecryptEntireObjectAllReadModes(AesCbcCipherDetails.INSTANCE_256_BIT, false);
+        canDecryptEntireObjectAllReadModes(AES_CBC_256, false);
     }
 
     public void canDecryptEntireObjectUnauthenticatedAesCtr128() throws IOException {
-        canDecryptEntireObjectAllReadModes(AesCtrCipherDetails.INSTANCE_128_BIT, false);
+        canDecryptEntireObjectAllReadModes(AES_CTR_128, false);
     }
 
     public void canDecryptEntireObjectUnauthenticatedAesCtr192() throws IOException {
-        canDecryptEntireObjectAllReadModes(AesCtrCipherDetails.INSTANCE_192_BIT, false);
+        canDecryptEntireObjectAllReadModes(AES_CTR_192, false);
     }
 
     public void canDecryptEntireObjectUnauthenticatedAesCtr256() throws IOException {
-        canDecryptEntireObjectAllReadModes(AesCtrCipherDetails.INSTANCE_256_BIT, false);
+        canDecryptEntireObjectAllReadModes(AES_CTR_256, false);
     }
 
     public void canDecryptEntireObjectUnauthenticatedAesGcm128() throws IOException {
-        canDecryptEntireObjectAllReadModes(AesGcmCipherDetails.INSTANCE_128_BIT, false);
+        canDecryptEntireObjectAllReadModes(AES_GCM_128, false);
     }
 
     public void canDecryptEntireObjectUnauthenticatedAesGcm192() throws IOException {
-        canDecryptEntireObjectAllReadModes(AesGcmCipherDetails.INSTANCE_192_BIT, false);
+        canDecryptEntireObjectAllReadModes(AES_GCM_192, false);
     }
 
     public void canDecryptEntireObjectUnauthenticatedAesGcm256() throws IOException {
-        canDecryptEntireObjectAllReadModes(AesGcmCipherDetails.INSTANCE_256_BIT, false);
+        canDecryptEntireObjectAllReadModes(AES_GCM_256, false);
     }
 
 
     public void willErrorIfCiphertextIsModifiedAesCbc128() throws IOException {
-        willErrorIfCiphertextIsModifiedAllReadModes(AesCbcCipherDetails.INSTANCE_128_BIT);
+        willErrorIfCiphertextIsModifiedAllReadModes(AES_CBC_128);
     }
 
     public void willErrorIfCiphertextIsModifiedAesCbc192() throws IOException {
-        willErrorIfCiphertextIsModifiedAllReadModes(AesCbcCipherDetails.INSTANCE_192_BIT);
+        willErrorIfCiphertextIsModifiedAllReadModes(AES_CBC_192);
     }
 
     public void willErrorIfCiphertextIsModifiedAesCbc256() throws IOException {
-        willErrorIfCiphertextIsModifiedAllReadModes(AesCbcCipherDetails.INSTANCE_256_BIT);
+        willErrorIfCiphertextIsModifiedAllReadModes(AES_CBC_256);
     }
 
     public void willErrorIfCiphertextIsModifiedAesCtr128() throws IOException {
-        willErrorIfCiphertextIsModifiedAllReadModes(AesCtrCipherDetails.INSTANCE_128_BIT);
+        willErrorIfCiphertextIsModifiedAllReadModes(AES_CTR_128);
     }
 
     public void willErrorIfCiphertextIsModifiedAesCtr192() throws IOException {
-        willErrorIfCiphertextIsModifiedAllReadModes(AesCtrCipherDetails.INSTANCE_192_BIT);
+        willErrorIfCiphertextIsModifiedAllReadModes(AES_CTR_192);
     }
 
     public void willErrorIfCiphertextIsModifiedAesCtr256() throws IOException {
-        willErrorIfCiphertextIsModifiedAllReadModes(AesCtrCipherDetails.INSTANCE_256_BIT);
+        willErrorIfCiphertextIsModifiedAllReadModes(AES_CTR_256);
     }
 
     public void willErrorIfCiphertextIsModifiedAesGcm128() throws IOException {
-        willErrorIfCiphertextIsModifiedAllReadModes(AesGcmCipherDetails.INSTANCE_128_BIT);
+        willErrorIfCiphertextIsModifiedAllReadModes(AES_GCM_128);
     }
 
     public void willErrorIfCiphertextIsModifiedAesGcm192() throws IOException {
-        willErrorIfCiphertextIsModifiedAllReadModes(AesGcmCipherDetails.INSTANCE_192_BIT);
+        willErrorIfCiphertextIsModifiedAllReadModes(AES_GCM_192);
     }
 
     public void willErrorIfCiphertextIsModifiedAesGcm256() throws IOException {
-        willErrorIfCiphertextIsModifiedAllReadModes(AesGcmCipherDetails.INSTANCE_256_BIT);
+        willErrorIfCiphertextIsModifiedAllReadModes(AES_GCM_256);
     }
 
 
     public void willErrorIfCiphertextIsModifiedAndNotReadFullyAesCbc128() throws IOException {
-        willErrorIfCiphertextIsModifiedAndNotReadFully(AesCbcCipherDetails.INSTANCE_128_BIT);
+        willErrorIfCiphertextIsModifiedAndNotReadFully(AES_CBC_128);
     }
 
     public void willErrorIfCiphertextIsModifiedAndNotReadFullyAesCbc192() throws IOException {
-        willErrorIfCiphertextIsModifiedAndNotReadFully(AesCbcCipherDetails.INSTANCE_192_BIT);
+        willErrorIfCiphertextIsModifiedAndNotReadFully(AES_CBC_192);
     }
 
     public void willErrorIfCiphertextIsModifiedAndNotReadFullyAesCbc256() throws IOException {
-        willErrorIfCiphertextIsModifiedAndNotReadFully(AesCbcCipherDetails.INSTANCE_256_BIT);
+        willErrorIfCiphertextIsModifiedAndNotReadFully(AES_CBC_256);
     }
 
     public void willErrorIfCiphertextIsModifiedAndNotReadFullyAesCtr128() throws IOException {
-        willErrorIfCiphertextIsModifiedAndNotReadFully(AesCtrCipherDetails.INSTANCE_128_BIT);
+        willErrorIfCiphertextIsModifiedAndNotReadFully(AES_CTR_128);
     }
 
     public void willErrorIfCiphertextIsModifiedAndNotReadFullyAesCtr192() throws IOException {
-        willErrorIfCiphertextIsModifiedAndNotReadFully(AesCtrCipherDetails.INSTANCE_192_BIT);
+        willErrorIfCiphertextIsModifiedAndNotReadFully(AES_CTR_192);
     }
 
     public void willErrorIfCiphertextIsModifiedAndNotReadFullyAesCtr256() throws IOException {
-        willErrorIfCiphertextIsModifiedAndNotReadFully(AesCtrCipherDetails.INSTANCE_256_BIT);
+        willErrorIfCiphertextIsModifiedAndNotReadFully(AES_CTR_256);
     }
 
     public void willErrorIfCiphertextIsModifiedAndNotReadFullyAesGcm128() throws IOException {
-        willErrorIfCiphertextIsModifiedAndNotReadFully(AesGcmCipherDetails.INSTANCE_128_BIT);
+        willErrorIfCiphertextIsModifiedAndNotReadFully(AES_GCM_128);
     }
 
     public void willErrorIfCiphertextIsModifiedAndNotReadFullyAesGcm192() throws IOException {
-        willErrorIfCiphertextIsModifiedAndNotReadFully(AesGcmCipherDetails.INSTANCE_192_BIT);
+        willErrorIfCiphertextIsModifiedAndNotReadFully(AES_GCM_192);
     }
 
     public void willErrorIfCiphertextIsModifiedAndNotReadFullyAesGcm256() throws IOException {
-        willErrorIfCiphertextIsModifiedAndNotReadFully(AesGcmCipherDetails.INSTANCE_256_BIT);
+        willErrorIfCiphertextIsModifiedAndNotReadFully(AES_GCM_256);
     }
 
 
     public void canSkipBytesAuthenticatedAesCbc128() throws IOException {
-        canSkipBytesAuthenticated(AesCbcCipherDetails.INSTANCE_128_BIT);
+        canSkipBytesAuthenticated(AES_CBC_128);
     }
 
     public void canSkipBytesAuthenticatedAesCbc192() throws IOException {
-        canSkipBytesAuthenticated(AesCbcCipherDetails.INSTANCE_192_BIT);
+        canSkipBytesAuthenticated(AES_CBC_192);
     }
 
     public void canSkipBytesAuthenticatedAesCbc256() throws IOException {
-        canSkipBytesAuthenticated(AesCbcCipherDetails.INSTANCE_256_BIT);
+        canSkipBytesAuthenticated(AES_CBC_256);
     }
 
     public void canSkipBytesAuthenticatedAesCtr128() throws IOException {
-        canSkipBytesAuthenticated(AesCtrCipherDetails.INSTANCE_128_BIT);
+        canSkipBytesAuthenticated(AES_CTR_128);
     }
 
     public void canSkipBytesAuthenticatedAesCtr192() throws IOException {
-        canSkipBytesAuthenticated(AesCtrCipherDetails.INSTANCE_192_BIT);
+        canSkipBytesAuthenticated(AES_CTR_192);
     }
 
     public void canSkipBytesAuthenticatedAesCtr256() throws IOException {
-        canSkipBytesAuthenticated(AesCtrCipherDetails.INSTANCE_256_BIT);
+        canSkipBytesAuthenticated(AES_CTR_256);
     }
 
     public void canSkipBytesAuthenticatedAesGcm128() throws IOException {
-        canSkipBytesAuthenticated(AesGcmCipherDetails.INSTANCE_128_BIT);
+        canSkipBytesAuthenticated(AES_GCM_128);
     }
 
     public void canSkipBytesAuthenticatedAesGcm192() throws IOException {
-        canSkipBytesAuthenticated(AesGcmCipherDetails.INSTANCE_192_BIT);
+        canSkipBytesAuthenticated(AES_GCM_192);
     }
 
     public void canSkipBytesAuthenticatedAesGcm256() throws IOException {
-        canSkipBytesAuthenticated(AesGcmCipherDetails.INSTANCE_256_BIT);
+        canSkipBytesAuthenticated(AES_GCM_256);
     }
 
 
     public void canSkipBytesUnauthenticatedAesCbc128() throws IOException {
-        canSkipBytesUnauthenticated(AesCbcCipherDetails.INSTANCE_128_BIT);
+        canSkipBytesUnauthenticated(AES_CBC_128);
     }
 
     public void canSkipBytesUnauthenticatedAesCbc192() throws IOException {
-        canSkipBytesUnauthenticated(AesCbcCipherDetails.INSTANCE_192_BIT);
+        canSkipBytesUnauthenticated(AES_CBC_192);
     }
 
     public void canSkipBytesUnauthenticatedAesCbc256() throws IOException {
-        canSkipBytesUnauthenticated(AesCbcCipherDetails.INSTANCE_256_BIT);
+        canSkipBytesUnauthenticated(AES_CBC_256);
     }
 
     public void canSkipBytesUnauthenticatedAesCtr128() throws IOException {
-        canSkipBytesUnauthenticated(AesCtrCipherDetails.INSTANCE_128_BIT);
+        canSkipBytesUnauthenticated(AES_CTR_128);
     }
 
     public void canSkipBytesUnauthenticatedAesCtr192() throws IOException {
-        canSkipBytesUnauthenticated(AesCtrCipherDetails.INSTANCE_192_BIT);
+        canSkipBytesUnauthenticated(AES_CTR_192);
     }
 
     public void canSkipBytesUnauthenticatedAesCtr256() throws IOException {
-        canSkipBytesUnauthenticated(AesCtrCipherDetails.INSTANCE_256_BIT);
+        canSkipBytesUnauthenticated(AES_CTR_256);
     }
 
     public void canSkipBytesUnauthenticatedAesGcm128() throws IOException {
-        canSkipBytesUnauthenticated(AesGcmCipherDetails.INSTANCE_128_BIT);
+        canSkipBytesUnauthenticated(AES_GCM_128);
     }
 
     public void canSkipBytesUnauthenticatedAesGcm192() throws IOException {
-        canSkipBytesUnauthenticated(AesGcmCipherDetails.INSTANCE_192_BIT);
+        canSkipBytesUnauthenticated(AES_GCM_192);
     }
 
     public void canSkipBytesUnauthenticatedAesGcm256() throws IOException {
-        canSkipBytesUnauthenticated(AesGcmCipherDetails.INSTANCE_256_BIT);
+        canSkipBytesUnauthenticated(AES_GCM_256);
     }
 
 
     public void willErrorIfCiphertextIsModifiedAndBytesAreSkippedAesCbc128() throws IOException {
-        willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesCbcCipherDetails.INSTANCE_128_BIT);
+        willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AES_CBC_128);
     }
 
     public void willErrorIfCiphertextIsModifiedAndBytesAreSkippedAesCbc192() throws IOException {
-        willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesCbcCipherDetails.INSTANCE_192_BIT);
+        willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AES_CBC_192);
     }
 
     public void willErrorIfCiphertextIsModifiedAndBytesAreSkippedAesCbc256() throws IOException {
-        willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesCbcCipherDetails.INSTANCE_256_BIT);
+        willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AES_CBC_256);
     }
 
     public void willErrorIfCiphertextIsModifiedAndBytesAreSkippedAesCtr128() throws IOException {
-        willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesCtrCipherDetails.INSTANCE_128_BIT);
+        willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AES_CTR_128);
     }
 
     public void willErrorIfCiphertextIsModifiedAndBytesAreSkippedAesCtr192() throws IOException {
-        willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesCtrCipherDetails.INSTANCE_192_BIT);
+        willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AES_CTR_192);
     }
 
     public void willErrorIfCiphertextIsModifiedAndBytesAreSkippedAesCtr256() throws IOException {
-        willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesCtrCipherDetails.INSTANCE_256_BIT);
+        willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AES_CTR_256);
     }
 
     public void willErrorIfCiphertextIsModifiedAndBytesAreSkippedAesGcm128() throws IOException {
-        willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesGcmCipherDetails.INSTANCE_128_BIT);
+        willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AES_GCM_128);
     }
 
     public void willErrorIfCiphertextIsModifiedAndBytesAreSkippedAesGcm192() throws IOException {
-        willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesGcmCipherDetails.INSTANCE_192_BIT);
+        willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AES_GCM_192);
     }
 
     public void willErrorIfCiphertextIsModifiedAndBytesAreSkippedAesGcm256() throws IOException {
-        willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesGcmCipherDetails.INSTANCE_256_BIT);
+        willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AES_GCM_256);
     }
 
     public void canReadByteRangeStartingAtZeroEndingInFirstBlockAesCtr128() throws IOException {
-        SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_128_BIT;
+        SupportedCipherDetails cipherDetails = AES_CTR_128;
         int endPos = cipherDetails.getBlockSizeInBytes() / 2;
         canReadByteRangeAllReadModes(cipherDetails, 0, endPos);
     }
 
     public void canReadByteRangeStartingAtZeroEndingInFirstBlockAesCtr192() throws IOException {
-        SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_192_BIT;
+        SupportedCipherDetails cipherDetails = AES_CTR_192;
         int endPos = cipherDetails.getBlockSizeInBytes() / 2;
         canReadByteRangeAllReadModes(cipherDetails, 0, endPos);
     }
 
     public void canReadByteRangeStartingAtZeroEndingInFirstBlockAesCtr256() throws IOException {
-        SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_256_BIT;
+        SupportedCipherDetails cipherDetails = AES_CTR_256;
         int endPos = cipherDetails.getBlockSizeInBytes() / 2;
         canReadByteRangeAllReadModes(cipherDetails, 0, endPos);
     }
 
     public void canReadByteRangeStartingAtZeroEndingInThirdBlockAesCtr128() throws IOException {
-        SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_128_BIT;
+        SupportedCipherDetails cipherDetails = AES_CTR_128;
         int endPos = cipherDetails.getBlockSizeInBytes() * 2 + (cipherDetails.getBlockSizeInBytes() / 2);
         canReadByteRangeAllReadModes(cipherDetails, 0, endPos);
     }
 
     public void canReadByteRangeStartingAtZeroEndingInThirdBlockAesCtr192() throws IOException {
-        SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_192_BIT;
+        SupportedCipherDetails cipherDetails = AES_CTR_192;
         int endPos = cipherDetails.getBlockSizeInBytes() * 2 + (cipherDetails.getBlockSizeInBytes() / 2);
         canReadByteRangeAllReadModes(cipherDetails, 0, endPos);
     }
 
     public void canReadByteRangeStartingAtZeroEndingInThirdBlockAesCtr256() throws IOException {
-        SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_256_BIT;
+        SupportedCipherDetails cipherDetails = AES_CTR_256;
         int endPos = cipherDetails.getBlockSizeInBytes() * 2 + (cipherDetails.getBlockSizeInBytes() / 2);
         canReadByteRangeAllReadModes(cipherDetails, 0, endPos);
     }
 
     public void canReadByteRangeStartingAtThreeEndingInFirstBlockAesCtr128() throws IOException {
-        SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_128_BIT;
+        SupportedCipherDetails cipherDetails = AES_CTR_128;
         int endPos = cipherDetails.getBlockSizeInBytes() / 2;
         canReadByteRangeAllReadModes(cipherDetails, 3, endPos);
     }
 
     public void canReadByteRangeStartingAtThreeEndingInFirstBlockAesCtr192() throws IOException {
-        SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_192_BIT;
+        SupportedCipherDetails cipherDetails = AES_CTR_192;
         int endPos = cipherDetails.getBlockSizeInBytes() / 2;
         canReadByteRangeAllReadModes(cipherDetails, 3, endPos);
     }
 
     public void canReadByteRangeStartingAtThreeEndingInFirstBlockAesCtr256() throws IOException {
-        SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_256_BIT;
+        SupportedCipherDetails cipherDetails = AES_CTR_256;
         int endPos = cipherDetails.getBlockSizeInBytes() / 2;
         canReadByteRangeAllReadModes(cipherDetails, 3, endPos);
     }
 
     public void canReadByteRangeStartingAtThirdBlockEndingInFifthBlockAesCtr128() throws IOException {
-        SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_128_BIT;
+        SupportedCipherDetails cipherDetails = AES_CTR_128;
         int startPos = cipherDetails.getBlockSizeInBytes() * 3 + (cipherDetails.getBlockSizeInBytes() / 2);
         int endPos = cipherDetails.getBlockSizeInBytes() * 5 + (cipherDetails.getBlockSizeInBytes() / 2);
         canReadByteRangeAllReadModes(cipherDetails, startPos, endPos);
     }
 
     public void canReadByteRangeStartingAtThirdBlockEndingInFifthBlockAesCtr192() throws IOException {
-        SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_192_BIT;
+        SupportedCipherDetails cipherDetails = AES_CTR_192;
         int startPos = cipherDetails.getBlockSizeInBytes() * 3 + (cipherDetails.getBlockSizeInBytes() / 2);
         int endPos = cipherDetails.getBlockSizeInBytes() * 5 + (cipherDetails.getBlockSizeInBytes() / 2);
         canReadByteRangeAllReadModes(cipherDetails, startPos, endPos);
     }
 
     public void canReadByteRangeStartingAtThirdBlockEndingInFifthBlockAesCtr256() throws IOException {
-        SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_256_BIT;
+        SupportedCipherDetails cipherDetails = AES_CTR_256;
         int startPos = cipherDetails.getBlockSizeInBytes() * 3 + (cipherDetails.getBlockSizeInBytes() / 2);
         int endPos = cipherDetails.getBlockSizeInBytes() * 5 + (cipherDetails.getBlockSizeInBytes() / 2);
         canReadByteRangeAllReadModes(cipherDetails, startPos, endPos);
     }
 
     public void canReadByteRangeStarting25bytesFromEndToEndAesCtr128() throws IOException {
-        SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_128_BIT;
+        SupportedCipherDetails cipherDetails = AES_CTR_128;
         int endPos = plaintextSize - 1;
         int startPos = endPos - 25;
         canReadByteRangeAllReadModes(cipherDetails, startPos, endPos);
     }
 
     public void canReadByteRangeStarting25bytesFromEndToEndAesCtr192() throws IOException {
-        SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_192_BIT;
+        SupportedCipherDetails cipherDetails = AES_CTR_192;
         int endPos = plaintextSize - 1;
         int startPos = endPos - 25;
         canReadByteRangeAllReadModes(cipherDetails, startPos, endPos);
     }
 
     public void canReadByteRangeStarting25bytesFromEndToEndAesCtr256() throws IOException {
-        SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_256_BIT;
+        SupportedCipherDetails cipherDetails = AES_CTR_256;
         int endPos = plaintextSize - 1;
         int startPos = endPos - 25;
         canReadByteRangeAllReadModes(cipherDetails, startPos, endPos);
     }
 
     public void canReadByteRangeStarting25bytesFromEndToBeyondEndAesCtr128() throws IOException {
-        SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_128_BIT;
+        SupportedCipherDetails cipherDetails = AES_CTR_128;
         int endPos = plaintextSize * 2;
         int startPos = plaintextSize - 26;
         canReadByteRangeAllReadModes(cipherDetails, startPos, endPos);
     }
 
     public void canReadByteRangeStarting25bytesFromEndToBeyondEndAesCtr192() throws IOException {
-        SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_192_BIT;
+        SupportedCipherDetails cipherDetails = AES_CTR_192;
         int endPos = plaintextSize * 2;
         int startPos = plaintextSize - 26;
         canReadByteRangeAllReadModes(cipherDetails, startPos, endPos);
     }
 
     public void canReadByteRangeStarting25bytesFromEndToBeyondEndAesCtr256() throws IOException {
-        SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_256_BIT;
+        SupportedCipherDetails cipherDetails = AES_CTR_256;
         int endPos = plaintextSize * 2;
         int startPos = plaintextSize - 26;
         canReadByteRangeAllReadModes(cipherDetails, startPos, endPos);
@@ -450,60 +493,60 @@ public class MantaEncryptedObjectInputStreamTest {
 
 
     public void canCopyStreamWithLargeBufferBufferAuthenticatedAesCbc128() throws IOException {
-         canCopyToOutputStreamWithLargeBuffer(AesCbcCipherDetails.INSTANCE_128_BIT, true);
+         canCopyToOutputStreamWithLargeBuffer(AES_CBC_128, true);
     }
 
     public void canCopyStreamWithLargeBufferBufferAuthenticatedAesCbc192() throws IOException {
-         canCopyToOutputStreamWithLargeBuffer(AesCbcCipherDetails.INSTANCE_192_BIT, true);
+         canCopyToOutputStreamWithLargeBuffer(AES_CBC_192, true);
     }
 
     public void canCopyStreamWithLargeBufferBufferAuthenticatedAesCbc256() throws IOException {
-         canCopyToOutputStreamWithLargeBuffer(AesCbcCipherDetails.INSTANCE_256_BIT, true);
+         canCopyToOutputStreamWithLargeBuffer(AES_CBC_256, true);
     }
 
     public void canCopyStreamWithLargeBufferBufferAuthenticatedAesCtr128() throws IOException {
-         canCopyToOutputStreamWithLargeBuffer(AesCtrCipherDetails.INSTANCE_128_BIT, true);
+         canCopyToOutputStreamWithLargeBuffer(AES_CTR_128, true);
     }
 
     public void canCopyStreamWithLargeBufferBufferAuthenticatedAesCtr192() throws IOException {
-         canCopyToOutputStreamWithLargeBuffer(AesCtrCipherDetails.INSTANCE_192_BIT, true);
+         canCopyToOutputStreamWithLargeBuffer(AES_CTR_192, true);
     }
 
     public void canCopyStreamWithLargeBufferBufferAuthenticatedAesCtr256() throws IOException {
-         canCopyToOutputStreamWithLargeBuffer(AesCtrCipherDetails.INSTANCE_256_BIT, true);
+         canCopyToOutputStreamWithLargeBuffer(AES_CTR_256, true);
     }
 
     public void canCopyStreamWithLargeBufferBufferAuthenticatedAesGcm128() throws IOException {
-         canCopyToOutputStreamWithLargeBuffer(AesGcmCipherDetails.INSTANCE_128_BIT, true);
+         canCopyToOutputStreamWithLargeBuffer(AES_GCM_128, true);
     }
 
     public void canCopyStreamWithLargeBufferBufferAuthenticatedAesGcm192() throws IOException {
-         canCopyToOutputStreamWithLargeBuffer(AesGcmCipherDetails.INSTANCE_192_BIT, true);
+         canCopyToOutputStreamWithLargeBuffer(AES_GCM_192, true);
     }
 
 
     public void canCopyStreamWithLargeBufferBufferUnauthenticatedAesCbc128() throws IOException {
-        canCopyToOutputStreamWithLargeBuffer(AesCbcCipherDetails.INSTANCE_128_BIT, false);
+        canCopyToOutputStreamWithLargeBuffer(AES_CBC_128, false);
     }
 
     public void canCopyStreamWithLargeBufferBufferUnauthenticatedAesCbc192() throws IOException {
-        canCopyToOutputStreamWithLargeBuffer(AesCbcCipherDetails.INSTANCE_192_BIT, false);
+        canCopyToOutputStreamWithLargeBuffer(AES_CBC_192, false);
     }
 
     public void canCopyStreamWithLargeBufferBufferUnauthenticatedAesCbc256() throws IOException {
-        canCopyToOutputStreamWithLargeBuffer(AesCbcCipherDetails.INSTANCE_256_BIT, false);
+        canCopyToOutputStreamWithLargeBuffer(AES_CBC_256, false);
     }
 
     public void canCopyStreamWithLargeBufferBufferUnauthenticatedAesCtr128() throws IOException {
-        canCopyToOutputStreamWithLargeBuffer(AesCtrCipherDetails.INSTANCE_128_BIT, false);
+        canCopyToOutputStreamWithLargeBuffer(AES_CTR_128, false);
     }
 
     public void canCopyStreamWithLargeBufferBufferUnauthenticatedAesCtr192() throws IOException {
-        canCopyToOutputStreamWithLargeBuffer(AesCtrCipherDetails.INSTANCE_192_BIT, false);
+        canCopyToOutputStreamWithLargeBuffer(AES_CTR_192, false);
     }
 
     public void canCopyStreamWithLargeBufferBufferUnauthenticatedAesCtr256() throws IOException {
-        canCopyToOutputStreamWithLargeBuffer(AesCtrCipherDetails.INSTANCE_256_BIT, false);
+        canCopyToOutputStreamWithLargeBuffer(AES_CTR_256, false);
     }
 
 

--- a/java-manta-client/src/test/java/com/joyent/manta/client/crypto/SecretKeyUtilsTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/crypto/SecretKeyUtilsTest.java
@@ -9,15 +9,18 @@ package com.joyent.manta.client.crypto;
 
 import org.apache.commons.io.FileUtils;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import javax.crypto.SecretKey;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 
 @Test
@@ -28,37 +31,51 @@ public class SecretKeyUtilsTest {
         keyBytes = "FFFFFFFBD96783C6C91E2222".getBytes(StandardCharsets.US_ASCII);
     }
 
+    private AesCbcCipherDetails AES_CBC_128;
+
+    private AesCtrCipherDetails AES_CTR_128;
+
+    private AesGcmCipherDetails AES_GCM_128;
+
+    @BeforeClass
+    private void init() throws NoSuchAlgorithmException {
+
+        AES_CBC_128 = AesCbcCipherDetails.aesCbc128();
+        AES_CTR_128 = AesCtrCipherDetails.aesCtr128();
+        AES_GCM_128 = AesGcmCipherDetails.aesGcm128();
+    }
+
     public void canGenerateAesGcmNoPaddingKey() {
-        SecretKey key = SecretKeyUtils.generate(AesGcmCipherDetails.INSTANCE_128_BIT);
+        SecretKey key = SecretKeyUtils.generate(AES_GCM_128);
         Assert.assertNotNull(key, "Generated key was null");
 
         byte[] bytes = key.getEncoded();
 
-        SecretKey loaded = SecretKeyUtils.loadKey(bytes, AesGcmCipherDetails.INSTANCE_128_BIT);
+        SecretKey loaded = SecretKeyUtils.loadKey(bytes, AES_GCM_128);
 
         Assert.assertEquals(loaded, key,
                 "Generated key doesn't match loaded key");
     }
 
     public void canGenerateAesCtrNoPaddingKey() {
-        SecretKey key = SecretKeyUtils.generate(AesCtrCipherDetails.INSTANCE_128_BIT);
+        SecretKey key = SecretKeyUtils.generate(AES_CTR_128);
         Assert.assertNotNull(key, "Generated key was null");
 
         byte[] bytes = key.getEncoded();
 
-        SecretKey loaded = SecretKeyUtils.loadKey(bytes, AesCtrCipherDetails.INSTANCE_128_BIT);
+        SecretKey loaded = SecretKeyUtils.loadKey(bytes, AES_CTR_128);
 
         Assert.assertEquals(loaded, key,
                 "Generated key doesn't match loaded key");
     }
 
     public void canGenerateAesCbcPkcs5PaddingKey() {
-        SecretKey key = SecretKeyUtils.generate(AesCbcCipherDetails.INSTANCE_128_BIT);
+        SecretKey key = SecretKeyUtils.generate(AES_CBC_128);
         Assert.assertNotNull(key, "Generated key was null");
 
         byte[] bytes = key.getEncoded();
 
-        SecretKey loaded = SecretKeyUtils.loadKey(bytes, AesCbcCipherDetails.INSTANCE_128_BIT);
+        SecretKey loaded = SecretKeyUtils.loadKey(bytes, AES_CBC_128);
 
         Assert.assertEquals(loaded, key,
                 "Generated key doesn't match loaded key");
@@ -70,8 +87,8 @@ public class SecretKeyUtilsTest {
         FileUtils.writeByteArrayToFile(file, keyBytes);
         URI uri = URI.create("file://" + file.getAbsolutePath());
 
-        SecretKey expected = SecretKeyUtils.loadKey(keyBytes, AesGcmCipherDetails.INSTANCE_128_BIT);
-        SecretKey actual = SecretKeyUtils.loadKeyFromPath(Paths.get(uri), AesGcmCipherDetails.INSTANCE_128_BIT);
+        SecretKey expected = SecretKeyUtils.loadKey(keyBytes, AES_GCM_128);
+        SecretKey actual = SecretKeyUtils.loadKeyFromPath(Paths.get(uri), AES_GCM_128);
 
         Assert.assertEquals(actual.getAlgorithm(), expected.getAlgorithm());
         Assert.assertTrue(Arrays.equals(expected.getEncoded(), actual.getEncoded()),
@@ -84,8 +101,8 @@ public class SecretKeyUtilsTest {
         FileUtils.writeByteArrayToFile(file, keyBytes);
         Path path = file.toPath();
 
-        SecretKey expected = SecretKeyUtils.loadKey(keyBytes, AesGcmCipherDetails.INSTANCE_128_BIT);
-        SecretKey actual = SecretKeyUtils.loadKeyFromPath(path, AesGcmCipherDetails.INSTANCE_128_BIT);
+        SecretKey expected = SecretKeyUtils.loadKey(keyBytes, AES_GCM_128);
+        SecretKey actual = SecretKeyUtils.loadKeyFromPath(path, AES_GCM_128);
 
         Assert.assertEquals(actual.getAlgorithm(), expected.getAlgorithm());
         Assert.assertTrue(Arrays.equals(expected.getEncoded(), actual.getEncoded()),
@@ -99,7 +116,7 @@ public class SecretKeyUtilsTest {
 
     @Test(expectedExceptions = Exception.class)
     public void writeKeyWithNullOutStream() throws IOException {
-        SupportedCipherDetails cipherDetails = AesGcmCipherDetails.INSTANCE_128_BIT;
+        SupportedCipherDetails cipherDetails = AES_GCM_128;
         byte[] keyBytes = SecretKeyUtils.generate(cipherDetails).getEncoded();
 
         SecretKey key = SecretKeyUtils.loadKey(Arrays.copyOfRange(keyBytes, 2, 10), cipherDetails);
@@ -116,7 +133,7 @@ public class SecretKeyUtilsTest {
         FileUtils.forceDeleteOnExit(file);
         Path path = file.toPath();
 
-        SupportedCipherDetails cipherDetails = AesGcmCipherDetails.INSTANCE_128_BIT;
+        SupportedCipherDetails cipherDetails = AES_GCM_128;
         byte[] keyBytes = SecretKeyUtils.generate(cipherDetails).getEncoded();
         SecretKey key = SecretKeyUtils.loadKey(keyBytes, cipherDetails);
         SecretKeyUtils.writeKeyToPath(key, path);

--- a/java-manta-client/src/test/java/com/joyent/manta/client/multipart/EncryptedMultipartManagerTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/multipart/EncryptedMultipartManagerTest.java
@@ -13,6 +13,7 @@ import com.joyent.manta.client.MantaMetadata;
 import com.joyent.manta.client.MantaObjectInputStream;
 import com.joyent.manta.client.MantaObjectMapper;
 import com.joyent.manta.client.MantaObjectResponse;
+import com.joyent.manta.client.crypto.AbstractAesCipherDetails;
 import com.joyent.manta.client.crypto.AesCtrCipherDetails;
 import com.joyent.manta.client.crypto.EncryptionContext;
 import com.joyent.manta.client.crypto.MantaEncryptedObjectInputStream;
@@ -28,6 +29,7 @@ import com.joyent.manta.http.EncryptionHttpHelper;
 import com.joyent.manta.http.MantaConnectionContext;
 import com.joyent.manta.http.MantaConnectionFactory;
 import com.joyent.manta.http.MantaHttpHeaders;
+
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -41,6 +43,7 @@ import org.testng.annotations.Test;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
+
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -56,7 +59,7 @@ import static org.mockito.Mockito.mock;
 
 @Test
 public class EncryptedMultipartManagerTest {
-    private SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_128_BIT;
+    private SupportedCipherDetails cipherDetails = AbstractAesCipherDetails.DEFAULT_CIPHER_AES;
     private SecretKey secretKey = SecretKeyUtils.loadKey(
             Base64.getDecoder().decode("qAnCNUmmFjUTtImNGv241Q=="), cipherDetails);
 

--- a/java-manta-client/src/test/java/com/joyent/manta/config/ConfigContextTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/config/ConfigContextTest.java
@@ -71,7 +71,7 @@ public class ConfigContextTest {
         config.setClientEncryptionEnabled(false);
     }
 
-    public void canValidateContextWithKeyPaths() throws IOException {
+    public void canValidateContextWithKeyPaths() throws Exception {
         File mantaAuthPrivateKey = File.createTempFile("manta-key", "");
         FileUtils.forceDeleteOnExit(mantaAuthPrivateKey);
         FileUtils.write(mantaAuthPrivateKey, MANTA_AUTH_PRIVATE_KEY, StandardCharsets.US_ASCII);
@@ -90,11 +90,11 @@ public class ConfigContextTest {
         config.setEncryptionAuthenticationMode(EncryptionAuthenticationMode.DEFAULT_MODE);
         config.setPermitUnencryptedDownloads(false);
         config.setEncryptionPrivateKeyPath(encryptionPrivateKey.getAbsolutePath());
-        config.setEncryptionAlgorithm(AesGcmCipherDetails.INSTANCE_128_BIT.getCipherId());
+        config.setEncryptionAlgorithm(AesGcmCipherDetails.aesGcm128().getCipherId());
         ConfigContext.validate(config);
     }
 
-    public void canValidateContextWithKeyValues() throws IOException {
+    public void canValidateContextWithKeyValues() throws Exception {
         StandardConfigContext config = new StandardConfigContext();
         config.setMantaURL(DefaultsConfigContext.DEFAULT_MANTA_URL);
         config.setMantaUser("username");
@@ -105,7 +105,7 @@ public class ConfigContextTest {
         config.setEncryptionAuthenticationMode(EncryptionAuthenticationMode.DEFAULT_MODE);
         config.setPermitUnencryptedDownloads(false);
         config.setEncryptionPrivateKeyBytes(keyBytes);
-        config.setEncryptionAlgorithm(AesGcmCipherDetails.INSTANCE_128_BIT.getCipherId());
+        config.setEncryptionAlgorithm(AesGcmCipherDetails.aesGcm128().getCipherId());
         ConfigContext.validate(config);
     }
 }

--- a/java-manta-client/src/test/java/com/joyent/manta/http/EncryptedHttpHelperTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/http/EncryptedHttpHelperTest.java
@@ -95,7 +95,7 @@ public class EncryptedHttpHelperTest {
         MantaConnectionFactory connectionFactory = mock(MantaConnectionFactory.class);
         StandardConfigContext config = new StandardConfigContext();
 
-        SupportedCipherDetails cipherDetails = AesCbcCipherDetails.INSTANCE_192_BIT;
+        SupportedCipherDetails cipherDetails = AesCbcCipherDetails.aesCbc192();
 
         config.setClientEncryptionEnabled(true)
                 .setEncryptionPrivateKeyBytes(SecretKeyUtils.generate(cipherDetails).getEncoded())
@@ -115,7 +115,7 @@ public class EncryptedHttpHelperTest {
 
 
         SupportedCipherDetails objectCipherDetails =
-                AesGcmCipherDetails.INSTANCE_128_BIT;
+                AesGcmCipherDetails.aesGcm128();
 
         Header[] headers = new Header[] {
                 // Notice this is a different cipher than the one set in config


### PR DESCRIPTION
This pull request moves jvm [jce policy](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html) errors earlier into the execution path, and gives a user friendly error message when a requested cipher details object exceeds the maximum policy key length.

It's possible to move the error even further in the execution path, to load or compile time, although the example preserves compatibility across jvms with and without an unlimited strength jce policy.

As such, please note this alters the public `SupportedCipherDetails` objects to be instantiated at execution time rather than load or compile time, which may alter part of the api people may already depend on.

Comments are very welcome.