### PR TITLE
Added SDK version to all contexted exceptions by default

### DIFF
--- a/java-manta-client/src/main/java/com/joyent/manta/exception/ConfigurationException.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/exception/ConfigurationException.java
@@ -7,6 +7,7 @@
  */
 package com.joyent.manta.exception;
 
+import com.joyent.manta.util.MantaVersion;
 import org.apache.commons.lang3.exception.ContextedRuntimeException;
 
 /**
@@ -17,6 +18,10 @@ import org.apache.commons.lang3.exception.ContextedRuntimeException;
  */
 public class ConfigurationException extends ContextedRuntimeException {
     private static final long serialVersionUID = -192386811586026956L;
+
+    {
+        addContextValue("mantaSdkVersion", MantaVersion.VERSION);
+    }
 
     /**
      * Constructs a new runtime exception with {@code null} as its

--- a/java-manta-client/src/main/java/com/joyent/manta/exception/MantaException.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/exception/MantaException.java
@@ -7,6 +7,7 @@
  */
 package com.joyent.manta.exception;
 
+import com.joyent.manta.util.MantaVersion;
 import org.apache.commons.lang3.exception.ContextedRuntimeException;
 
 /**
@@ -16,6 +17,10 @@ import org.apache.commons.lang3.exception.ContextedRuntimeException;
 public class MantaException extends ContextedRuntimeException {
 
     private static final long serialVersionUID = 146894136987570504L;
+
+    {
+        addContextValue("mantaSdkVersion", MantaVersion.VERSION);
+    }
 
     /**
      * Default constructor.

--- a/java-manta-client/src/main/java/com/joyent/manta/exception/MantaIOException.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/exception/MantaIOException.java
@@ -7,6 +7,7 @@
  */
 package com.joyent.manta.exception;
 
+import com.joyent.manta.util.MantaVersion;
 import org.apache.commons.lang3.exception.DefaultExceptionContext;
 import org.apache.commons.lang3.exception.ExceptionContext;
 import org.apache.commons.lang3.tuple.Pair;
@@ -33,6 +34,7 @@ public class MantaIOException extends IOException implements ExceptionContext {
      */
     public MantaIOException() {
         exceptionContext = new DefaultExceptionContext();
+        addContextValue("mantaSdkVersion", MantaVersion.VERSION);
     }
 
     /**
@@ -45,6 +47,7 @@ public class MantaIOException extends IOException implements ExceptionContext {
     public MantaIOException(final String message) {
         super(message);
         exceptionContext = new DefaultExceptionContext();
+        addContextValue("mantaSdkVersion", MantaVersion.VERSION);
     }
 
     /**
@@ -67,6 +70,7 @@ public class MantaIOException extends IOException implements ExceptionContext {
     public MantaIOException(final String message, final Throwable cause) {
         super(message, cause);
         exceptionContext = new DefaultExceptionContext();
+        addContextValue("mantaSdkVersion", MantaVersion.VERSION);
     }
 
     /**
@@ -84,6 +88,7 @@ public class MantaIOException extends IOException implements ExceptionContext {
     public MantaIOException(final Throwable cause) {
         super(cause);
         exceptionContext = new DefaultExceptionContext();
+        addContextValue("mantaSdkVersion", MantaVersion.VERSION);
     }
 
     /* All code below was copied from org.apache.commons.lang3.exception.ContextedException

--- a/java-manta-client/src/main/java/com/joyent/manta/exception/OnCloseAggregateException.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/exception/OnCloseAggregateException.java
@@ -7,6 +7,7 @@
  */
 package com.joyent.manta.exception;
 
+import com.joyent.manta.util.MantaVersion;
 import org.apache.commons.lang3.exception.ContextedRuntimeException;
 import org.apache.commons.lang3.exception.ExceptionContext;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -22,6 +23,10 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class OnCloseAggregateException extends ContextedRuntimeException {
     private static final long serialVersionUID = -593809028604170624L;
+
+    {
+        addContextValue("mantaSdkVersion", MantaVersion.VERSION);
+    }
 
     /**
      * Count of the number of exceptions that have been aggregated.

--- a/java-manta-client/src/test/java/com/joyent/manta/exception/ConfigurationExceptionTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/exception/ConfigurationExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -12,25 +12,13 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 @Test
-public class OnCloseAggregateExceptionTest {
+public class ConfigurationExceptionTest {
     public void containsMantaVersionContext() {
-        OnCloseAggregateException e = new OnCloseAggregateException();
+        ConfigurationException e = new ConfigurationException();
         String sdkVersion = e.getContextValues("mantaSdkVersion").get(0).toString();
         Assert.assertNotNull(sdkVersion,
                 "SDK version data should be in exception context");
         Assert.assertEquals(sdkVersion, MantaVersion.VERSION,
                 "SDK version should equal value coded");
-    }
-    public void canAggregateExceptions() {
-        String msg = "Exception message";
-        OnCloseAggregateException exception = new OnCloseAggregateException(msg);
-
-        for (int i = 1; i < 11; i++) {
-            Exception inner = new RuntimeException("Exception " + i);
-            exception.aggregateException(inner);
-        }
-
-        int entries = exception.getContextEntries().size();
-        Assert.assertEquals(entries, 11);
     }
 }

--- a/java-manta-client/src/test/java/com/joyent/manta/exception/MantaExceptionTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/exception/MantaExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -12,25 +12,13 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 @Test
-public class OnCloseAggregateExceptionTest {
+public class MantaExceptionTest {
     public void containsMantaVersionContext() {
-        OnCloseAggregateException e = new OnCloseAggregateException();
+        MantaException e = new MantaException();
         String sdkVersion = e.getContextValues("mantaSdkVersion").get(0).toString();
         Assert.assertNotNull(sdkVersion,
                 "SDK version data should be in exception context");
         Assert.assertEquals(sdkVersion, MantaVersion.VERSION,
                 "SDK version should equal value coded");
-    }
-    public void canAggregateExceptions() {
-        String msg = "Exception message";
-        OnCloseAggregateException exception = new OnCloseAggregateException(msg);
-
-        for (int i = 1; i < 11; i++) {
-            Exception inner = new RuntimeException("Exception " + i);
-            exception.aggregateException(inner);
-        }
-
-        int entries = exception.getContextEntries().size();
-        Assert.assertEquals(entries, 11);
     }
 }

--- a/java-manta-client/src/test/java/com/joyent/manta/exception/MantaIOExceptionTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/exception/MantaIOExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -12,25 +12,13 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 @Test
-public class OnCloseAggregateExceptionTest {
+public class MantaIOExceptionTest {
     public void containsMantaVersionContext() {
-        OnCloseAggregateException e = new OnCloseAggregateException();
+        MantaIOException e = new MantaIOException();
         String sdkVersion = e.getContextValues("mantaSdkVersion").get(0).toString();
         Assert.assertNotNull(sdkVersion,
                 "SDK version data should be in exception context");
         Assert.assertEquals(sdkVersion, MantaVersion.VERSION,
                 "SDK version should equal value coded");
-    }
-    public void canAggregateExceptions() {
-        String msg = "Exception message";
-        OnCloseAggregateException exception = new OnCloseAggregateException(msg);
-
-        for (int i = 1; i < 11; i++) {
-            Exception inner = new RuntimeException("Exception " + i);
-            exception.aggregateException(inner);
-        }
-
-        int entries = exception.getContextEntries().size();
-        Assert.assertEquals(entries, 11);
     }
 }


### PR DESCRIPTION
When users submit bugs with stack traces against the SDK, there is no way to know what version of the SDK that they are using by a single glance. This change embeds the SDK version in every Manta exception class that implements`ExceptionContext`.