### PR TITLE
Upgraded Error Prone code checker and fixed new errors / warnings

### DIFF
--- a/java-manta-benchmark/pom.xml
+++ b/java-manta-benchmark/pom.xml
@@ -61,6 +61,19 @@
             <version>${dependency.jmh.version}</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>${dependency.testng.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>junit</artifactId>
+                    <groupId>junit</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>
@@ -86,6 +99,17 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+                <configuration>
+                    <skip>${maven.test.skip}</skip>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/java-manta-benchmark/src/main/java/com/joyent/manta/benchmark/RandomInputStream.java
+++ b/java-manta-benchmark/src/main/java/com/joyent/manta/benchmark/RandomInputStream.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  */
+@SuppressWarnings("InputStreamSlowMultibyteRead")
 public class RandomInputStream extends InputStream {
     /**
      * End of file magic number.

--- a/java-manta-benchmark/src/main/java/com/joyent/manta/benchmark/RandomInputStream.java
+++ b/java-manta-benchmark/src/main/java/com/joyent/manta/benchmark/RandomInputStream.java
@@ -18,7 +18,6 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  */
-@SuppressWarnings("InputStreamSlowMultibyteRead")
 public class RandomInputStream extends InputStream {
     /**
      * End of file magic number.
@@ -50,5 +49,28 @@ public class RandomInputStream extends InputStream {
         }
 
         return RandomUtils.nextInt(0, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public int read(final byte[] b, final int off, final int len) throws IOException {
+        if (count.get() >= maximumBytes) {
+            return EOF;
+        }
+
+        final int bytesToRead;
+
+        if (maximumBytes - count.get() >= len) {
+            bytesToRead = len;
+        } else {
+            bytesToRead = (int)(maximumBytes - count.get());
+        }
+
+        count.addAndGet(bytesToRead);
+
+        final byte[] randomBytes = RandomUtils.nextBytes(bytesToRead);
+
+        System.arraycopy(randomBytes, 0, b, off, bytesToRead);
+
+        return bytesToRead;
     }
 }

--- a/java-manta-benchmark/src/test/java/com/joyent/manta/benchmark/RandomInputStreamTest.java
+++ b/java-manta-benchmark/src/test/java/com/joyent/manta/benchmark/RandomInputStreamTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.manta.benchmark;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+@Test
+public class RandomInputStreamTest {
+    public void canDoSingleByteReadsForOnlyTheExpectedNumberOfBytes() throws IOException {
+        final long expectedBytes = 1119;
+
+        try (RandomInputStream stream = new RandomInputStream(expectedBytes)) {
+            long actualBytesRead = 0;
+
+            for (int readVal = stream.read(); readVal != -1; readVal = stream.read()) {
+                actualBytesRead++;
+            }
+
+            Assert.assertEquals(actualBytesRead, expectedBytes,
+                    "Number bytes actually read didn't match actual bytes read");
+        }
+    }
+
+    public void canDoMultiByteReadsForOnlyTheExpectedNumberOfBytes() throws IOException {
+        final long expectedBytes = 1119;
+
+        try (RandomInputStream stream = new RandomInputStream(expectedBytes)) {
+            long actualBytesRead = 0;
+            int lastReadBytes;
+            byte buffer[] = new byte[16];
+
+            while ((lastReadBytes = stream.read(buffer, 0, 16)) != -1) {
+                actualBytesRead += lastReadBytes;
+            }
+
+            Assert.assertEquals(actualBytesRead, expectedBytes,
+                    "Number bytes actually read didn't match actual bytes read");
+        }
+    }
+}

--- a/java-manta-benchmark/src/test/resources/testng.xml
+++ b/java-manta-benchmark/src/test/resources/testng.xml
@@ -1,0 +1,8 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="Java Manta Client Test Suite" verbose="1">
+    <test name="Benchmark Unit Tests">
+        <classes>
+            <class name="com.joyent.manta.benchmark.RandomInputStreamTest" />
+        </classes>
+    </test>
+</suite>

--- a/java-manta-client/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -2305,7 +2305,8 @@ public class MantaClient implements AutoCloseable {
             throws IOException {
         // This resource is closed using the onClose() lambda below
         final HttpEntity entity = response.getEntity();
-        final Reader reader = new InputStreamReader(entity.getContent());
+        final Reader reader = new InputStreamReader(entity.getContent(),
+                StandardCharsets.UTF_8);
         final BufferedReader br = new BufferedReader(reader);
 
         Stream<String> stream = br.lines().onClose(() -> {

--- a/java-manta-client/src/main/java/com/joyent/manta/client/MantaObjectResponse.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/MantaObjectResponse.java
@@ -262,6 +262,7 @@ public class MantaObjectResponse implements MantaObject {
      *
      * @return the mtime
      */
+    @Override
     public final String getMtime() {
         return mtime;
     }

--- a/java-manta-client/src/main/java/com/joyent/manta/client/StringIteratorHttpContent.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/StringIteratorHttpContent.java
@@ -79,6 +79,7 @@ public class StringIteratorHttpContent implements HttpEntity {
         this.contentType = contentType;
     }
 
+    @Override
     public boolean isRepeatable() {
         return false;
     }

--- a/java-manta-client/src/main/java/com/joyent/manta/client/UriSigner.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/UriSigner.java
@@ -17,6 +17,7 @@ import org.bouncycastle.util.encoders.Base64;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 
 /**
@@ -94,7 +95,8 @@ public class UriSigner {
 
 
         StringBuilder request = new StringBuilder();
-        final byte[] sigBytes = sigText.toString().getBytes();
+        final byte[] sigBytes = sigText.toString().getBytes(
+                StandardCharsets.UTF_8);
         final byte[] signed = signer.get().sign(config.getMantaUser(),
                                                 keyPair, sigBytes);
         final String encoded = new String(Base64.encode(signed), charset);

--- a/java-manta-client/src/main/java/com/joyent/manta/client/multipart/AbstractMultipartManager.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/multipart/AbstractMultipartManager.java
@@ -47,6 +47,7 @@ import java.lang.reflect.Field;
 abstract class AbstractMultipartManager<UPLOAD extends MantaMultipartUpload,
                                         PART extends MantaMultipartUploadPart>
         implements MantaMultipartManager<UPLOAD, PART> {
+    @SuppressWarnings("ReturnValueIgnored")
     @Override
     public void validateThatThereAreSequentialPartNumbers(final UPLOAD upload)
             throws IOException, MantaMultipartException {

--- a/java-manta-client/src/main/java/com/joyent/manta/util/MantaUtils.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/util/MantaUtils.java
@@ -276,6 +276,10 @@ public final class MantaUtils {
             Enum<?> enumValue = (Enum<?>)value;
 
             try {
+                /* In this case, we actually want the subclass of the enum type
+                 * because we are trying to read a property from it via
+                 * reflection. */
+                @SuppressWarnings("GetClassOnEnum")
                 Field field = enumValue.getClass().getField(enumValue.name());
                 Validate.notNull(field,
                         "A non-null field should always be returned. "

--- a/java-manta-client/src/main/java/com/joyent/manta/util/MantaVersion.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/util/MantaVersion.java
@@ -22,7 +22,7 @@ public final class MantaVersion {
     /**
      * Release version of the SDK.
      */
-    public static final String VERSION = "3.1.2-SNAPSHOT";
+    public static final String VERSION = "3.0.0-SNAPSHOT";
 
     /**
      * Minimum version of client-side encryption supported.
@@ -37,5 +37,5 @@ public final class MantaVersion {
     /**
      * Release date of the SDK.
      */
-    public static final Instant DATE = Instant.parse("2017-06-21T16:40:40Z");
+    public static final Instant DATE = Instant.now();
 }

--- a/java-manta-client/src/main/java/com/joyent/manta/util/MantaVersion.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/util/MantaVersion.java
@@ -22,7 +22,7 @@ public final class MantaVersion {
     /**
      * Release version of the SDK.
      */
-    public static final String VERSION = "3.0.0-SNAPSHOT";
+    public static final String VERSION = "3.1.2-SNAPSHOT";
 
     /**
      * Minimum version of client-side encryption supported.
@@ -37,5 +37,5 @@ public final class MantaVersion {
     /**
      * Release date of the SDK.
      */
-    public static final Instant DATE = Instant.now();
+    public static final Instant DATE = Instant.parse("2017-06-21T16:40:40Z");
 }

--- a/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesCtrCipherDetailsTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/crypto/AesCtrCipherDetailsTest.java
@@ -191,8 +191,8 @@ public class AesCtrCipherDetailsTest extends AbstractCipherDetailsTest {
                 byte[] decrypted = Arrays.copyOfRange(out, (int) adjustedPlaintextRange,
                         (int) Math.min(out.length, adjustedPlaintextLength));
 
-                String decryptedText = new String(decrypted);
-                String adjustedText = new String(adjustedPlaintext);
+                String decryptedText = new String(decrypted, StandardCharsets.UTF_8);
+                String adjustedText = new String(adjustedPlaintext, StandardCharsets.UTF_8);
 
                 Assert.assertEquals(adjustedText, decryptedText,
                         "Random read output from ciphertext doesn't match expectation " +

--- a/java-manta-client/src/test/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStreamTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStreamTest.java
@@ -42,6 +42,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -619,9 +620,9 @@ public class MantaEncryptedObjectInputStreamTest {
     }
 
     /*
-    
+
     removing failing tests documented in https://github.com/joyent/java-manta/issues/257
-    
+
     public void willValidateIfHmacIsReadInMultipleReadsAesCbc128() throws IOException {
         willValidateIfHmacIsReadInMultipleReads(AesCbcCipherDetails.INSTANCE_128_BIT);
     }
@@ -635,7 +636,7 @@ public class MantaEncryptedObjectInputStreamTest {
     public void willValidateIfHmacIsReadInMultipleReadsAesCbc256() throws IOException {
         willValidateIfHmacIsReadInMultipleReads(AesCbcCipherDetails.INSTANCE_256_BIT);
     }
-    
+
     */
 
     /* TEST UTILITY CLASSES */
@@ -1025,7 +1026,9 @@ public class MantaEncryptedObjectInputStreamTest {
                             expected, actual);
                 } catch (AssertionError e) {
                     Assert.fail(String.format("%s\nexpected: %s\nactual  : %s",
-                            e.getMessage(), new String(expected), new String(actual)));
+                            e.getMessage(),
+                            new String(expected, StandardCharsets.UTF_8),
+                            new String(actual, StandardCharsets.UTF_8)));
                 }
             }
         }

--- a/java-manta-examples/src/main/java/ClientEncryptionDownloadException.java
+++ b/java-manta-examples/src/main/java/ClientEncryptionDownloadException.java
@@ -13,6 +13,7 @@ import com.joyent.manta.exception.MantaClientEncryptionException;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Scanner;
 
@@ -70,7 +71,7 @@ public class ClientEncryptionDownloadException {
         try (MantaClient downloadClient = new MantaClient(downloadConfig)) {
             // Try to download and decrypt the file, handle the expected exception from an invalid key
             try (InputStream is = downloadClient.getAsInputStream(mantaPath);
-                 Scanner scanner = new Scanner(is)) {
+                 Scanner scanner = new Scanner(is, StandardCharsets.UTF_8.name())) {
 
                 while (scanner.hasNextLine()) {
                     System.out.println(scanner.nextLine());

--- a/java-manta-examples/src/main/java/ClientEncryptionRangeDownload.java
+++ b/java-manta-examples/src/main/java/ClientEncryptionRangeDownload.java
@@ -18,6 +18,7 @@ import com.joyent.manta.http.MantaHttpHeaders;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Scanner;
 
@@ -65,7 +66,7 @@ public class ClientEncryptionRangeDownload {
             headers.setByteRange(0L, 15L);
 
             try (InputStream is = client.getAsInputStream(mantaPath, headers);
-                 Scanner scanner = new Scanner(is)) {
+                 Scanner scanner = new Scanner(is, StandardCharsets.UTF_8.name())) {
 
                 while (scanner.hasNextLine()) {
                     System.out.println(scanner.nextLine());

--- a/java-manta-examples/src/main/java/SimpleClient.java
+++ b/java-manta-examples/src/main/java/SimpleClient.java
@@ -12,6 +12,7 @@ import com.joyent.manta.config.StandardConfigContext;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 
 public class SimpleClient {
@@ -29,7 +30,7 @@ public class SimpleClient {
 
             // Print out every line from file streamed real-time from Manta
             try (InputStream is = client.getAsInputStream(mantaFile);
-                 Scanner scanner = new Scanner(is)) {
+                 Scanner scanner = new Scanner(is, StandardCharsets.UTF_8.name())) {
 
                 while (scanner.hasNextLine()) {
                     System.out.println(scanner.nextLine());

--- a/java-manta-examples/src/main/java/SimpleClientEncryption.java
+++ b/java-manta-examples/src/main/java/SimpleClientEncryption.java
@@ -10,6 +10,7 @@ import com.joyent.manta.client.MantaClient;
 import com.joyent.manta.client.MantaObjectResponse;
 import com.joyent.manta.config.*;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.io.IOException;
 import java.io.InputStream;
@@ -51,7 +52,7 @@ public class SimpleClientEncryption {
 
             // Print out every line from file streamed real-time from Manta
             try (InputStream is = client.getAsInputStream(mantaPath);
-                 Scanner scanner = new Scanner(is)) {
+                 Scanner scanner = new Scanner(is, StandardCharsets.UTF_8.name())) {
 
                 while (scanner.hasNextLine()) {
                     System.out.println(scanner.nextLine());

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
@@ -518,6 +518,7 @@ public class MantaClientIT {
         Assert.assertEquals(3, count.get());
     }
 
+    @SuppressWarnings("ReturnValueIgnored")
     @Test(expectedExceptions = MantaObjectException.class)
     public final void testListNotADir() throws IOException {
         final String name = UUID.randomUUID().toString();
@@ -530,6 +531,7 @@ public class MantaClientIT {
         }
     }
 
+    @SuppressWarnings("ReturnValueIgnored")
     @Test(expectedExceptions = MantaClientHttpResponseException.class)
     public final void testListNonexistentDir() throws IOException {
         final String doesntExist = String.format("%s/stor/doesnt-exist-%s/",

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSeekableByteChannelIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSeekableByteChannelIT.java
@@ -28,6 +28,7 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.channels.NonWritableChannelException;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 /**
@@ -77,7 +78,7 @@ public class MantaClientSeekableByteChannelIT {
         final String path = testPathPrefix + name;
         mantaClient.put(path, TEST_DATA);
 
-        final long expectedSize = TEST_DATA.getBytes().length;
+        final long expectedSize = TEST_DATA.getBytes(StandardCharsets.UTF_8).length;
 
         try (SeekableByteChannel channel = mantaClient.getSeekableByteChannel(path)) {
             Assert.assertEquals(channel.size(), expectedSize,
@@ -92,7 +93,7 @@ public class MantaClientSeekableByteChannelIT {
         mantaClient.put(path, TEST_DATA);
 
         try (SeekableByteChannel channel = mantaClient.getSeekableByteChannel(path)) {
-            String actual = new String(readAllBytes(channel));
+            String actual = new String(readAllBytes(channel), StandardCharsets.UTF_8);
             Assert.assertEquals(actual, TEST_DATA, "Couldn't read the same bytes as written");
         }
     }
@@ -107,7 +108,7 @@ public class MantaClientSeekableByteChannelIT {
         final String expected = TEST_DATA.substring(position);
 
         try (SeekableByteChannel channel = mantaClient.getSeekableByteChannel(path, position)) {
-            String actual = new String(readAllBytes(channel));
+            String actual = new String(readAllBytes(channel), StandardCharsets.UTF_8);
             Assert.assertEquals(actual, expected, "Couldn't read the same bytes as written");
         }
     }
@@ -121,14 +122,15 @@ public class MantaClientSeekableByteChannelIT {
         try (SeekableByteChannel channel = mantaClient.getSeekableByteChannel(path)) {
             ByteBuffer first5Bytes = ByteBuffer.allocate(5);
             channel.read(first5Bytes);
-            String firstPos = new String(first5Bytes.array());
+            String firstPos = new String(first5Bytes.array(), StandardCharsets.UTF_8);
             Assert.assertEquals(firstPos, TEST_DATA.substring(0, 5),
                     "Couldn't read the same bytes as written");
 
             try (SeekableByteChannel channel2 = channel.position(7L)) {
                 ByteBuffer seventhTo12thBytes = ByteBuffer.allocate(5);
                 channel2.read(seventhTo12thBytes);
-                String secondPos = new String(seventhTo12thBytes.array());
+                String secondPos = new String(seventhTo12thBytes.array(),
+                        StandardCharsets.UTF_8);
                 Assert.assertEquals(secondPos, TEST_DATA.substring(7, 12),
                         "Couldn't read the same bytes as written");
             }
@@ -237,7 +239,7 @@ public class MantaClientSeekableByteChannelIT {
         try (SeekableByteChannel channel = mantaClient.getSeekableByteChannel(path);
              SeekableByteChannel position1 = channel.position(positionIndex)) {
 
-            String actual = new String(readAllBytes(position1));
+            String actual = new String(readAllBytes(position1), StandardCharsets.UTF_8);
             Assert.assertEquals(actual, expectedPosition1,
                     "Couldn't read the same bytes as written to specified position");
         }
@@ -255,10 +257,10 @@ public class MantaClientSeekableByteChannelIT {
         try (SeekableByteChannel channel = mantaClient.getSeekableByteChannel(path);
              SeekableByteChannel position1 = channel.position(positionIndex)) {
 
-            String actual = new String(readAllBytes(channel));
+            String actual = new String(readAllBytes(channel), StandardCharsets.UTF_8);
             Assert.assertEquals(actual, TEST_DATA, "Couldn't read the same bytes as written");
 
-            String positionActual = new String(readAllBytes(position1));
+            String positionActual = new String(readAllBytes(position1), StandardCharsets.UTF_8);
             Assert.assertEquals(positionActual, expectedPosition1,
                     "Couldn't read the same bytes as written to specified position");
         }
@@ -280,14 +282,14 @@ public class MantaClientSeekableByteChannelIT {
              SeekableByteChannel position1 = channel.position(position1Index);
              SeekableByteChannel position2 = channel.position(position2Index)) {
 
-            String actual = new String(readAllBytes(channel));
+            String actual = new String(readAllBytes(channel), StandardCharsets.UTF_8);
             Assert.assertEquals(actual, TEST_DATA, "Couldn't read the same bytes as written");
 
-            String position1Actual = new String(readAllBytes(position1));
+            String position1Actual = new String(readAllBytes(position1), StandardCharsets.UTF_8);
             Assert.assertEquals(position1Actual, expectedPosition1,
                     "Couldn't read the same bytes as written to specified position");
 
-            String position2Actual = new String(readAllBytes(position2));
+            String position2Actual = new String(readAllBytes(position2), StandardCharsets.UTF_8);
             Assert.assertEquals(position2Actual, expectedPosition2,
                     "Couldn't read the same bytes as written to specified position");
         }

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSigningIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSigningIT.java
@@ -22,6 +22,7 @@ import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -158,7 +159,7 @@ public class MantaClientSigningIT {
         connection.connect();
 
         try (OutputStreamWriter out = new OutputStreamWriter(
-                connection.getOutputStream())) {
+                connection.getOutputStream(), StandardCharsets.UTF_8)) {
             out.write(TEST_DATA);
         } finally {
             connection.disconnect();

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaObjectOutputStreamIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaObjectOutputStreamIT.java
@@ -23,6 +23,7 @@ import org.testng.annotations.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.UUID;
 
@@ -60,7 +61,7 @@ public class MantaObjectOutputStreamIT {
         MantaObjectOutputStream out = mantaClient.putAsOutputStream(path);
 
         try {
-            out.write(TEST_DATA.getBytes());
+            out.write(TEST_DATA.getBytes(StandardCharsets.UTF_8));
         } finally {
             out.close();
         }
@@ -83,7 +84,7 @@ public class MantaObjectOutputStreamIT {
         MantaObjectOutputStream out = mantaClient.putAsOutputStream(path);
 
         try {
-            out.write(TEST_DATA.getBytes());
+            out.write(TEST_DATA.getBytes(StandardCharsets.UTF_8));
         } finally {
             out.close();
         }

--- a/pom.xml
+++ b/pom.xml
@@ -131,8 +131,8 @@
         <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
 
         <!-- Maven plugin dependency versions -->
-        <maven-plexus-compiler-javac-errorprone.version>2.8.1</maven-plexus-compiler-javac-errorprone.version>
-        <maven-error-prone-core.version>2.0.15</maven-error-prone-core.version>
+        <maven-plexus-compiler-javac-errorprone.version>2.8.2</maven-plexus-compiler-javac-errorprone.version>
+        <maven-error-prone-core.version>2.0.19</maven-error-prone-core.version>
 
         <!-- Dependency versions -->
         <dependency.http-client-signature.version>4.0.3</dependency.http-client-signature.version>

--- a/pom.xml
+++ b/pom.xml
@@ -258,6 +258,7 @@
                         <arg>-Xdiags:verbose</arg>
                         <arg>-Xlint:all</arg>
                     </compilerArgs>
+                    <showWarnings>true</showWarnings>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
This PR upgrades [Error Prone](https://github.com/google/error-prone) and fixes errors / warns that are thrown in the latest version.

The impetus for this change is because IntelliJ went ahead and upgraded its version of Error Prone, so my IDE builds often fail unless we make these changes.