### PR TITLE
Add SnapLink tests and additional exception context for SnapLink failures

### DIFF
--- a/java-manta-client/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -40,6 +40,8 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
+import org.apache.commons.lang3.exception.ContextedException;
+import org.apache.commons.lang3.exception.ExceptionContext;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
@@ -1472,9 +1474,15 @@ public class MantaClient implements AutoCloseable {
         put.setHeader(HttpHeaders.CONTENT_TYPE, MantaContentTypes.SNAPLINK.getContentType());
         put.setHeader(HttpHeaders.LOCATION, objectPath);
 
-        httpHelper.executeAndCloseRequest(put, HttpStatus.SC_NO_CONTENT,
-                "PUT    {} -> {} response [{}] {} ",
-                objectPath, linkPath);
+        try {
+            httpHelper.executeAndCloseRequest(put, HttpStatus.SC_NO_CONTENT,
+                    "PUT    {} -> {} response [{}] {} ",
+                    objectPath, linkPath);
+        } catch (MantaIOException e) {
+            e.addContextValue("linkPath", linkPath);
+            e.addContextValue("objectPath", objectPath);
+            throw e;
+        }
     }
 
     /**

--- a/java-manta-client/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -40,8 +40,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
-import org.apache.commons.lang3.exception.ContextedException;
-import org.apache.commons.lang3.exception.ExceptionContext;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;

--- a/java-manta-client/src/main/java/com/joyent/manta/util/MantaUtils.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/util/MantaUtils.java
@@ -7,8 +7,8 @@
  */
 package com.joyent.manta.util;
 
-import io.mikael.urlbuilder.util.Encoder;
 import io.mikael.urlbuilder.util.Decoder;
+import io.mikael.urlbuilder.util.Encoder;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
@@ -347,11 +347,11 @@ public class MantaClientIT {
     @Test
     public final void testPutLinkWithPlusInPath() throws IOException {
         final String name = UUID.randomUUID().toString();
-        final String prefix = testPathPrefix + MantaClient.SEPARATOR + "+tmp";
+        final String destPrefix = testPathPrefix + MantaClient.SEPARATOR + "+tmp";
+        mantaClient.putDirectory(destPrefix);
 
-        mantaClient.putDirectory(prefix);
         final String sourcePath = testPathPrefix + name;
-        final String destPath = prefix + MantaClient.SEPARATOR + name;
+        final String destPath = destPrefix + MantaClient.SEPARATOR + name;
 
         mantaClient.put(sourcePath, TEST_DATA);
 

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
@@ -346,34 +346,32 @@ public class MantaClientIT {
 
     @Test
     public final void testPutLinkWithPlusInPathOfDestination() throws IOException {
-        final String destPrefix = testPathPrefix + MantaClient.SEPARATOR + "+tmp";
-        mantaClient.putDirectory(destPrefix);
-
-        final String sourcePath = testPathPrefix + UUID.randomUUID();
-        final String destPath = destPrefix
-                + MantaClient.SEPARATOR + UUID.randomUUID();
-
-        mantaClient.put(sourcePath, TEST_DATA);
-
-        mantaClient.putSnapLink(destPath, sourcePath, null);
-        final String linkContent = mantaClient.getAsString(destPath);
-        Assert.assertEquals(linkContent, TEST_DATA);
+        putLinkWithCharInPathOfDestination('+');
     }
 
     @Test
     public final void testPutLinkWithPlusInPathOfSource() throws IOException {
-        final String sourcePrefix = testPathPrefix + MantaClient.SEPARATOR + "+tmp";
-        mantaClient.putDirectory(sourcePrefix);
+        putLinkWithCharInPathOfSource('+');
+    }
 
-        final String sourcePath = sourcePrefix + MantaClient.SEPARATOR + UUID.randomUUID();
-        final String destPath = testPathPrefix
-                + MantaClient.SEPARATOR + UUID.randomUUID();
+    @Test
+    public final void testPutLinkWithEqualsInPathOfDestination() throws IOException {
+        putLinkWithCharInPathOfDestination('=');
+    }
 
-        mantaClient.put(sourcePath, TEST_DATA);
+    @Test
+    public final void testPutLinkWithEqualsInPathOfSource() throws IOException {
+        putLinkWithCharInPathOfSource('=');
+    }
 
-        mantaClient.putSnapLink(destPath, sourcePath, null);
-        final String linkContent = mantaClient.getAsString(destPath);
-        Assert.assertEquals(linkContent, TEST_DATA);
+    @Test
+    public final void testPutLinkWithAtInPathOfDestination() throws IOException {
+        putLinkWithCharInPathOfDestination('@');
+    }
+
+    @Test
+    public final void testPutLinkWithAtInPathOfSource() throws IOException {
+        putLinkWithCharInPathOfSource('@');
     }
 
     @Test
@@ -645,4 +643,33 @@ public class MantaClientIT {
                 "Last modified date should be null when mtime is null");
     }
 
+    private final void putLinkWithCharInPathOfDestination(final char c) throws IOException {
+        final String destPrefix = testPathPrefix + MantaClient.SEPARATOR + c + "tmp";
+        mantaClient.putDirectory(destPrefix);
+
+        final String sourcePath = testPathPrefix + UUID.randomUUID();
+        final String destPath = destPrefix
+                + MantaClient.SEPARATOR + UUID.randomUUID();
+
+        mantaClient.put(sourcePath, TEST_DATA);
+
+        mantaClient.putSnapLink(destPath, sourcePath, null);
+        final String linkContent = mantaClient.getAsString(destPath);
+        Assert.assertEquals(linkContent, TEST_DATA);
+    }
+
+    public final void putLinkWithCharInPathOfSource(char c) throws IOException {
+        final String sourcePrefix = testPathPrefix + MantaClient.SEPARATOR + c + "tmp";
+        mantaClient.putDirectory(sourcePrefix);
+
+        final String sourcePath = sourcePrefix + MantaClient.SEPARATOR + UUID.randomUUID();
+        final String destPath = testPathPrefix
+                + MantaClient.SEPARATOR + UUID.randomUUID();
+
+        mantaClient.put(sourcePath, TEST_DATA);
+
+        mantaClient.putSnapLink(destPath, sourcePath, null);
+        final String linkContent = mantaClient.getAsString(destPath);
+        Assert.assertEquals(linkContent, TEST_DATA);
+    }
 }

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
@@ -345,6 +345,24 @@ public class MantaClientIT {
     }
 
     @Test
+    public final void testPutLinkWithPlusInPath() throws IOException {
+        final String name = UUID.randomUUID().toString();
+        final String prefix = testPathPrefix + MantaClient.SEPARATOR + "+tmp";
+
+        mantaClient.putDirectory(prefix);
+        final String sourcePath = testPathPrefix + name;
+        final String destPath = prefix + MantaClient.SEPARATOR + name;
+
+        mantaClient.put(sourcePath, TEST_DATA);
+
+        final String link = UUID.randomUUID().toString();
+        mantaClient.putSnapLink(sourcePath + link,
+                destPath + name, null);
+        final String linkContent = mantaClient.getAsString(testPathPrefix + link);
+        Assert.assertEquals(linkContent, TEST_DATA);
+    }
+
+    @Test
     public final void testPutJsonLink() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name + ".json";
@@ -482,6 +500,7 @@ public class MantaClientIT {
     }
 
     @Test(expectedExceptions = MantaObjectException.class)
+    @SuppressWarnings("ReturnValueIgnored")
     public final void testListNotADir() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -494,6 +513,7 @@ public class MantaClientIT {
     }
 
     @Test(expectedExceptions = MantaClientHttpResponseException.class)
+    @SuppressWarnings("ReturnValueIgnored")
     public final void testListNonexistentDir() throws IOException {
         final String doesntExist = String.format("%s/stor/doesnt-exist-%s/",
                 mantaClient.getContext().getMantaHomeDirectory(), UUID.randomUUID());

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
@@ -345,20 +345,34 @@ public class MantaClientIT {
     }
 
     @Test
-    public final void testPutLinkWithPlusInPath() throws IOException {
-        final String name = UUID.randomUUID().toString();
+    public final void testPutLinkWithPlusInPathOfDestination() throws IOException {
         final String destPrefix = testPathPrefix + MantaClient.SEPARATOR + "+tmp";
         mantaClient.putDirectory(destPrefix);
 
-        final String sourcePath = testPathPrefix + name;
-        final String destPath = destPrefix + MantaClient.SEPARATOR + name;
+        final String sourcePath = testPathPrefix + UUID.randomUUID();
+        final String destPath = destPrefix
+                + MantaClient.SEPARATOR + UUID.randomUUID();
 
         mantaClient.put(sourcePath, TEST_DATA);
 
-        final String link = UUID.randomUUID().toString();
-        mantaClient.putSnapLink(sourcePath + link,
-                destPath + name, null);
-        final String linkContent = mantaClient.getAsString(testPathPrefix + link);
+        mantaClient.putSnapLink(destPath, sourcePath, null);
+        final String linkContent = mantaClient.getAsString(destPath);
+        Assert.assertEquals(linkContent, TEST_DATA);
+    }
+
+    @Test
+    public final void testPutLinkWithPlusInPathOfSource() throws IOException {
+        final String sourcePrefix = testPathPrefix + MantaClient.SEPARATOR + "+tmp";
+        mantaClient.putDirectory(sourcePrefix);
+
+        final String sourcePath = sourcePrefix + MantaClient.SEPARATOR + UUID.randomUUID();
+        final String destPath = testPathPrefix
+                + MantaClient.SEPARATOR + UUID.randomUUID();
+
+        mantaClient.put(sourcePath, TEST_DATA);
+
+        mantaClient.putSnapLink(destPath, sourcePath, null);
+        final String linkContent = mantaClient.getAsString(destPath);
         Assert.assertEquals(linkContent, TEST_DATA);
     }
 


### PR DESCRIPTION
This PR adds some minor improvements to tests and exception messages for SnapLinks. These changes were spawned out of the investigation of a bug reporded with the Manta Hadoop Filesystem driver.