### PR TITLE
#242 jce size check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ were affected, not the content.
    path.
  - Recursive directory creation will no longer
    [encode the path twice](https://github.com/joyent/java-manta/issues/231).
+ - Gracefully handle missing JCE Unlimited Strength Policy by [only enabling stronger ciphers when
+   they are allowed by the runtime](https://github.com/joyent/java-manta/issues/242).
+   Installing the Unlimited Policy files where necessary is still strongly recommended.
 
 ## [3.0.0] - 2017-04-06
 ### Changed

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ If you prefer to build from source, you'll also need
 Which will compile the jar to ./targets/java-manta-version.jar. You can then
 add it as a dependency to your Java project.
 
+If you want to skip running of the test suite, use the `-DskipTests` property.
+
 ## Configuration
 
 Configuration parameters take precedence from left to right - values on the
@@ -157,8 +159,6 @@ ConfigContext customConfig = new StandardConfigContext()
     .setMantaUser("test-user");
 ConfigContext config = new ChainedConfigContext(defaultConfig, customConfig);
 ```
-
-If you want to skip running of the test suite, use the `-DskipTests` property.
 
 ## Accounts, Usernames and Subusers
 Joyent's SmartDataCenter account implementation is such that you can have a

--- a/README.md
+++ b/README.md
@@ -440,6 +440,12 @@ service.  In order to run the test suite, you will need to specify environment
 variables, system properties or TestNG parameters to tell the library how to
 authenticate against Manta.
 
+While the Java Cryptography Extensions are expected to be installed, it is possible to
+run a subset of the test suite by adding `-DexcludedGroups=unlimited-crypto`, e.g.:
+```
+mvn test -DexcludedGroups=unlimited-crypto
+```
+
 ### Releasing
 
 Please refer to the [release documentation](RELEASING.md).

--- a/java-manta-client-kryo-serialization/src/test/java/com/joyent/manta/serialization/CipherSerializerTest.java
+++ b/java-manta-client-kryo-serialization/src/test/java/com/joyent/manta/serialization/CipherSerializerTest.java
@@ -50,12 +50,12 @@ public class CipherSerializerTest {
         canSerializeCipher(AesGcmCipherDetails.INSTANCE_128_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canSerializeAesGcm192() throws Exception {
         canSerializeCipher(AesGcmCipherDetails.INSTANCE_192_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canSerializeAesGcm256() throws Exception {
         canSerializeCipher(AesGcmCipherDetails.INSTANCE_256_BIT);
     }
@@ -64,12 +64,12 @@ public class CipherSerializerTest {
         canSerializeCipher(AesCtrCipherDetails.INSTANCE_128_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canSerializeAesCtr192() throws Exception {
         canSerializeCipher(AesCtrCipherDetails.INSTANCE_192_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canSerializeAesCtr256() throws Exception {
         canSerializeCipher(AesCtrCipherDetails.INSTANCE_256_BIT);
     }
@@ -78,12 +78,12 @@ public class CipherSerializerTest {
         canSerializeCipher(AesCbcCipherDetails.INSTANCE_128_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canSerializeAesCbc192() throws Exception {
         canSerializeCipher(AesCbcCipherDetails.INSTANCE_192_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canSerializeAesCbc256() throws Exception {
         canSerializeCipher(AesCbcCipherDetails.INSTANCE_256_BIT);
     }

--- a/java-manta-client-kryo-serialization/src/test/java/com/joyent/manta/serialization/CipherSerializerTest.java
+++ b/java-manta-client-kryo-serialization/src/test/java/com/joyent/manta/serialization/CipherSerializerTest.java
@@ -50,10 +50,12 @@ public class CipherSerializerTest {
         canSerializeCipher(AesGcmCipherDetails.INSTANCE_128_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canSerializeAesGcm192() throws Exception {
         canSerializeCipher(AesGcmCipherDetails.INSTANCE_192_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canSerializeAesGcm256() throws Exception {
         canSerializeCipher(AesGcmCipherDetails.INSTANCE_256_BIT);
     }
@@ -62,10 +64,12 @@ public class CipherSerializerTest {
         canSerializeCipher(AesCtrCipherDetails.INSTANCE_128_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canSerializeAesCtr192() throws Exception {
         canSerializeCipher(AesCtrCipherDetails.INSTANCE_192_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canSerializeAesCtr256() throws Exception {
         canSerializeCipher(AesCtrCipherDetails.INSTANCE_256_BIT);
     }
@@ -74,10 +78,12 @@ public class CipherSerializerTest {
         canSerializeCipher(AesCbcCipherDetails.INSTANCE_128_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canSerializeAesCbc192() throws Exception {
         canSerializeCipher(AesCbcCipherDetails.INSTANCE_192_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canSerializeAesCbc256() throws Exception {
         canSerializeCipher(AesCbcCipherDetails.INSTANCE_256_BIT);
     }

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AbstractAesCipherDetails.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AbstractAesCipherDetails.java
@@ -7,7 +7,6 @@
  */
 package com.joyent.manta.client.crypto;
 
-import com.joyent.manta.exception.MantaClientException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -40,11 +39,6 @@ public abstract class AbstractAesCipherDetails implements SupportedCipherDetails
      * Default HMAC algorithm to use for AES ciphers.
      */
     protected static final String DEFAULT_HMAC_ALGORITHM = "HmacMD5";
-
-    /**
-     * Default maximum key length.
-     */
-    private static final int DEFAULT_MAX_KEY_LENGTH = 128;
 
     /**
      * HMAC algorithm identifier.
@@ -99,8 +93,6 @@ public abstract class AbstractAesCipherDetails implements SupportedCipherDetails
     public AbstractAesCipherDetails(final int keyLengthBits,
                                     final String cipherAlgorithmJavaName,
                                     final int authenticationTagLength) {
-        ensureKeyStrengthAllowed(keyLengthBits);
-
         this.keyLengthBits = keyLengthBits;
         this.cipherAlgorithmJavaName = cipherAlgorithmJavaName;
         this.cipherId = createMantaCipherIdFromJavaAlgorithmId(
@@ -121,7 +113,6 @@ public abstract class AbstractAesCipherDetails implements SupportedCipherDetails
     public AbstractAesCipherDetails(final int keyLengthBits,
                                     final String cipherAlgorithmJavaName,
                                     final String hmacAlgorithm) {
-        ensureKeyStrengthAllowed(keyLengthBits);
 
         this.keyLengthBits = keyLengthBits;
         this.cipherAlgorithmJavaName = cipherAlgorithmJavaName;
@@ -315,28 +306,5 @@ public abstract class AbstractAesCipherDetails implements SupportedCipherDetails
             // so we go with the default value
             return new SecureRandom();
         }
-    }
-
-    /**
-     *
-     * @param requestedKeyLengthBits size of the secret key
-     */
-    private void ensureKeyStrengthAllowed(final int requestedKeyLengthBits) {
-        int maxKeyLength;
-
-        try {
-            maxKeyLength = Cipher.getMaxAllowedKeyLength("AES");
-            // will return DEFAULT_MAX_KEY_LENGTH if JCE missing, catch is for the compiler
-        } catch (NoSuchAlgorithmException nsae) {
-            maxKeyLength = DEFAULT_MAX_KEY_LENGTH;
-        }
-
-        if (requestedKeyLengthBits <= maxKeyLength) {
-            return;
-        }
-
-        final String msg = "requested cipher key length greater than maximum allowed [jce policy] "
-                + "(keyLengthBits=" + requestedKeyLengthBits + ", maxKeyLength=" + maxKeyLength + ")";
-        throw new MantaClientException(msg);
     }
 }

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AbstractAesCipherDetails.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AbstractAesCipherDetails.java
@@ -102,7 +102,6 @@ public abstract class AbstractAesCipherDetails implements SupportedCipherDetails
         this.isAEADCipher = true;
     }
 
-
     /**
      * Creates a new instance for a cipher authenticated by a HMAC.
      *
@@ -113,7 +112,6 @@ public abstract class AbstractAesCipherDetails implements SupportedCipherDetails
     public AbstractAesCipherDetails(final int keyLengthBits,
                                     final String cipherAlgorithmJavaName,
                                     final String hmacAlgorithm) {
-
         this.keyLengthBits = keyLengthBits;
         this.cipherAlgorithmJavaName = cipherAlgorithmJavaName;
         this.cipherId = createMantaCipherIdFromJavaAlgorithmId(

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCbcCipherDetails.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCbcCipherDetails.java
@@ -39,7 +39,7 @@ public final class AesCbcCipherDetails extends AbstractAesCipherDetails {
      *
      * @param keyLengthBits size of the private key - which determines the AES algorithm type
      */
-    private AesCbcCipherDetails(final int keyLengthBits) {
+    protected AesCbcCipherDetails(final int keyLengthBits) {
         super(keyLengthBits, "AES/CBC/PKCS5Padding", DEFAULT_HMAC_ALGORITHM);
     }
 

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCbcCipherDetails.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCbcCipherDetails.java
@@ -7,6 +7,7 @@
  */
 package com.joyent.manta.client.crypto;
 
+import com.joyent.manta.client.crypto.AesCipherDetailsFactory.CipherMode;
 import org.apache.commons.lang3.Validate;
 
 import javax.crypto.Cipher;
@@ -22,17 +23,20 @@ public final class AesCbcCipherDetails extends AbstractAesCipherDetails {
     /**
      * Instance of AES128-CBC cipher.
      */
-    public static final AesCbcCipherDetails INSTANCE_128_BIT = new AesCbcCipherDetails(128);
+    public static final SupportedCipherDetails INSTANCE_128_BIT =
+            AesCipherDetailsFactory.buildWith(CipherMode.CBC, 128);
 
     /**
      * Instance of AES192-CBC cipher.
      */
-    public static final AesCbcCipherDetails INSTANCE_192_BIT = new AesCbcCipherDetails(192);
+    public static final SupportedCipherDetails INSTANCE_192_BIT =
+            AesCipherDetailsFactory.buildWith(CipherMode.CBC, 192);
 
     /**
      * Instance of AES256-CBC cipher.
      */
-    public static final AesCbcCipherDetails INSTANCE_256_BIT = new AesCbcCipherDetails(256);
+    public static final SupportedCipherDetails INSTANCE_256_BIT =
+            AesCipherDetailsFactory.buildWith(CipherMode.CBC, 256);
 
     /**
      * Creates a new instance of a AES-CBC cipher for the static instance.

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCipherDetailsFactory.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCipherDetailsFactory.java
@@ -14,7 +14,6 @@ import java.security.NoSuchAlgorithmException;
  * Class for constructing AesCipherDetails which may or may not be useable in the current runtime.
  *
  * @author <a href="https://github.com/tjcelaya">Tomas Celayac</a>
- * @since 3.0.0
  */
 public final class AesCipherDetailsFactory {
 
@@ -64,8 +63,6 @@ public final class AesCipherDetailsFactory {
      *
      * @param mode cipher mode
      * @param requestedKeyLengthBits secret key length in bits
-     *
-     * @return static
      */
     static SupportedCipherDetails buildWith(final CipherMode mode, final int requestedKeyLengthBits) {
 

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCipherDetailsFactory.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCipherDetailsFactory.java
@@ -36,7 +36,7 @@ public final class AesCipherDetailsFactory {
     /**
      * Maximum AES key length when Java Cryptography Extensions are missing.
      */
-    private static final int MAX_KEY_LENGTH_FALLBACK = 128;
+    static final int MAX_KEY_LENGTH_FALLBACK = 128;
 
     /**
      * Maximum key length allowed by current runtime.

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCipherDetailsFactory.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCipherDetailsFactory.java
@@ -58,6 +58,10 @@ public final class AesCipherDetailsFactory {
     }
 
     /**
+     * Builds a concrete subclass of AbstractAesCipherDetails, or a LocallyIllegalAesCipherDetails when the current
+     * runtime lacks the required <a href="https://en.wikipedia.org/wiki/Java_Cryptography_Extension">Java Cryptography
+     * Extensions</a>.
+     *
      * @param mode cipher mode
      * @param requestedKeyLengthBits secret key length in bits
      *

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCipherDetailsFactory.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCipherDetailsFactory.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.manta.client.crypto;
+
+import javax.crypto.Cipher;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Class for constructing AesCipherDetails which may or may not be useable in the current runtime.
+ *
+ * @author <a href="https://github.com/tjcelaya">Tomas Celayac</a>
+ * @since 3.0.0
+ */
+public final class AesCipherDetailsFactory {
+
+    /**
+     * Private constructor.
+     */
+    private AesCipherDetailsFactory() {
+    }
+
+    /**
+     * Supported AES Cipher modes.
+     */
+    @SuppressWarnings("checkstyle:JavadocVariable")
+    public enum CipherMode {
+        CBC,
+        CTR,
+        GCM
+    }
+
+    /**
+     * Default maximum key length.
+     */
+    static final int DEFAULT_MAX_KEY_LENGTH = 128;
+
+    /**
+     * @param mode cipher mode
+     * @param requestedKeyLengthBits secret key length in bits
+     *
+     * @return static
+     */
+    static SupportedCipherDetails buildWith(final CipherMode mode, final int requestedKeyLengthBits) {
+
+        if (!keyStrengthAllowedByRuntime(requestedKeyLengthBits)) {
+            return new LocallyIllegalAesCipherDetails(requestedKeyLengthBits);
+        }
+
+        switch (mode) {
+            case CBC:
+                return new AesCbcCipherDetails(requestedKeyLengthBits);
+            case CTR:
+                return new AesCtrCipherDetails(requestedKeyLengthBits);
+            case GCM:
+                return new AesGcmCipherDetails(requestedKeyLengthBits);
+            default:
+                throw new Error("Invalid CipherMode provided when building AesCipherDetails: " + mode.toString());
+        }
+    }
+
+    /**
+     * Check if the requested key strength is permissible within the current runtime.
+     *
+     * @param requestedKeyLengthBits size of the secret key
+     *
+     * @return runtime legality of key length
+     */
+    private static boolean keyStrengthAllowedByRuntime(final int requestedKeyLengthBits) {
+        int maxKeyLength;
+
+        try {
+            // TODO: potentially reuse {@code cipherAlgorithmJavaName} here?
+            maxKeyLength = Cipher.getMaxAllowedKeyLength("AES");
+            // will return DEFAULT_MAX_KEY_LENGTH if JCE missing, catch is for the compiler
+        } catch (NoSuchAlgorithmException nsae) {
+            maxKeyLength = DEFAULT_MAX_KEY_LENGTH;
+        }
+
+        return requestedKeyLengthBits <= maxKeyLength;
+    }
+}

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCipherDetailsFactory.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCipherDetailsFactory.java
@@ -37,7 +37,25 @@ public final class AesCipherDetailsFactory {
     /**
      * Default maximum key length.
      */
-    static final int DEFAULT_MAX_KEY_LENGTH = 128;
+    private static final int MAX_KEY_LENGTH_DEFAULT = 128;
+
+    /**
+     * Maximum key length allowed by current runtime.
+     */
+    static final int MAX_KEY_LENGTH_ALLOWED;
+
+    static {
+        int maxKeyLength;
+
+        try {
+            maxKeyLength = Cipher.getMaxAllowedKeyLength("AES");
+            // will return MAX_KEY_LENGTH_DEFAULT if JCE missing, catch is for the compiler
+        } catch (NoSuchAlgorithmException nsae) {
+            maxKeyLength = MAX_KEY_LENGTH_DEFAULT;
+        }
+
+        MAX_KEY_LENGTH_ALLOWED = maxKeyLength;
+    }
 
     /**
      * @param mode cipher mode
@@ -71,16 +89,6 @@ public final class AesCipherDetailsFactory {
      * @return runtime legality of key length
      */
     private static boolean keyStrengthAllowedByRuntime(final int requestedKeyLengthBits) {
-        int maxKeyLength;
-
-        try {
-            // TODO: potentially reuse {@code cipherAlgorithmJavaName} here?
-            maxKeyLength = Cipher.getMaxAllowedKeyLength("AES");
-            // will return DEFAULT_MAX_KEY_LENGTH if JCE missing, catch is for the compiler
-        } catch (NoSuchAlgorithmException nsae) {
-            maxKeyLength = DEFAULT_MAX_KEY_LENGTH;
-        }
-
-        return requestedKeyLengthBits <= maxKeyLength;
+        return requestedKeyLengthBits <= MAX_KEY_LENGTH_ALLOWED;
     }
 }

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCipherDetailsFactory.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCipherDetailsFactory.java
@@ -34,9 +34,9 @@ public final class AesCipherDetailsFactory {
     }
 
     /**
-     * Default maximum key length.
+     * Maximum AES key length when Java Cryptography Extensions are missing.
      */
-    private static final int MAX_KEY_LENGTH_DEFAULT = 128;
+    private static final int MAX_KEY_LENGTH_FALLBACK = 128;
 
     /**
      * Maximum key length allowed by current runtime.
@@ -48,9 +48,9 @@ public final class AesCipherDetailsFactory {
 
         try {
             maxKeyLength = Cipher.getMaxAllowedKeyLength("AES");
-            // will return MAX_KEY_LENGTH_DEFAULT if JCE missing, catch is for the compiler
+            // will return MAX_KEY_LENGTH_FALLBACK if JCE missing, catch is for the compiler
         } catch (NoSuchAlgorithmException nsae) {
-            maxKeyLength = MAX_KEY_LENGTH_DEFAULT;
+            maxKeyLength = MAX_KEY_LENGTH_FALLBACK;
         }
 
         MAX_KEY_LENGTH_ALLOWED = maxKeyLength;

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCtrCipherDetails.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCtrCipherDetails.java
@@ -7,6 +7,7 @@
  */
 package com.joyent.manta.client.crypto;
 
+import com.joyent.manta.client.crypto.AesCipherDetailsFactory.CipherMode;
 import org.apache.commons.lang3.Validate;
 
 import javax.crypto.Cipher;
@@ -22,17 +23,20 @@ public final class AesCtrCipherDetails extends AbstractAesCipherDetails {
     /**
      * Instance of AES128-CTR cipher.
      */
-    public static final AesCtrCipherDetails INSTANCE_128_BIT = new AesCtrCipherDetails(128);
+    public static final SupportedCipherDetails INSTANCE_128_BIT =
+            AesCipherDetailsFactory.buildWith(CipherMode.CTR, 128);
 
     /**
      * Instance of AES192-CTR cipher.
      */
-    public static final AesCtrCipherDetails INSTANCE_192_BIT = new AesCtrCipherDetails(192);
+    public static final SupportedCipherDetails INSTANCE_192_BIT =
+            AesCipherDetailsFactory.buildWith(CipherMode.CTR, 192);
 
     /**
      * Instance of AES256-CTR cipher.
      */
-    public static final AesCtrCipherDetails INSTANCE_256_BIT = new AesCtrCipherDetails(256);
+    public static final SupportedCipherDetails INSTANCE_256_BIT =
+            AesCipherDetailsFactory.buildWith(CipherMode.CTR, 256);
 
     /**
      * Creates a new instance of a AES-CTR cipher for the static instance.

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCtrCipherDetails.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesCtrCipherDetails.java
@@ -39,7 +39,7 @@ public final class AesCtrCipherDetails extends AbstractAesCipherDetails {
      *
      * @param keyLengthBits size of the private key - which determines the AES algorithm type
      */
-    private AesCtrCipherDetails(final int keyLengthBits) {
+    protected AesCtrCipherDetails(final int keyLengthBits) {
         super(keyLengthBits, "AES/CTR/NoPadding", DEFAULT_HMAC_ALGORITHM);
     }
 

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesGcmCipherDetails.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesGcmCipherDetails.java
@@ -52,7 +52,7 @@ public final class AesGcmCipherDetails  extends AbstractAesCipherDetails {
      *
      * @param keyLengthBits size of the private key - which determines the AES algorithm type
      */
-    private AesGcmCipherDetails(final int keyLengthBits) {
+    protected AesGcmCipherDetails(final int keyLengthBits) {
         // Use 128-bit AEAD tag
         super(keyLengthBits, "AES/GCM/NoPadding", 16);
     }

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesGcmCipherDetails.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/AesGcmCipherDetails.java
@@ -7,6 +7,7 @@
  */
 package com.joyent.manta.client.crypto;
 
+import com.joyent.manta.client.crypto.AesCipherDetailsFactory.CipherMode;
 import org.apache.commons.lang3.Validate;
 
 import javax.crypto.Cipher;
@@ -35,17 +36,20 @@ public final class AesGcmCipherDetails  extends AbstractAesCipherDetails {
     /**
      * Instance of AES128-GCM cipher.
      */
-    public static final AesGcmCipherDetails INSTANCE_128_BIT = new AesGcmCipherDetails(128);
+    public static final SupportedCipherDetails INSTANCE_128_BIT =
+            AesCipherDetailsFactory.buildWith(CipherMode.GCM, 128);
 
     /**
      * Instance of AES192-GCM cipher.
      */
-    public static final AesGcmCipherDetails INSTANCE_192_BIT = new AesGcmCipherDetails(192);
+    public static final SupportedCipherDetails INSTANCE_192_BIT =
+            AesCipherDetailsFactory.buildWith(CipherMode.GCM, 192);
 
     /**
      * Instance of AES256-GCM cipher.
      */
-    public static final AesGcmCipherDetails INSTANCE_256_BIT = new AesGcmCipherDetails(256);
+    public static final SupportedCipherDetails INSTANCE_256_BIT =
+            AesCipherDetailsFactory.buildWith(CipherMode.GCM, 256);
 
     /**
      * Creates a new instance of a AES-GCM cipher for the static instance.

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/LocallyIllegalAesCipherDetails.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/LocallyIllegalAesCipherDetails.java
@@ -16,7 +16,6 @@ import java.security.spec.AlgorithmParameterSpec;
  * Implementation of an AESCipherDetails that MUST NOT be used within the current runtime.
  *
  * @author <a href="https://github.com/tjcelaya">Tomas Celayac</a>
- * @since 3.0.0
  */
 public class LocallyIllegalAesCipherDetails implements SupportedCipherDetails {
 
@@ -35,7 +34,9 @@ public class LocallyIllegalAesCipherDetails implements SupportedCipherDetails {
     }
 
     /**
-     * Fail immediately, we don't belong on this JVM.
+     * Fail immediately, we don't belong on this JVM. We throw an Error instead of an Exception because it is unlikely
+     * the runtime could recover from a missing extension. Additionally, Errors are unchecked exceptions so they don't
+     * require callers to change their method signatures.
      */
     private void fail() {
         throw new Error("This cipher is not compatible with the current runtime: (keyLengthBits="

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/LocallyIllegalAesCipherDetails.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/LocallyIllegalAesCipherDetails.java
@@ -30,7 +30,7 @@ public class LocallyIllegalAesCipherDetails implements SupportedCipherDetails {
      *
      * @param keyLengthBits size of the secret key
      */
-    LocallyIllegalAesCipherDetails(int keyLengthBits) {
+    LocallyIllegalAesCipherDetails(final int keyLengthBits) {
         this.keyLengthBits = keyLengthBits;
     }
 

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/LocallyIllegalAesCipherDetails.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/LocallyIllegalAesCipherDetails.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.manta.client.crypto;
+
+import org.bouncycastle.crypto.macs.HMac;
+
+import javax.crypto.Cipher;
+import java.security.spec.AlgorithmParameterSpec;
+
+/**
+ * Implementation of an AESCipherDetails that MUST NOT be used within the current runtime.
+ *
+ * @author <a href="https://github.com/tjcelaya">Tomas Celayac</a>
+ * @since 3.0.0
+ */
+public class LocallyIllegalAesCipherDetails implements SupportedCipherDetails {
+
+    /**
+     * Size of the private key - which determines the AES algorithm type.
+     */
+    private final int keyLengthBits;
+
+    /**
+     * Package private constructor for LocallyIllegalAesCipherDetails.
+     *
+     * @param keyLengthBits size of the secret key
+     */
+    LocallyIllegalAesCipherDetails(int keyLengthBits) {
+        this.keyLengthBits = keyLengthBits;
+    }
+
+    /**
+     * Fail immediately, we don't belong on this JVM.
+     */
+    private void fail() {
+        throw new Error("This cipher is not compatible with the current runtime: (keyLengthBits="
+                + this.keyLengthBits + ", maxKeyLength=" + AesCipherDetailsFactory.DEFAULT_MAX_KEY_LENGTH);
+    }
+
+    @Override
+    public String getKeyGenerationAlgorithm() {
+        fail();
+        return null;
+    }
+
+    @Override
+    public String getCipherId() {
+        fail();
+        return null;
+    }
+
+    @Override
+    public String getCipherAlgorithm() {
+        fail();
+        return null;
+    }
+
+    @Override
+    public int getKeyLengthBits() {
+        fail();
+        return 0;
+    }
+
+    @Override
+    public int getBlockSizeInBytes() {
+        fail();
+        return 0;
+    }
+
+    @Override
+    public int getIVLengthInBytes() {
+        fail();
+        return 0;
+    }
+
+    @Override
+    public int getAuthenticationTagOrHmacLengthInBytes() {
+        fail();
+        return 0;
+    }
+
+    @Override
+    public long getMaximumPlaintextSizeInBytes() {
+        fail();
+        return 0L;
+    }
+
+    @Override
+    public Cipher getCipher() {
+        fail();
+        return null;
+    }
+
+    @Override
+    public long ciphertextSize(final long plaintextSize) {
+        fail();
+        return 0L;
+    }
+
+    @Override
+    public long plaintextSize(final long ciphertextSize) {
+        fail();
+        return 0L;
+    }
+
+    @Override
+    public boolean plaintextSizeCalculationIsAnEstimate() {
+        fail();
+        return false;
+    }
+
+    @Override
+    public boolean isAEADCipher() {
+        fail();
+        return false;
+    }
+
+    @Override
+    public AlgorithmParameterSpec getEncryptionParameterSpec(final byte[] iv) {
+        fail();
+        return null;
+    }
+
+    @Override
+    public HMac getAuthenticationHmac() {
+        fail();
+        return null;
+    }
+
+    @Override
+    public ByteRangeConversion translateByteRange(final long startPositionInclusive, final long endPositionInclusive) {
+        fail();
+        return null;
+    }
+
+    @Override
+    public long updateCipherToPosition(final Cipher cipher, final long position) {
+        fail();
+        return 0L;
+    }
+
+    @Override
+    public byte[] generateIv() {
+        fail();
+        return null;
+    }
+
+    @Override
+    public boolean supportsRandomAccess() {
+        fail();
+        return false;
+    }
+
+}

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/LocallyIllegalAesCipherDetails.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/LocallyIllegalAesCipherDetails.java
@@ -39,7 +39,7 @@ public class LocallyIllegalAesCipherDetails implements SupportedCipherDetails {
      */
     private void fail() {
         throw new Error("This cipher is not compatible with the current runtime: (keyLengthBits="
-                + this.keyLengthBits + ", maxKeyLength=" + AesCipherDetailsFactory.DEFAULT_MAX_KEY_LENGTH);
+                + this.keyLengthBits + ", maxKeyLength=" + AesCipherDetailsFactory.MAX_KEY_LENGTH_ALLOWED);
     }
 
     @Override

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/SupportedCiphersLookupMap.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/SupportedCiphersLookupMap.java
@@ -30,18 +30,37 @@ public final class SupportedCiphersLookupMap extends LookupMap<String, Supported
      * Package default constructor because interface is through {@link SupportedCipherDetails}.
      */
     private SupportedCiphersLookupMap() {
-        super(MantaUtils.unmodifiableMap(
-                AesGcmCipherDetails.INSTANCE_128_BIT.getCipherId(), AesGcmCipherDetails.INSTANCE_128_BIT,
-                AesGcmCipherDetails.INSTANCE_192_BIT.getCipherId(), AesGcmCipherDetails.INSTANCE_192_BIT,
-                AesGcmCipherDetails.INSTANCE_256_BIT.getCipherId(), AesGcmCipherDetails.INSTANCE_256_BIT,
+        super(runtimeCompatibleCiphers());
+    }
 
-                AesCtrCipherDetails.INSTANCE_128_BIT.getCipherId(), AesCtrCipherDetails.INSTANCE_128_BIT,
-                AesCtrCipherDetails.INSTANCE_192_BIT.getCipherId(), AesCtrCipherDetails.INSTANCE_192_BIT,
-                AesCtrCipherDetails.INSTANCE_256_BIT.getCipherId(), AesCtrCipherDetails.INSTANCE_256_BIT,
+    /**
+     * Provide a map of legal ciphers for the current runtime.
+     *
+     * @return A plain Map for use with super() containing only the ciphers which are valid for the current runtime
+     */
+    private static Map<String, SupportedCipherDetails> runtimeCompatibleCiphers() {
+        if (AesCipherDetailsFactory.MAX_KEY_LENGTH_FALLBACK == AesCipherDetailsFactory.MAX_KEY_LENGTH_ALLOWED) {
+            // The max allowed cipher strength is unchanged, JCE is not installed
 
-                AesCbcCipherDetails.INSTANCE_128_BIT.getCipherId(), AesCbcCipherDetails.INSTANCE_128_BIT,
-                AesCbcCipherDetails.INSTANCE_192_BIT.getCipherId(), AesCbcCipherDetails.INSTANCE_192_BIT,
-                AesCbcCipherDetails.INSTANCE_256_BIT.getCipherId(), AesCbcCipherDetails.INSTANCE_256_BIT
-        ));
+            return MantaUtils.unmodifiableMap(
+                    AesGcmCipherDetails.INSTANCE_128_BIT.getCipherId(), AesGcmCipherDetails.INSTANCE_128_BIT,
+                    AesCtrCipherDetails.INSTANCE_128_BIT.getCipherId(), AesCtrCipherDetails.INSTANCE_128_BIT,
+                    AesCbcCipherDetails.INSTANCE_128_BIT.getCipherId(), AesCbcCipherDetails.INSTANCE_128_BIT
+            );
+        } else {
+            return MantaUtils.unmodifiableMap(
+                    AesGcmCipherDetails.INSTANCE_128_BIT.getCipherId(), AesGcmCipherDetails.INSTANCE_128_BIT,
+                    AesGcmCipherDetails.INSTANCE_192_BIT.getCipherId(), AesGcmCipherDetails.INSTANCE_192_BIT,
+                    AesGcmCipherDetails.INSTANCE_256_BIT.getCipherId(), AesGcmCipherDetails.INSTANCE_256_BIT,
+
+                    AesCtrCipherDetails.INSTANCE_128_BIT.getCipherId(), AesCtrCipherDetails.INSTANCE_128_BIT,
+                    AesCtrCipherDetails.INSTANCE_192_BIT.getCipherId(), AesCtrCipherDetails.INSTANCE_192_BIT,
+                    AesCtrCipherDetails.INSTANCE_256_BIT.getCipherId(), AesCtrCipherDetails.INSTANCE_256_BIT,
+
+                    AesCbcCipherDetails.INSTANCE_128_BIT.getCipherId(), AesCbcCipherDetails.INSTANCE_128_BIT,
+                    AesCbcCipherDetails.INSTANCE_192_BIT.getCipherId(), AesCbcCipherDetails.INSTANCE_192_BIT,
+                    AesCbcCipherDetails.INSTANCE_256_BIT.getCipherId(), AesCbcCipherDetails.INSTANCE_256_BIT
+            );
+        }
     }
 }

--- a/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesCbcCipherDetailsTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesCbcCipherDetailsTest.java
@@ -19,11 +19,13 @@ public class AesCbcCipherDetailsTest extends AbstractCipherDetailsTest {
         sizeCalculationWorksRoundTrip(AesCbcCipherDetails.INSTANCE_128_BIT, size);
     }
 
+    @Test(groups = {"unlimited-crypto"})
     public void size1024bCalculationWorksRoundTripAes192() {
         final long size = 1024;
         sizeCalculationWorksRoundTrip(AesCbcCipherDetails.INSTANCE_192_BIT, size);
     }
 
+    @Test(groups = {"unlimited-crypto"})
     public void size1024bCalculationWorksRoundTripAes256() {
         final long size = 1024;
         sizeCalculationWorksRoundTrip(AesCbcCipherDetails.INSTANCE_256_BIT, size);
@@ -34,11 +36,13 @@ public class AesCbcCipherDetailsTest extends AbstractCipherDetailsTest {
         sizeCalculationWorksRoundTrip(AesCbcCipherDetails.INSTANCE_128_BIT, size);
     }
 
+    @Test(groups = {"unlimited-crypto"})
     public void size0bCalculationWorksRoundTripAes192() {
         final long size = 0;
         sizeCalculationWorksRoundTrip(AesCbcCipherDetails.INSTANCE_192_BIT, size);
     }
 
+    @Test(groups = {"unlimited-crypto"})
     public void size0bCalculationWorksRoundTripAes256() {
         final long size = 0;
         sizeCalculationWorksRoundTrip(AesCbcCipherDetails.INSTANCE_256_BIT, size);
@@ -49,11 +53,13 @@ public class AesCbcCipherDetailsTest extends AbstractCipherDetailsTest {
         sizeCalculationWorksRoundTrip(AesCbcCipherDetails.INSTANCE_128_BIT, size);
     }
 
+    @Test(groups = {"unlimited-crypto"})
     public void size2009125bCalculationWorksRoundTripAes192() {
         final long size = 2009125;
         sizeCalculationWorksRoundTrip(AesCbcCipherDetails.INSTANCE_192_BIT, size);
     }
 
+    @Test(groups = {"unlimited-crypto"})
     public void size2009125bCalculationWorksRoundTripAes256() {
         final long size = 2009125;
         sizeCalculationWorksRoundTrip(AesCbcCipherDetails.INSTANCE_256_BIT, size);
@@ -63,10 +69,12 @@ public class AesCbcCipherDetailsTest extends AbstractCipherDetailsTest {
         sizeCalculationWorksComparedToActualCipher(AesCbcCipherDetails.INSTANCE_128_BIT);
     }
 
+    @Test(groups = {"unlimited-crypto"})
     public void ciphertextSizeCalculationWorksForAes192() throws Exception {
         sizeCalculationWorksComparedToActualCipher(AesCbcCipherDetails.INSTANCE_192_BIT);
     }
 
+    @Test(groups = {"unlimited-crypto"})
     public void ciphertextSizeCalculationWorksForAes256() throws Exception {
         sizeCalculationWorksComparedToActualCipher(AesCbcCipherDetails.INSTANCE_256_BIT);
     }
@@ -78,14 +86,14 @@ public class AesCbcCipherDetailsTest extends AbstractCipherDetailsTest {
         cipherDetails.translateByteRange(0, 128);
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
+    @Test(expectedExceptions = UnsupportedOperationException.class, groups = {"unlimited-crypto"})
     public void canQueryCiphertextByteRangeAes192() throws Exception {
         SupportedCipherDetails cipherDetails = AesCbcCipherDetails.INSTANCE_192_BIT;
         SecretKey secretKey = SecretKeyUtils.generate(cipherDetails);
         cipherDetails.translateByteRange(0, 128);
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
+    @Test(expectedExceptions = UnsupportedOperationException.class, groups = {"unlimited-crypto"})
     public void canQueryCiphertextByteRangeAes256() throws Exception {
         SupportedCipherDetails cipherDetails = AesCbcCipherDetails.INSTANCE_256_BIT;
         SecretKey secretKey = SecretKeyUtils.generate(cipherDetails);

--- a/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesCtrCipherDetailsTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesCtrCipherDetailsTest.java
@@ -27,13 +27,13 @@ public class AesCtrCipherDetailsTest extends AbstractCipherDetailsTest {
         sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_128_BIT, size);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void size1024bCalculationWorksRoundTripAes192() {
         final long size = 1024;
         sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_192_BIT, size);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void size1024bCalculationWorksRoundTripAes256() {
         final long size = 1024;
         sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_256_BIT, size);
@@ -44,13 +44,13 @@ public class AesCtrCipherDetailsTest extends AbstractCipherDetailsTest {
         sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_128_BIT, size);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void size0bCalculationWorksRoundTripAes192() {
         final long size = 0;
         sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_192_BIT, size);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void size0bCalculationWorksRoundTripAes256() {
         final long size = 0;
         sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_256_BIT, size);
@@ -61,13 +61,13 @@ public class AesCtrCipherDetailsTest extends AbstractCipherDetailsTest {
         sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_128_BIT, size);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void size2009125bCalculationWorksRoundTripAes192() {
         final long size = 2009125;
         sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_192_BIT, size);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void size2009125bCalculationWorksRoundTripAes256() {
         final long size = 2009125;
         sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_256_BIT, size);
@@ -77,17 +77,17 @@ public class AesCtrCipherDetailsTest extends AbstractCipherDetailsTest {
         sizeCalculationWorksComparedToActualCipher(AesCtrCipherDetails.INSTANCE_128_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void ciphertextSizeCalculationWorksForAes192() throws Exception {
         sizeCalculationWorksComparedToActualCipher(AesCtrCipherDetails.INSTANCE_192_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void ciphertextSizeCalculationWorksForAes256() throws Exception {
         sizeCalculationWorksComparedToActualCipher(AesCtrCipherDetails.INSTANCE_256_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canQueryCiphertextByteRangeAes256() throws Exception {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_256_BIT;
         SecretKey secretKey = SecretKeyUtils.generate(cipherDetails);

--- a/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesCtrCipherDetailsTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesCtrCipherDetailsTest.java
@@ -27,11 +27,13 @@ public class AesCtrCipherDetailsTest extends AbstractCipherDetailsTest {
         sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_128_BIT, size);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void size1024bCalculationWorksRoundTripAes192() {
         final long size = 1024;
         sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_192_BIT, size);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void size1024bCalculationWorksRoundTripAes256() {
         final long size = 1024;
         sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_256_BIT, size);
@@ -42,11 +44,13 @@ public class AesCtrCipherDetailsTest extends AbstractCipherDetailsTest {
         sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_128_BIT, size);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void size0bCalculationWorksRoundTripAes192() {
         final long size = 0;
         sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_192_BIT, size);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void size0bCalculationWorksRoundTripAes256() {
         final long size = 0;
         sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_256_BIT, size);
@@ -57,11 +61,13 @@ public class AesCtrCipherDetailsTest extends AbstractCipherDetailsTest {
         sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_128_BIT, size);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void size2009125bCalculationWorksRoundTripAes192() {
         final long size = 2009125;
         sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_192_BIT, size);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void size2009125bCalculationWorksRoundTripAes256() {
         final long size = 2009125;
         sizeCalculationWorksRoundTrip(AesCtrCipherDetails.INSTANCE_256_BIT, size);
@@ -71,14 +77,17 @@ public class AesCtrCipherDetailsTest extends AbstractCipherDetailsTest {
         sizeCalculationWorksComparedToActualCipher(AesCtrCipherDetails.INSTANCE_128_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void ciphertextSizeCalculationWorksForAes192() throws Exception {
         sizeCalculationWorksComparedToActualCipher(AesCtrCipherDetails.INSTANCE_192_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void ciphertextSizeCalculationWorksForAes256() throws Exception {
         sizeCalculationWorksComparedToActualCipher(AesCtrCipherDetails.INSTANCE_256_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canQueryCiphertextByteRangeAes256() throws Exception {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_256_BIT;
         SecretKey secretKey = SecretKeyUtils.generate(cipherDetails);

--- a/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesGcmCipherDetailsTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesGcmCipherDetailsTest.java
@@ -21,13 +21,13 @@ public class AesGcmCipherDetailsTest extends AbstractCipherDetailsTest {
         sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_128_BIT, size);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void size1024bCalculationWorksRoundTripAes192() {
         final long size = 1024;
         sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_192_BIT, size);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void size1024bCalculationWorksRoundTripAes256() {
         final long size = 1024;
         sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_256_BIT, size);
@@ -38,13 +38,13 @@ public class AesGcmCipherDetailsTest extends AbstractCipherDetailsTest {
         sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_128_BIT, size);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void size0bCalculationWorksRoundTripAes192() {
         final long size = 0;
         sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_192_BIT, size);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void size0bCalculationWorksRoundTripAes256() {
         final long size = 0;
         sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_256_BIT, size);
@@ -55,13 +55,13 @@ public class AesGcmCipherDetailsTest extends AbstractCipherDetailsTest {
         sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_128_BIT, size);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void size2009125bCalculationWorksRoundTripAes192() {
         final long size = 2009125;
         sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_192_BIT, size);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void size2009125bCalculationWorksRoundTripAes256() {
         final long size = 2009125;
         sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_256_BIT, size);
@@ -71,12 +71,12 @@ public class AesGcmCipherDetailsTest extends AbstractCipherDetailsTest {
         sizeCalculationWorksComparedToActualCipher(AesGcmCipherDetails.INSTANCE_128_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void ciphertextSizeCalculationWorksForAes192() throws Exception {
         sizeCalculationWorksComparedToActualCipher(AesGcmCipherDetails.INSTANCE_192_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void ciphertextSizeCalculationWorksForAes256() throws Exception {
         sizeCalculationWorksComparedToActualCipher(AesGcmCipherDetails.INSTANCE_256_BIT);
     }
@@ -87,13 +87,13 @@ public class AesGcmCipherDetailsTest extends AbstractCipherDetailsTest {
         cipherDetails.translateByteRange(0, 128);
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class, groups = {"strong-crypto"})
+    @Test(expectedExceptions = UnsupportedOperationException.class, groups = {"unlimited-crypto"})
     public void canQueryCiphertextByteRangeAes192() throws Exception {
         SupportedCipherDetails cipherDetails = AesGcmCipherDetails.INSTANCE_192_BIT;
         cipherDetails.translateByteRange(0, 128);
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class, groups = {"strong-crypto"})
+    @Test(expectedExceptions = UnsupportedOperationException.class, groups = {"unlimited-crypto"})
     public void canQueryCiphertextByteRangeAes256() throws Exception {
         SupportedCipherDetails cipherDetails = AesGcmCipherDetails.INSTANCE_256_BIT;
         cipherDetails.translateByteRange(0, 128);

--- a/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesGcmCipherDetailsTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesGcmCipherDetailsTest.java
@@ -12,6 +12,8 @@ import org.testng.annotations.Test;
 
 @Test
 public class AesGcmCipherDetailsTest extends AbstractCipherDetailsTest {
+
+    @Test(groups = {"unlimited-crypto"})
     public void doesntCalculateHmac() throws Exception {
         Assert.assertEquals(AesGcmCipherDetails.INSTANCE_256_BIT.getAuthenticationHmac(), null);
     }

--- a/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesGcmCipherDetailsTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesGcmCipherDetailsTest.java
@@ -21,11 +21,13 @@ public class AesGcmCipherDetailsTest extends AbstractCipherDetailsTest {
         sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_128_BIT, size);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void size1024bCalculationWorksRoundTripAes192() {
         final long size = 1024;
         sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_192_BIT, size);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void size1024bCalculationWorksRoundTripAes256() {
         final long size = 1024;
         sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_256_BIT, size);
@@ -36,11 +38,13 @@ public class AesGcmCipherDetailsTest extends AbstractCipherDetailsTest {
         sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_128_BIT, size);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void size0bCalculationWorksRoundTripAes192() {
         final long size = 0;
         sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_192_BIT, size);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void size0bCalculationWorksRoundTripAes256() {
         final long size = 0;
         sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_256_BIT, size);
@@ -51,11 +55,13 @@ public class AesGcmCipherDetailsTest extends AbstractCipherDetailsTest {
         sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_128_BIT, size);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void size2009125bCalculationWorksRoundTripAes192() {
         final long size = 2009125;
         sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_192_BIT, size);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void size2009125bCalculationWorksRoundTripAes256() {
         final long size = 2009125;
         sizeCalculationWorksRoundTrip(AesGcmCipherDetails.INSTANCE_256_BIT, size);
@@ -65,10 +71,12 @@ public class AesGcmCipherDetailsTest extends AbstractCipherDetailsTest {
         sizeCalculationWorksComparedToActualCipher(AesGcmCipherDetails.INSTANCE_128_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void ciphertextSizeCalculationWorksForAes192() throws Exception {
         sizeCalculationWorksComparedToActualCipher(AesGcmCipherDetails.INSTANCE_192_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void ciphertextSizeCalculationWorksForAes256() throws Exception {
         sizeCalculationWorksComparedToActualCipher(AesGcmCipherDetails.INSTANCE_256_BIT);
     }
@@ -79,13 +87,13 @@ public class AesGcmCipherDetailsTest extends AbstractCipherDetailsTest {
         cipherDetails.translateByteRange(0, 128);
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
+    @Test(expectedExceptions = UnsupportedOperationException.class, groups = {"strong-crypto"})
     public void canQueryCiphertextByteRangeAes192() throws Exception {
         SupportedCipherDetails cipherDetails = AesGcmCipherDetails.INSTANCE_192_BIT;
         cipherDetails.translateByteRange(0, 128);
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
+    @Test(expectedExceptions = UnsupportedOperationException.class, groups = {"strong-crypto"})
     public void canQueryCiphertextByteRangeAes256() throws Exception {
         SupportedCipherDetails cipherDetails = AesGcmCipherDetails.INSTANCE_256_BIT;
         cipherDetails.translateByteRange(0, 128);

--- a/java-manta-client/src/test/java/com/joyent/manta/client/crypto/LocallyIllegalAesCipherDetailsTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/crypto/LocallyIllegalAesCipherDetailsTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.manta.client.crypto;
+
+import org.testng.annotations.Test;
+
+public class LocallyIllegalAesCipherDetailsTest {
+
+    @Test(expectedExceptions = Error.class,
+          expectedExceptionsMessageRegExp = "This cipher is not compatible with the current runtime: .*")
+    public void throwsUncheckedErrorsForAnyMethodCall() {
+        // keyLengthBits passed here is for error reporting, no validation is applied
+        LocallyIllegalAesCipherDetails illegalAesCipherDetails = new LocallyIllegalAesCipherDetails(0);
+
+        illegalAesCipherDetails.getCipher(); // or any other method call from the SupportedCipherDetails interface
+    }
+}

--- a/java-manta-client/src/test/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStreamTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStreamTest.java
@@ -77,10 +77,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canDecryptEntireObjectAllReadModes(AesCbcCipherDetails.INSTANCE_128_BIT, true);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canDecryptEntireObjectAuthenticatedAesCbc192() throws IOException {
         canDecryptEntireObjectAllReadModes(AesCbcCipherDetails.INSTANCE_192_BIT, true);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canDecryptEntireObjectAuthenticatedAesCbc256() throws IOException {
         canDecryptEntireObjectAllReadModes(AesCbcCipherDetails.INSTANCE_256_BIT, true);
     }
@@ -89,10 +91,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canDecryptEntireObjectAllReadModes(AesCtrCipherDetails.INSTANCE_128_BIT, true);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canDecryptEntireObjectAuthenticatedAesCtr192() throws IOException {
         canDecryptEntireObjectAllReadModes(AesCtrCipherDetails.INSTANCE_192_BIT, true);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canDecryptEntireObjectAuthenticatedAesCtr256() throws IOException {
         canDecryptEntireObjectAllReadModes(AesCtrCipherDetails.INSTANCE_256_BIT, true);
     }
@@ -101,10 +105,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canDecryptEntireObjectAllReadModes(AesGcmCipherDetails.INSTANCE_128_BIT, true);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canDecryptEntireObjectAuthenticatedAesGcm192() throws IOException {
         canDecryptEntireObjectAllReadModes(AesGcmCipherDetails.INSTANCE_192_BIT, true);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canDecryptEntireObjectAuthenticatedAesGcm256() throws IOException {
         canDecryptEntireObjectAllReadModes(AesGcmCipherDetails.INSTANCE_256_BIT, true);
     }
@@ -114,10 +120,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canDecryptEntireObjectAllReadModes(AesCbcCipherDetails.INSTANCE_128_BIT, false);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canDecryptEntireObjectUnauthenticatedAesCbc192() throws IOException {
         canDecryptEntireObjectAllReadModes(AesCbcCipherDetails.INSTANCE_192_BIT, false);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canDecryptEntireObjectUnauthenticatedAesCbc256() throws IOException {
         canDecryptEntireObjectAllReadModes(AesCbcCipherDetails.INSTANCE_256_BIT, false);
     }
@@ -126,10 +134,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canDecryptEntireObjectAllReadModes(AesCtrCipherDetails.INSTANCE_128_BIT, false);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canDecryptEntireObjectUnauthenticatedAesCtr192() throws IOException {
         canDecryptEntireObjectAllReadModes(AesCtrCipherDetails.INSTANCE_192_BIT, false);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canDecryptEntireObjectUnauthenticatedAesCtr256() throws IOException {
         canDecryptEntireObjectAllReadModes(AesCtrCipherDetails.INSTANCE_256_BIT, false);
     }
@@ -138,10 +148,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canDecryptEntireObjectAllReadModes(AesGcmCipherDetails.INSTANCE_128_BIT, false);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canDecryptEntireObjectUnauthenticatedAesGcm192() throws IOException {
         canDecryptEntireObjectAllReadModes(AesGcmCipherDetails.INSTANCE_192_BIT, false);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canDecryptEntireObjectUnauthenticatedAesGcm256() throws IOException {
         canDecryptEntireObjectAllReadModes(AesGcmCipherDetails.INSTANCE_256_BIT, false);
     }
@@ -151,10 +163,12 @@ public class MantaEncryptedObjectInputStreamTest {
         willErrorIfCiphertextIsModifiedAllReadModes(AesCbcCipherDetails.INSTANCE_128_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void willErrorIfCiphertextIsModifiedAesCbc192() throws IOException {
         willErrorIfCiphertextIsModifiedAllReadModes(AesCbcCipherDetails.INSTANCE_192_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void willErrorIfCiphertextIsModifiedAesCbc256() throws IOException {
         willErrorIfCiphertextIsModifiedAllReadModes(AesCbcCipherDetails.INSTANCE_256_BIT);
     }
@@ -163,10 +177,12 @@ public class MantaEncryptedObjectInputStreamTest {
         willErrorIfCiphertextIsModifiedAllReadModes(AesCtrCipherDetails.INSTANCE_128_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void willErrorIfCiphertextIsModifiedAesCtr192() throws IOException {
         willErrorIfCiphertextIsModifiedAllReadModes(AesCtrCipherDetails.INSTANCE_192_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void willErrorIfCiphertextIsModifiedAesCtr256() throws IOException {
         willErrorIfCiphertextIsModifiedAllReadModes(AesCtrCipherDetails.INSTANCE_256_BIT);
     }
@@ -175,10 +191,12 @@ public class MantaEncryptedObjectInputStreamTest {
         willErrorIfCiphertextIsModifiedAllReadModes(AesGcmCipherDetails.INSTANCE_128_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void willErrorIfCiphertextIsModifiedAesGcm192() throws IOException {
         willErrorIfCiphertextIsModifiedAllReadModes(AesGcmCipherDetails.INSTANCE_192_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void willErrorIfCiphertextIsModifiedAesGcm256() throws IOException {
         willErrorIfCiphertextIsModifiedAllReadModes(AesGcmCipherDetails.INSTANCE_256_BIT);
     }
@@ -188,10 +206,12 @@ public class MantaEncryptedObjectInputStreamTest {
         willErrorIfCiphertextIsModifiedAndNotReadFully(AesCbcCipherDetails.INSTANCE_128_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void willErrorIfCiphertextIsModifiedAndNotReadFullyAesCbc192() throws IOException {
         willErrorIfCiphertextIsModifiedAndNotReadFully(AesCbcCipherDetails.INSTANCE_192_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void willErrorIfCiphertextIsModifiedAndNotReadFullyAesCbc256() throws IOException {
         willErrorIfCiphertextIsModifiedAndNotReadFully(AesCbcCipherDetails.INSTANCE_256_BIT);
     }
@@ -200,10 +220,12 @@ public class MantaEncryptedObjectInputStreamTest {
         willErrorIfCiphertextIsModifiedAndNotReadFully(AesCtrCipherDetails.INSTANCE_128_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void willErrorIfCiphertextIsModifiedAndNotReadFullyAesCtr192() throws IOException {
         willErrorIfCiphertextIsModifiedAndNotReadFully(AesCtrCipherDetails.INSTANCE_192_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void willErrorIfCiphertextIsModifiedAndNotReadFullyAesCtr256() throws IOException {
         willErrorIfCiphertextIsModifiedAndNotReadFully(AesCtrCipherDetails.INSTANCE_256_BIT);
     }
@@ -212,10 +234,12 @@ public class MantaEncryptedObjectInputStreamTest {
         willErrorIfCiphertextIsModifiedAndNotReadFully(AesGcmCipherDetails.INSTANCE_128_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void willErrorIfCiphertextIsModifiedAndNotReadFullyAesGcm192() throws IOException {
         willErrorIfCiphertextIsModifiedAndNotReadFully(AesGcmCipherDetails.INSTANCE_192_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void willErrorIfCiphertextIsModifiedAndNotReadFullyAesGcm256() throws IOException {
         willErrorIfCiphertextIsModifiedAndNotReadFully(AesGcmCipherDetails.INSTANCE_256_BIT);
     }
@@ -225,10 +249,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canSkipBytesAuthenticated(AesCbcCipherDetails.INSTANCE_128_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canSkipBytesAuthenticatedAesCbc192() throws IOException {
         canSkipBytesAuthenticated(AesCbcCipherDetails.INSTANCE_192_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canSkipBytesAuthenticatedAesCbc256() throws IOException {
         canSkipBytesAuthenticated(AesCbcCipherDetails.INSTANCE_256_BIT);
     }
@@ -237,10 +263,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canSkipBytesAuthenticated(AesCtrCipherDetails.INSTANCE_128_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canSkipBytesAuthenticatedAesCtr192() throws IOException {
         canSkipBytesAuthenticated(AesCtrCipherDetails.INSTANCE_192_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canSkipBytesAuthenticatedAesCtr256() throws IOException {
         canSkipBytesAuthenticated(AesCtrCipherDetails.INSTANCE_256_BIT);
     }
@@ -249,10 +277,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canSkipBytesAuthenticated(AesGcmCipherDetails.INSTANCE_128_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canSkipBytesAuthenticatedAesGcm192() throws IOException {
         canSkipBytesAuthenticated(AesGcmCipherDetails.INSTANCE_192_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canSkipBytesAuthenticatedAesGcm256() throws IOException {
         canSkipBytesAuthenticated(AesGcmCipherDetails.INSTANCE_256_BIT);
     }
@@ -262,10 +292,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canSkipBytesUnauthenticated(AesCbcCipherDetails.INSTANCE_128_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canSkipBytesUnauthenticatedAesCbc192() throws IOException {
         canSkipBytesUnauthenticated(AesCbcCipherDetails.INSTANCE_192_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canSkipBytesUnauthenticatedAesCbc256() throws IOException {
         canSkipBytesUnauthenticated(AesCbcCipherDetails.INSTANCE_256_BIT);
     }
@@ -274,10 +306,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canSkipBytesUnauthenticated(AesCtrCipherDetails.INSTANCE_128_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canSkipBytesUnauthenticatedAesCtr192() throws IOException {
         canSkipBytesUnauthenticated(AesCtrCipherDetails.INSTANCE_192_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canSkipBytesUnauthenticatedAesCtr256() throws IOException {
         canSkipBytesUnauthenticated(AesCtrCipherDetails.INSTANCE_256_BIT);
     }
@@ -286,10 +320,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canSkipBytesUnauthenticated(AesGcmCipherDetails.INSTANCE_128_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canSkipBytesUnauthenticatedAesGcm192() throws IOException {
         canSkipBytesUnauthenticated(AesGcmCipherDetails.INSTANCE_192_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canSkipBytesUnauthenticatedAesGcm256() throws IOException {
         canSkipBytesUnauthenticated(AesGcmCipherDetails.INSTANCE_256_BIT);
     }
@@ -299,10 +335,12 @@ public class MantaEncryptedObjectInputStreamTest {
         willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesCbcCipherDetails.INSTANCE_128_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void willErrorIfCiphertextIsModifiedAndBytesAreSkippedAesCbc192() throws IOException {
         willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesCbcCipherDetails.INSTANCE_192_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void willErrorIfCiphertextIsModifiedAndBytesAreSkippedAesCbc256() throws IOException {
         willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesCbcCipherDetails.INSTANCE_256_BIT);
     }
@@ -311,10 +349,12 @@ public class MantaEncryptedObjectInputStreamTest {
         willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesCtrCipherDetails.INSTANCE_128_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void willErrorIfCiphertextIsModifiedAndBytesAreSkippedAesCtr192() throws IOException {
         willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesCtrCipherDetails.INSTANCE_192_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void willErrorIfCiphertextIsModifiedAndBytesAreSkippedAesCtr256() throws IOException {
         willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesCtrCipherDetails.INSTANCE_256_BIT);
     }
@@ -323,10 +363,12 @@ public class MantaEncryptedObjectInputStreamTest {
         willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesGcmCipherDetails.INSTANCE_128_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void willErrorIfCiphertextIsModifiedAndBytesAreSkippedAesGcm192() throws IOException {
         willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesGcmCipherDetails.INSTANCE_192_BIT);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void willErrorIfCiphertextIsModifiedAndBytesAreSkippedAesGcm256() throws IOException {
         willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesGcmCipherDetails.INSTANCE_256_BIT);
     }
@@ -337,12 +379,14 @@ public class MantaEncryptedObjectInputStreamTest {
         canReadByteRangeAllReadModes(cipherDetails, 0, endPos);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canReadByteRangeStartingAtZeroEndingInFirstBlockAesCtr192() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_192_BIT;
         int endPos = cipherDetails.getBlockSizeInBytes() / 2;
         canReadByteRangeAllReadModes(cipherDetails, 0, endPos);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canReadByteRangeStartingAtZeroEndingInFirstBlockAesCtr256() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_256_BIT;
         int endPos = cipherDetails.getBlockSizeInBytes() / 2;
@@ -355,12 +399,14 @@ public class MantaEncryptedObjectInputStreamTest {
         canReadByteRangeAllReadModes(cipherDetails, 0, endPos);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canReadByteRangeStartingAtZeroEndingInThirdBlockAesCtr192() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_192_BIT;
         int endPos = cipherDetails.getBlockSizeInBytes() * 2 + (cipherDetails.getBlockSizeInBytes() / 2);
         canReadByteRangeAllReadModes(cipherDetails, 0, endPos);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canReadByteRangeStartingAtZeroEndingInThirdBlockAesCtr256() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_256_BIT;
         int endPos = cipherDetails.getBlockSizeInBytes() * 2 + (cipherDetails.getBlockSizeInBytes() / 2);
@@ -373,12 +419,14 @@ public class MantaEncryptedObjectInputStreamTest {
         canReadByteRangeAllReadModes(cipherDetails, 3, endPos);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canReadByteRangeStartingAtThreeEndingInFirstBlockAesCtr192() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_192_BIT;
         int endPos = cipherDetails.getBlockSizeInBytes() / 2;
         canReadByteRangeAllReadModes(cipherDetails, 3, endPos);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canReadByteRangeStartingAtThreeEndingInFirstBlockAesCtr256() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_256_BIT;
         int endPos = cipherDetails.getBlockSizeInBytes() / 2;
@@ -392,6 +440,7 @@ public class MantaEncryptedObjectInputStreamTest {
         canReadByteRangeAllReadModes(cipherDetails, startPos, endPos);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canReadByteRangeStartingAtThirdBlockEndingInFifthBlockAesCtr192() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_192_BIT;
         int startPos = cipherDetails.getBlockSizeInBytes() * 3 + (cipherDetails.getBlockSizeInBytes() / 2);
@@ -399,6 +448,7 @@ public class MantaEncryptedObjectInputStreamTest {
         canReadByteRangeAllReadModes(cipherDetails, startPos, endPos);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canReadByteRangeStartingAtThirdBlockEndingInFifthBlockAesCtr256() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_256_BIT;
         int startPos = cipherDetails.getBlockSizeInBytes() * 3 + (cipherDetails.getBlockSizeInBytes() / 2);
@@ -413,6 +463,7 @@ public class MantaEncryptedObjectInputStreamTest {
         canReadByteRangeAllReadModes(cipherDetails, startPos, endPos);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canReadByteRangeStarting25bytesFromEndToEndAesCtr192() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_192_BIT;
         int endPos = plaintextSize - 1;
@@ -420,6 +471,7 @@ public class MantaEncryptedObjectInputStreamTest {
         canReadByteRangeAllReadModes(cipherDetails, startPos, endPos);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canReadByteRangeStarting25bytesFromEndToEndAesCtr256() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_256_BIT;
         int endPos = plaintextSize - 1;
@@ -434,6 +486,7 @@ public class MantaEncryptedObjectInputStreamTest {
         canReadByteRangeAllReadModes(cipherDetails, startPos, endPos);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canReadByteRangeStarting25bytesFromEndToBeyondEndAesCtr192() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_192_BIT;
         int endPos = plaintextSize * 2;
@@ -441,6 +494,7 @@ public class MantaEncryptedObjectInputStreamTest {
         canReadByteRangeAllReadModes(cipherDetails, startPos, endPos);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canReadByteRangeStarting25bytesFromEndToBeyondEndAesCtr256() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_256_BIT;
         int endPos = plaintextSize * 2;
@@ -453,10 +507,12 @@ public class MantaEncryptedObjectInputStreamTest {
          canCopyToOutputStreamWithLargeBuffer(AesCbcCipherDetails.INSTANCE_128_BIT, true);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canCopyStreamWithLargeBufferBufferAuthenticatedAesCbc192() throws IOException {
          canCopyToOutputStreamWithLargeBuffer(AesCbcCipherDetails.INSTANCE_192_BIT, true);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canCopyStreamWithLargeBufferBufferAuthenticatedAesCbc256() throws IOException {
          canCopyToOutputStreamWithLargeBuffer(AesCbcCipherDetails.INSTANCE_256_BIT, true);
     }
@@ -465,10 +521,12 @@ public class MantaEncryptedObjectInputStreamTest {
          canCopyToOutputStreamWithLargeBuffer(AesCtrCipherDetails.INSTANCE_128_BIT, true);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canCopyStreamWithLargeBufferBufferAuthenticatedAesCtr192() throws IOException {
          canCopyToOutputStreamWithLargeBuffer(AesCtrCipherDetails.INSTANCE_192_BIT, true);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canCopyStreamWithLargeBufferBufferAuthenticatedAesCtr256() throws IOException {
          canCopyToOutputStreamWithLargeBuffer(AesCtrCipherDetails.INSTANCE_256_BIT, true);
     }
@@ -477,6 +535,7 @@ public class MantaEncryptedObjectInputStreamTest {
          canCopyToOutputStreamWithLargeBuffer(AesGcmCipherDetails.INSTANCE_128_BIT, true);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canCopyStreamWithLargeBufferBufferAuthenticatedAesGcm192() throws IOException {
          canCopyToOutputStreamWithLargeBuffer(AesGcmCipherDetails.INSTANCE_192_BIT, true);
     }
@@ -486,10 +545,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canCopyToOutputStreamWithLargeBuffer(AesCbcCipherDetails.INSTANCE_128_BIT, false);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canCopyStreamWithLargeBufferBufferUnauthenticatedAesCbc192() throws IOException {
         canCopyToOutputStreamWithLargeBuffer(AesCbcCipherDetails.INSTANCE_192_BIT, false);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canCopyStreamWithLargeBufferBufferUnauthenticatedAesCbc256() throws IOException {
         canCopyToOutputStreamWithLargeBuffer(AesCbcCipherDetails.INSTANCE_256_BIT, false);
     }
@@ -498,10 +559,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canCopyToOutputStreamWithLargeBuffer(AesCtrCipherDetails.INSTANCE_128_BIT, false);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canCopyStreamWithLargeBufferBufferUnauthenticatedAesCtr192() throws IOException {
         canCopyToOutputStreamWithLargeBuffer(AesCtrCipherDetails.INSTANCE_192_BIT, false);
     }
 
+    @Test(groups = {"strong-crypto"})
     public void canCopyStreamWithLargeBufferBufferUnauthenticatedAesCtr256() throws IOException {
         canCopyToOutputStreamWithLargeBuffer(AesCtrCipherDetails.INSTANCE_256_BIT, false);
     }

--- a/java-manta-client/src/test/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStreamTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStreamTest.java
@@ -77,12 +77,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canDecryptEntireObjectAllReadModes(AesCbcCipherDetails.INSTANCE_128_BIT, true);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canDecryptEntireObjectAuthenticatedAesCbc192() throws IOException {
         canDecryptEntireObjectAllReadModes(AesCbcCipherDetails.INSTANCE_192_BIT, true);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canDecryptEntireObjectAuthenticatedAesCbc256() throws IOException {
         canDecryptEntireObjectAllReadModes(AesCbcCipherDetails.INSTANCE_256_BIT, true);
     }
@@ -91,12 +91,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canDecryptEntireObjectAllReadModes(AesCtrCipherDetails.INSTANCE_128_BIT, true);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canDecryptEntireObjectAuthenticatedAesCtr192() throws IOException {
         canDecryptEntireObjectAllReadModes(AesCtrCipherDetails.INSTANCE_192_BIT, true);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canDecryptEntireObjectAuthenticatedAesCtr256() throws IOException {
         canDecryptEntireObjectAllReadModes(AesCtrCipherDetails.INSTANCE_256_BIT, true);
     }
@@ -105,12 +105,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canDecryptEntireObjectAllReadModes(AesGcmCipherDetails.INSTANCE_128_BIT, true);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canDecryptEntireObjectAuthenticatedAesGcm192() throws IOException {
         canDecryptEntireObjectAllReadModes(AesGcmCipherDetails.INSTANCE_192_BIT, true);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canDecryptEntireObjectAuthenticatedAesGcm256() throws IOException {
         canDecryptEntireObjectAllReadModes(AesGcmCipherDetails.INSTANCE_256_BIT, true);
     }
@@ -120,12 +120,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canDecryptEntireObjectAllReadModes(AesCbcCipherDetails.INSTANCE_128_BIT, false);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canDecryptEntireObjectUnauthenticatedAesCbc192() throws IOException {
         canDecryptEntireObjectAllReadModes(AesCbcCipherDetails.INSTANCE_192_BIT, false);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canDecryptEntireObjectUnauthenticatedAesCbc256() throws IOException {
         canDecryptEntireObjectAllReadModes(AesCbcCipherDetails.INSTANCE_256_BIT, false);
     }
@@ -134,12 +134,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canDecryptEntireObjectAllReadModes(AesCtrCipherDetails.INSTANCE_128_BIT, false);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canDecryptEntireObjectUnauthenticatedAesCtr192() throws IOException {
         canDecryptEntireObjectAllReadModes(AesCtrCipherDetails.INSTANCE_192_BIT, false);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canDecryptEntireObjectUnauthenticatedAesCtr256() throws IOException {
         canDecryptEntireObjectAllReadModes(AesCtrCipherDetails.INSTANCE_256_BIT, false);
     }
@@ -148,12 +148,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canDecryptEntireObjectAllReadModes(AesGcmCipherDetails.INSTANCE_128_BIT, false);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canDecryptEntireObjectUnauthenticatedAesGcm192() throws IOException {
         canDecryptEntireObjectAllReadModes(AesGcmCipherDetails.INSTANCE_192_BIT, false);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canDecryptEntireObjectUnauthenticatedAesGcm256() throws IOException {
         canDecryptEntireObjectAllReadModes(AesGcmCipherDetails.INSTANCE_256_BIT, false);
     }
@@ -163,12 +163,12 @@ public class MantaEncryptedObjectInputStreamTest {
         willErrorIfCiphertextIsModifiedAllReadModes(AesCbcCipherDetails.INSTANCE_128_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void willErrorIfCiphertextIsModifiedAesCbc192() throws IOException {
         willErrorIfCiphertextIsModifiedAllReadModes(AesCbcCipherDetails.INSTANCE_192_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void willErrorIfCiphertextIsModifiedAesCbc256() throws IOException {
         willErrorIfCiphertextIsModifiedAllReadModes(AesCbcCipherDetails.INSTANCE_256_BIT);
     }
@@ -177,12 +177,12 @@ public class MantaEncryptedObjectInputStreamTest {
         willErrorIfCiphertextIsModifiedAllReadModes(AesCtrCipherDetails.INSTANCE_128_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void willErrorIfCiphertextIsModifiedAesCtr192() throws IOException {
         willErrorIfCiphertextIsModifiedAllReadModes(AesCtrCipherDetails.INSTANCE_192_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void willErrorIfCiphertextIsModifiedAesCtr256() throws IOException {
         willErrorIfCiphertextIsModifiedAllReadModes(AesCtrCipherDetails.INSTANCE_256_BIT);
     }
@@ -191,12 +191,12 @@ public class MantaEncryptedObjectInputStreamTest {
         willErrorIfCiphertextIsModifiedAllReadModes(AesGcmCipherDetails.INSTANCE_128_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void willErrorIfCiphertextIsModifiedAesGcm192() throws IOException {
         willErrorIfCiphertextIsModifiedAllReadModes(AesGcmCipherDetails.INSTANCE_192_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void willErrorIfCiphertextIsModifiedAesGcm256() throws IOException {
         willErrorIfCiphertextIsModifiedAllReadModes(AesGcmCipherDetails.INSTANCE_256_BIT);
     }
@@ -206,12 +206,12 @@ public class MantaEncryptedObjectInputStreamTest {
         willErrorIfCiphertextIsModifiedAndNotReadFully(AesCbcCipherDetails.INSTANCE_128_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void willErrorIfCiphertextIsModifiedAndNotReadFullyAesCbc192() throws IOException {
         willErrorIfCiphertextIsModifiedAndNotReadFully(AesCbcCipherDetails.INSTANCE_192_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void willErrorIfCiphertextIsModifiedAndNotReadFullyAesCbc256() throws IOException {
         willErrorIfCiphertextIsModifiedAndNotReadFully(AesCbcCipherDetails.INSTANCE_256_BIT);
     }
@@ -220,12 +220,12 @@ public class MantaEncryptedObjectInputStreamTest {
         willErrorIfCiphertextIsModifiedAndNotReadFully(AesCtrCipherDetails.INSTANCE_128_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void willErrorIfCiphertextIsModifiedAndNotReadFullyAesCtr192() throws IOException {
         willErrorIfCiphertextIsModifiedAndNotReadFully(AesCtrCipherDetails.INSTANCE_192_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void willErrorIfCiphertextIsModifiedAndNotReadFullyAesCtr256() throws IOException {
         willErrorIfCiphertextIsModifiedAndNotReadFully(AesCtrCipherDetails.INSTANCE_256_BIT);
     }
@@ -234,12 +234,12 @@ public class MantaEncryptedObjectInputStreamTest {
         willErrorIfCiphertextIsModifiedAndNotReadFully(AesGcmCipherDetails.INSTANCE_128_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void willErrorIfCiphertextIsModifiedAndNotReadFullyAesGcm192() throws IOException {
         willErrorIfCiphertextIsModifiedAndNotReadFully(AesGcmCipherDetails.INSTANCE_192_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void willErrorIfCiphertextIsModifiedAndNotReadFullyAesGcm256() throws IOException {
         willErrorIfCiphertextIsModifiedAndNotReadFully(AesGcmCipherDetails.INSTANCE_256_BIT);
     }
@@ -249,12 +249,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canSkipBytesAuthenticated(AesCbcCipherDetails.INSTANCE_128_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canSkipBytesAuthenticatedAesCbc192() throws IOException {
         canSkipBytesAuthenticated(AesCbcCipherDetails.INSTANCE_192_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canSkipBytesAuthenticatedAesCbc256() throws IOException {
         canSkipBytesAuthenticated(AesCbcCipherDetails.INSTANCE_256_BIT);
     }
@@ -263,12 +263,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canSkipBytesAuthenticated(AesCtrCipherDetails.INSTANCE_128_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canSkipBytesAuthenticatedAesCtr192() throws IOException {
         canSkipBytesAuthenticated(AesCtrCipherDetails.INSTANCE_192_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canSkipBytesAuthenticatedAesCtr256() throws IOException {
         canSkipBytesAuthenticated(AesCtrCipherDetails.INSTANCE_256_BIT);
     }
@@ -277,12 +277,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canSkipBytesAuthenticated(AesGcmCipherDetails.INSTANCE_128_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canSkipBytesAuthenticatedAesGcm192() throws IOException {
         canSkipBytesAuthenticated(AesGcmCipherDetails.INSTANCE_192_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canSkipBytesAuthenticatedAesGcm256() throws IOException {
         canSkipBytesAuthenticated(AesGcmCipherDetails.INSTANCE_256_BIT);
     }
@@ -292,12 +292,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canSkipBytesUnauthenticated(AesCbcCipherDetails.INSTANCE_128_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canSkipBytesUnauthenticatedAesCbc192() throws IOException {
         canSkipBytesUnauthenticated(AesCbcCipherDetails.INSTANCE_192_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canSkipBytesUnauthenticatedAesCbc256() throws IOException {
         canSkipBytesUnauthenticated(AesCbcCipherDetails.INSTANCE_256_BIT);
     }
@@ -306,12 +306,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canSkipBytesUnauthenticated(AesCtrCipherDetails.INSTANCE_128_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canSkipBytesUnauthenticatedAesCtr192() throws IOException {
         canSkipBytesUnauthenticated(AesCtrCipherDetails.INSTANCE_192_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canSkipBytesUnauthenticatedAesCtr256() throws IOException {
         canSkipBytesUnauthenticated(AesCtrCipherDetails.INSTANCE_256_BIT);
     }
@@ -320,12 +320,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canSkipBytesUnauthenticated(AesGcmCipherDetails.INSTANCE_128_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canSkipBytesUnauthenticatedAesGcm192() throws IOException {
         canSkipBytesUnauthenticated(AesGcmCipherDetails.INSTANCE_192_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canSkipBytesUnauthenticatedAesGcm256() throws IOException {
         canSkipBytesUnauthenticated(AesGcmCipherDetails.INSTANCE_256_BIT);
     }
@@ -335,12 +335,12 @@ public class MantaEncryptedObjectInputStreamTest {
         willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesCbcCipherDetails.INSTANCE_128_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void willErrorIfCiphertextIsModifiedAndBytesAreSkippedAesCbc192() throws IOException {
         willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesCbcCipherDetails.INSTANCE_192_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void willErrorIfCiphertextIsModifiedAndBytesAreSkippedAesCbc256() throws IOException {
         willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesCbcCipherDetails.INSTANCE_256_BIT);
     }
@@ -349,12 +349,12 @@ public class MantaEncryptedObjectInputStreamTest {
         willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesCtrCipherDetails.INSTANCE_128_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void willErrorIfCiphertextIsModifiedAndBytesAreSkippedAesCtr192() throws IOException {
         willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesCtrCipherDetails.INSTANCE_192_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void willErrorIfCiphertextIsModifiedAndBytesAreSkippedAesCtr256() throws IOException {
         willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesCtrCipherDetails.INSTANCE_256_BIT);
     }
@@ -363,12 +363,12 @@ public class MantaEncryptedObjectInputStreamTest {
         willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesGcmCipherDetails.INSTANCE_128_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void willErrorIfCiphertextIsModifiedAndBytesAreSkippedAesGcm192() throws IOException {
         willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesGcmCipherDetails.INSTANCE_192_BIT);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void willErrorIfCiphertextIsModifiedAndBytesAreSkippedAesGcm256() throws IOException {
         willErrorIfCiphertextIsModifiedAndBytesAreSkipped(AesGcmCipherDetails.INSTANCE_256_BIT);
     }
@@ -379,14 +379,14 @@ public class MantaEncryptedObjectInputStreamTest {
         canReadByteRangeAllReadModes(cipherDetails, 0, endPos);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canReadByteRangeStartingAtZeroEndingInFirstBlockAesCtr192() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_192_BIT;
         int endPos = cipherDetails.getBlockSizeInBytes() / 2;
         canReadByteRangeAllReadModes(cipherDetails, 0, endPos);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canReadByteRangeStartingAtZeroEndingInFirstBlockAesCtr256() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_256_BIT;
         int endPos = cipherDetails.getBlockSizeInBytes() / 2;
@@ -399,14 +399,14 @@ public class MantaEncryptedObjectInputStreamTest {
         canReadByteRangeAllReadModes(cipherDetails, 0, endPos);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canReadByteRangeStartingAtZeroEndingInThirdBlockAesCtr192() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_192_BIT;
         int endPos = cipherDetails.getBlockSizeInBytes() * 2 + (cipherDetails.getBlockSizeInBytes() / 2);
         canReadByteRangeAllReadModes(cipherDetails, 0, endPos);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canReadByteRangeStartingAtZeroEndingInThirdBlockAesCtr256() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_256_BIT;
         int endPos = cipherDetails.getBlockSizeInBytes() * 2 + (cipherDetails.getBlockSizeInBytes() / 2);
@@ -419,14 +419,14 @@ public class MantaEncryptedObjectInputStreamTest {
         canReadByteRangeAllReadModes(cipherDetails, 3, endPos);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canReadByteRangeStartingAtThreeEndingInFirstBlockAesCtr192() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_192_BIT;
         int endPos = cipherDetails.getBlockSizeInBytes() / 2;
         canReadByteRangeAllReadModes(cipherDetails, 3, endPos);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canReadByteRangeStartingAtThreeEndingInFirstBlockAesCtr256() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_256_BIT;
         int endPos = cipherDetails.getBlockSizeInBytes() / 2;
@@ -440,7 +440,7 @@ public class MantaEncryptedObjectInputStreamTest {
         canReadByteRangeAllReadModes(cipherDetails, startPos, endPos);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canReadByteRangeStartingAtThirdBlockEndingInFifthBlockAesCtr192() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_192_BIT;
         int startPos = cipherDetails.getBlockSizeInBytes() * 3 + (cipherDetails.getBlockSizeInBytes() / 2);
@@ -448,7 +448,7 @@ public class MantaEncryptedObjectInputStreamTest {
         canReadByteRangeAllReadModes(cipherDetails, startPos, endPos);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canReadByteRangeStartingAtThirdBlockEndingInFifthBlockAesCtr256() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_256_BIT;
         int startPos = cipherDetails.getBlockSizeInBytes() * 3 + (cipherDetails.getBlockSizeInBytes() / 2);
@@ -463,7 +463,7 @@ public class MantaEncryptedObjectInputStreamTest {
         canReadByteRangeAllReadModes(cipherDetails, startPos, endPos);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canReadByteRangeStarting25bytesFromEndToEndAesCtr192() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_192_BIT;
         int endPos = plaintextSize - 1;
@@ -471,7 +471,7 @@ public class MantaEncryptedObjectInputStreamTest {
         canReadByteRangeAllReadModes(cipherDetails, startPos, endPos);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canReadByteRangeStarting25bytesFromEndToEndAesCtr256() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_256_BIT;
         int endPos = plaintextSize - 1;
@@ -486,7 +486,7 @@ public class MantaEncryptedObjectInputStreamTest {
         canReadByteRangeAllReadModes(cipherDetails, startPos, endPos);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canReadByteRangeStarting25bytesFromEndToBeyondEndAesCtr192() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_192_BIT;
         int endPos = plaintextSize * 2;
@@ -494,7 +494,7 @@ public class MantaEncryptedObjectInputStreamTest {
         canReadByteRangeAllReadModes(cipherDetails, startPos, endPos);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canReadByteRangeStarting25bytesFromEndToBeyondEndAesCtr256() throws IOException {
         SupportedCipherDetails cipherDetails = AesCtrCipherDetails.INSTANCE_256_BIT;
         int endPos = plaintextSize * 2;
@@ -507,12 +507,12 @@ public class MantaEncryptedObjectInputStreamTest {
          canCopyToOutputStreamWithLargeBuffer(AesCbcCipherDetails.INSTANCE_128_BIT, true);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canCopyStreamWithLargeBufferBufferAuthenticatedAesCbc192() throws IOException {
          canCopyToOutputStreamWithLargeBuffer(AesCbcCipherDetails.INSTANCE_192_BIT, true);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canCopyStreamWithLargeBufferBufferAuthenticatedAesCbc256() throws IOException {
          canCopyToOutputStreamWithLargeBuffer(AesCbcCipherDetails.INSTANCE_256_BIT, true);
     }
@@ -521,12 +521,12 @@ public class MantaEncryptedObjectInputStreamTest {
          canCopyToOutputStreamWithLargeBuffer(AesCtrCipherDetails.INSTANCE_128_BIT, true);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canCopyStreamWithLargeBufferBufferAuthenticatedAesCtr192() throws IOException {
          canCopyToOutputStreamWithLargeBuffer(AesCtrCipherDetails.INSTANCE_192_BIT, true);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canCopyStreamWithLargeBufferBufferAuthenticatedAesCtr256() throws IOException {
          canCopyToOutputStreamWithLargeBuffer(AesCtrCipherDetails.INSTANCE_256_BIT, true);
     }
@@ -535,7 +535,7 @@ public class MantaEncryptedObjectInputStreamTest {
          canCopyToOutputStreamWithLargeBuffer(AesGcmCipherDetails.INSTANCE_128_BIT, true);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canCopyStreamWithLargeBufferBufferAuthenticatedAesGcm192() throws IOException {
          canCopyToOutputStreamWithLargeBuffer(AesGcmCipherDetails.INSTANCE_192_BIT, true);
     }
@@ -545,12 +545,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canCopyToOutputStreamWithLargeBuffer(AesCbcCipherDetails.INSTANCE_128_BIT, false);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canCopyStreamWithLargeBufferBufferUnauthenticatedAesCbc192() throws IOException {
         canCopyToOutputStreamWithLargeBuffer(AesCbcCipherDetails.INSTANCE_192_BIT, false);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canCopyStreamWithLargeBufferBufferUnauthenticatedAesCbc256() throws IOException {
         canCopyToOutputStreamWithLargeBuffer(AesCbcCipherDetails.INSTANCE_256_BIT, false);
     }
@@ -559,12 +559,12 @@ public class MantaEncryptedObjectInputStreamTest {
         canCopyToOutputStreamWithLargeBuffer(AesCtrCipherDetails.INSTANCE_128_BIT, false);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canCopyStreamWithLargeBufferBufferUnauthenticatedAesCtr192() throws IOException {
         canCopyToOutputStreamWithLargeBuffer(AesCtrCipherDetails.INSTANCE_192_BIT, false);
     }
 
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     public void canCopyStreamWithLargeBufferBufferUnauthenticatedAesCtr256() throws IOException {
         canCopyToOutputStreamWithLargeBuffer(AesCtrCipherDetails.INSTANCE_256_BIT, false);
     }

--- a/java-manta-client/src/test/java/com/joyent/manta/client/crypto/SupportedCiphersLookupMapTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/crypto/SupportedCiphersLookupMapTest.java
@@ -18,16 +18,21 @@ import static com.joyent.manta.client.crypto.SupportedCiphersLookupMap.INSTANCE;
 
 @Test
 public class SupportedCiphersLookupMapTest {
-    public void canGetAllCiphers() {
+
+    public void canGetRestrictedCiphers() {
         Assert.assertTrue(INSTANCE.get("AES128/GCM/NoPadding") instanceof AesGcmCipherDetails);
+        Assert.assertTrue(INSTANCE.get("AES128/CTR/NoPadding") instanceof AesCtrCipherDetails);
+        Assert.assertTrue(INSTANCE.get("AES128/CBC/PKCS5Padding") instanceof AesCbcCipherDetails);
+    }
+
+    @Test(groups = {"unlimited-crypto"})
+    public void canGetAllCiphers() {
         Assert.assertTrue(INSTANCE.get("AES192/GCM/NoPadding") instanceof AesGcmCipherDetails);
         Assert.assertTrue(INSTANCE.get("AES256/GCM/NoPadding") instanceof AesGcmCipherDetails);
 
-        Assert.assertTrue(INSTANCE.get("AES128/CTR/NoPadding") instanceof AesCtrCipherDetails);
         Assert.assertTrue(INSTANCE.get("AES192/CTR/NoPadding") instanceof AesCtrCipherDetails);
         Assert.assertTrue(INSTANCE.get("AES256/CTR/NoPadding") instanceof AesCtrCipherDetails);
 
-        Assert.assertTrue(INSTANCE.get("AES128/CBC/PKCS5Padding") instanceof AesCbcCipherDetails);
         Assert.assertTrue(INSTANCE.get("AES192/CBC/PKCS5Padding") instanceof AesCbcCipherDetails);
         Assert.assertTrue(INSTANCE.get("AES256/CBC/PKCS5Padding") instanceof AesCbcCipherDetails);
     }

--- a/java-manta-client/src/test/java/com/joyent/manta/http/EncryptedHttpHelperTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/http/EncryptedHttpHelperTest.java
@@ -89,7 +89,7 @@ public class EncryptedHttpHelperTest {
      * be configured for one cipher/mode and executes requests in another
      * cipher/mode.
      */
-    @Test(groups = {"strong-crypto"})
+    @Test(groups = {"unlimited-crypto"})
     private static EncryptionHttpHelper fakeEncryptionHttpHelper(String path)
             throws Exception {
         MantaConnectionContext connectionContext = mock(MantaConnectionContext.class);

--- a/java-manta-client/src/test/java/com/joyent/manta/http/EncryptedHttpHelperTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/http/EncryptedHttpHelperTest.java
@@ -44,6 +44,7 @@ public class EncryptedHttpHelperTest {
      * Verifies that encrypted HEAD requests made with a different cipher/mode
      * configured from the cipher/mode on the object will result in an error.
      */
+    @Test(groups = {"unlimited-crypto"})
     public void doesntAllowDifferentCipherForObjectAndConfigHeadIfOnlyReadingUnencryptedMetadata() throws Exception {
         String path = "/user/path/encrypted-object";
         EncryptionHttpHelper httpHelper = fakeEncryptionHttpHelper(path);
@@ -54,6 +55,7 @@ public class EncryptedHttpHelperTest {
      * Verifies that encrypted GET requests made with a different cipher/mode
      * configured from the cipher/mode on the object will result in an error.
      */
+    @Test(groups = {"unlimited-crypto"})
     public void allowDifferentCipherForObjectAndConfigGetIfOnlyReadingUnencryptedMetadata() throws Exception {
         String path = "/user/path/encrypted-object";
         EncryptionHttpHelper httpHelper = fakeEncryptionHttpHelper(path);
@@ -65,6 +67,7 @@ public class EncryptedHttpHelperTest {
      * made with a different cipher/mode configured from the cipher/mode on
      * the object will result in an error.
      */
+    @Test(groups = {"unlimited-crypto"})
     public void doesntAllowDifferentCipherForObjectAndConfigInputStream() throws Exception {
         String path = "/user/path/encrypted-object";
         EncryptionHttpHelper httpHelper = fakeEncryptionHttpHelper(path);
@@ -89,7 +92,6 @@ public class EncryptedHttpHelperTest {
      * be configured for one cipher/mode and executes requests in another
      * cipher/mode.
      */
-    @Test(groups = {"unlimited-crypto"})
     private static EncryptionHttpHelper fakeEncryptionHttpHelper(String path)
             throws Exception {
         MantaConnectionContext connectionContext = mock(MantaConnectionContext.class);

--- a/java-manta-client/src/test/java/com/joyent/manta/http/EncryptedHttpHelperTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/http/EncryptedHttpHelperTest.java
@@ -89,6 +89,7 @@ public class EncryptedHttpHelperTest {
      * be configured for one cipher/mode and executes requests in another
      * cipher/mode.
      */
+    @Test(groups = {"strong-crypto"})
     private static EncryptionHttpHelper fakeEncryptionHttpHelper(String path)
             throws Exception {
         MantaConnectionContext connectionContext = mock(MantaConnectionContext.class);


### PR DESCRIPTION
This PR is based off of PR #243 and addresses issue #242. @uxcn: While we would like to be more explicit about the library's requirements, the same effect can be accomplished without changing the external interface.

Using the [null object pattern](https://en.wikipedia.org/wiki/Null_Object_pattern) to allow for construction of illegal ciphers without changing the public interface. Makes minor adjustments to constructor visibility (`private` is now `protected`, could be package-private). 

Tests which use the stronger ciphers have been marked with the ~`strong-crypto`~ `unlimited-crypto` group so they can be skipped in case installing Java Cryptography Extensions is not desired or possible:

~`mvn test -DexcludedGroups=strong-crypto`~
`mvn test -DexcludedGroups=unlimited-crypto`