### PR TITLE
resolve #250

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 All notable changes to this project will be documented in this file.
 This project aims to adhere to [Semantic Versioning](http://semver.org/).
 
+## [x.x.x] - YYYY-MM-DD
+
+ - Resolve issue where
+   [MantaClient.getAsInputStream().close() throws MantaIOException](https://github.com/joyent/java-manta/issues/250)
+   for encrypted objects with trailing HMAC. Infrequently an issue could occur where
+   less bytes than requested were read and the stream was left in a bad state.
+   This would prevent the underlying connection from being returned to the connection pool.
+ - [Exception contexts now include SDK version.](https://github.com/joyent/java-manta/issues/254)
+
 ## [3.1.0] - 2017-06-07
 
 Several related URL encoding bugs have been fixed.  Objects with

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStream.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStream.java
@@ -676,8 +676,8 @@ public class MantaEncryptedObjectInputStream extends MantaObjectInputStream {
                 String msg = "Unable to read HMAC from the end of stream";
                 MantaIOException mioe = new MantaIOException(msg);
                 annotateException(mioe);
-                mioe.setContextValue("backing_stream_class", stream.getClass());
-                mioe.setContextValue("total_hmac_bytes_read", totalBytesRead);
+                mioe.setContextValue("backingStreamClass", stream.getClass());
+                mioe.setContextValue("totalHmacBytesRead", totalBytesRead);
 
                 throw mioe;
             }

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStream.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStream.java
@@ -672,24 +672,6 @@ public class MantaEncryptedObjectInputStream extends MantaObjectInputStream {
             byte[] expected = new byte[this.hmac.getMacSize()];
             int readHmacBytes = super.getBackingStream().read(expected);
 
-            if (plaintextBytesRead == getContentLength()
-                    && plaintextBytesRead + readHmacBytes < super.getContentLength()) {
-                // we read too few bytes for the hmac but there are still more available AND expected
-                while (readHmacBytes < this.hmac.getMacSize()) {
-                    int bytesNeeded = this.hmac.getMacSize() - readHmacBytes;
-                    int bytesRetried = super.getBackingStream().read(expected, readHmacBytes, bytesNeeded);
-
-                    /*
-                     * it is unlikely that we would get EOF out of the previous call to read() but then again
-                     * we just failed to get all 16 bytes on the first read() so might as well be on the safe side
-                     */
-
-                    if (bytesRetried > EOF) {
-                        readHmacBytes += bytesRetried;
-                    }
-                }
-            }
-
             if (super.getBackingStream().read() != EOF) {
                 String msg = "Expecting the end of the stream. However, more "
                         + "bytes were available.";

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStream.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStream.java
@@ -677,7 +677,8 @@ public class MantaEncryptedObjectInputStream extends MantaObjectInputStream {
                 MantaIOException mioe = new MantaIOException(msg);
                 annotateException(mioe);
                 mioe.setContextValue("backingStreamClass", stream.getClass());
-                mioe.setContextValue("totalHmacBytesRead", totalBytesRead);
+                mioe.setContextValue("hmacBytesReadTotal", totalBytesRead);
+                mioe.setContextValue("hmacBytesExpected", hmacSize);
 
                 throw mioe;
             }

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStream.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStream.java
@@ -672,10 +672,6 @@ public class MantaEncryptedObjectInputStream extends MantaObjectInputStream {
             byte[] expected = new byte[this.hmac.getMacSize()];
             int readHmacBytes = super.getBackingStream().read(expected);
 
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Calculated HMAC is: {}", Hex.encodeHexString(checksum));
-            }
-
             if (plaintextBytesRead == getContentLength()
                     && plaintextBytesRead + readHmacBytes < super.getContentLength()) {
                 // we read too few bytes for the hmac but there are still more available AND expected
@@ -694,6 +690,9 @@ public class MantaEncryptedObjectInputStream extends MantaObjectInputStream {
                 throw e;
             }
 
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Calculated HMAC is: {}", Hex.encodeHexString(checksum));
+            }
 
             if (readHmacBytes != this.hmac.getMacSize()) {
                 MantaIOException e = new MantaIOException("The HMAC stored was in the incorrect size");

--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStream.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStream.java
@@ -678,7 +678,15 @@ public class MantaEncryptedObjectInputStream extends MantaObjectInputStream {
                 while (readHmacBytes < this.hmac.getMacSize()) {
                     int bytesNeeded = this.hmac.getMacSize() - readHmacBytes;
                     int bytesRetried = super.getBackingStream().read(expected, readHmacBytes, bytesNeeded);
-                    readHmacBytes += bytesRetried;
+
+                    /*
+                     * it is unlikely that we would get EOF out of the previous call to read() but then again
+                     * we just failed to get all 16 bytes on the first read() so might as well be on the safe side
+                     */
+
+                    if (bytesRetried > EOF) {
+                        readHmacBytes += bytesRetried;
+                    }
                 }
             }
 

--- a/java-manta-client/src/test/java/com/joyent/manta/client/crypto/IncompleteByteReadInputStream.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/crypto/IncompleteByteReadInputStream.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.manta.client.crypto;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * {@link java.io.InputStream} implementation that will always read one byte
+ * less than the length specified in a {@link InputStream#read(byte[], int, int)}
+ * method invocation.
+ *
+ * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @since 3.1.1
+ */
+public class IncompleteByteReadInputStream extends InputStream {
+    private final InputStream wrapped;
+
+    public IncompleteByteReadInputStream(final InputStream wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public int read() throws IOException {
+        return wrapped.read();
+    }
+
+    @Override
+    public int read(final byte[] b) throws IOException {
+        return read(b, 0, b.length);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        if (len > 1 && len - off - 1 > 0) {
+            return wrapped.read(b, off, len - 1);
+        } else {
+            return wrapped.read(b, off, len);
+        }
+    }
+}

--- a/java-manta-client/src/test/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStreamTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStreamTest.java
@@ -618,6 +618,20 @@ public class MantaEncryptedObjectInputStreamTest {
         willValidateIfHmacIsReadInMultipleReads(AesCtrCipherDetails.INSTANCE_256_BIT);
     }
 
+    public void willValidateIfHmacIsReadInMultipleReadsAesCbc128() throws IOException {
+        willValidateIfHmacIsReadInMultipleReads(AesCbcCipherDetails.INSTANCE_128_BIT);
+    }
+
+    @Test(groups = {"unlimited-crypto"})
+    public void willValidateIfHmacIsReadInMultipleReadsAesCbc192() throws IOException {
+        willValidateIfHmacIsReadInMultipleReads(AesCbcCipherDetails.INSTANCE_192_BIT);
+    }
+
+    @Test(groups = {"unlimited-crypto"})
+    public void willValidateIfHmacIsReadInMultipleReadsAesCbc256() throws IOException {
+        willValidateIfHmacIsReadInMultipleReads(AesCbcCipherDetails.INSTANCE_256_BIT);
+    }
+
     /* TEST UTILITY CLASSES */
 
     private static class EncryptedFile {

--- a/java-manta-client/src/test/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStreamTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStreamTest.java
@@ -11,10 +11,13 @@ import com.joyent.manta.client.MantaMetadata;
 import com.joyent.manta.client.MantaObjectInputStream;
 import com.joyent.manta.client.MantaObjectResponse;
 import com.joyent.manta.exception.MantaClientEncryptionCiphertextAuthenticationException;
+import com.joyent.manta.exception.MantaIOException;
 import com.joyent.manta.http.MantaHttpHeaders;
 import com.joyent.manta.http.entity.MantaInputStreamEntity;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.BoundedInputStream;
+import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.conn.EofSensorInputStream;
@@ -32,6 +35,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.RandomAccessFile;
 import java.io.UncheckedIOException;
 import java.net.URISyntaxException;
@@ -570,6 +574,50 @@ public class MantaEncryptedObjectInputStreamTest {
     }
 
 
+
+    public void willErrorIfCiphertextIsMissingHmacAesCbc128() throws IOException {
+        willErrorWhenMissingHMAC(AesCbcCipherDetails.INSTANCE_128_BIT);
+    }
+
+    @Test(groups = {"unlimited-crypto"})
+    public void willErrorIfCiphertextIsMissingHmacAesCbc192() throws IOException {
+        willErrorWhenMissingHMAC(AesCbcCipherDetails.INSTANCE_192_BIT);
+    }
+
+    @Test(groups = {"unlimited-crypto"})
+    public void willErrorIfCiphertextIsMissingHmacAesCbc256() throws IOException {
+        willErrorWhenMissingHMAC(AesCbcCipherDetails.INSTANCE_256_BIT);
+    }
+
+    public void willErrorIfCiphertextIsMissingHmacAesCtr128() throws IOException {
+        willErrorWhenMissingHMAC(AesCtrCipherDetails.INSTANCE_128_BIT);
+    }
+
+    @Test(groups = {"unlimited-crypto"})
+    public void willErrorIfCiphertextIsMissingHmacAesCtr192() throws IOException {
+        willErrorWhenMissingHMAC(AesCtrCipherDetails.INSTANCE_192_BIT);
+    }
+
+    @Test(groups = {"unlimited-crypto"})
+    public void willErrorIfCiphertextIsMissingHmacAesCtr256() throws IOException {
+        willErrorWhenMissingHMAC(AesCtrCipherDetails.INSTANCE_256_BIT);
+    }
+
+
+    public void willValidateIfHmacIsReadInMultipleReadsAesCtr128() throws IOException {
+        willValidateIfHmacIsReadInMultipleReads(AesCtrCipherDetails.INSTANCE_128_BIT);
+    }
+
+    @Test(groups = {"unlimited-crypto"})
+    public void willValidateIfHmacIsReadInMultipleReadsAesCtr192() throws IOException {
+        willValidateIfHmacIsReadInMultipleReads(AesCtrCipherDetails.INSTANCE_192_BIT);
+    }
+
+    @Test(groups = {"unlimited-crypto"})
+    public void willValidateIfHmacIsReadInMultipleReadsAesCtr256() throws IOException {
+        willValidateIfHmacIsReadInMultipleReads(AesCtrCipherDetails.INSTANCE_256_BIT);
+    }
+
     /* TEST UTILITY CLASSES */
 
     private static class EncryptedFile {
@@ -1014,6 +1062,51 @@ public class MantaEncryptedObjectInputStreamTest {
         }
 
         Assert.assertTrue(thrown, "Ciphertext authentication exception wasn't thrown");
+    }
+
+    private void willErrorWhenMissingHMAC(final SupportedCipherDetails cipherDetails) throws IOException {
+        SecretKey key = SecretKeyUtils.generate(cipherDetails);
+        EncryptedFile encryptedFile = encryptedFile(key, cipherDetails, this.plaintextSize);
+        long ciphertextSize = encryptedFile.file.length();
+        int hmacSize = cipherDetails.getAuthenticationTagOrHmacLengthInBytes();
+        long ciphertextSizeWithoutHmac = ciphertextSize - hmacSize;
+
+        boolean thrown = false;
+
+        try (FileInputStream fin = new FileInputStream(encryptedFile.file);
+             BoundedInputStream in = new BoundedInputStream(fin, ciphertextSizeWithoutHmac);
+             MantaEncryptedObjectInputStream min = createEncryptedObjectInputStream(key, in,
+                     ciphertextSize, cipherDetails, encryptedFile.cipher.getIV(),
+                     true, (long)this.plaintextSize)) {
+            // Do a single read to make sure that everything is working
+            Assert.assertNotEquals(min.read(), -1,
+                    "The encrypted stream should not be empty");
+        } catch (MantaIOException e) {
+            if (e.getMessage().startsWith("No HMAC was stored at the end of the stream")) {
+                thrown = true;
+            } else {
+                throw e;
+            }
+        }
+
+        Assert.assertTrue(thrown, "Expected MantaIOException was not thrown");
+    }
+
+    private void willValidateIfHmacIsReadInMultipleReads(final SupportedCipherDetails cipherDetails)
+            throws IOException {
+        SecretKey key = SecretKeyUtils.generate(cipherDetails);
+        EncryptedFile encryptedFile = encryptedFile(key, cipherDetails, this.plaintextSize);
+        long ciphertextSize = encryptedFile.file.length();
+
+        try (FileInputStream fin = new FileInputStream(encryptedFile.file);
+             IncompleteByteReadInputStream ibrin = new IncompleteByteReadInputStream(fin);
+             MantaEncryptedObjectInputStream min = createEncryptedObjectInputStream(key, ibrin,
+                     ciphertextSize, cipherDetails, encryptedFile.cipher.getIV(),
+                     true, (long)this.plaintextSize);
+             OutputStream out = new NullOutputStream()) {
+
+            IOUtils.copy(min, out);
+        }
     }
 
     private EncryptedFile encryptedFile(


### PR DESCRIPTION
Need to add more detail to this PR before it can be merged, but it looks like we weren't checking if we read all the HMAC bytes from the end of the backing stream.

The `readHmacBytes != this.hmac.getMacSize()` check which leads to an exception was moved up while diagnosing the issue but I don't think that's actually necessary.