### PR TITLE
reduce durability test level: 4-->3

### DIFF
--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
@@ -219,13 +219,13 @@ public class MantaClientIT {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
         final MantaHttpHeaders headers = new MantaHttpHeaders();
-        headers.setDurabilityLevel(4);
+        headers.setDurabilityLevel(3);
 
         mantaClient.put(path, TEST_DATA, headers);
         try (final MantaObjectInputStream gotObject = mantaClient.getAsInputStream(path)) {
             final String data = IOUtils.toString(gotObject, Charset.defaultCharset());
             Assert.assertEquals(data, TEST_DATA);
-            Assert.assertEquals("4", gotObject.getHttpHeaders().getFirstHeaderStringValue("durability-level"));
+            Assert.assertEquals("3", gotObject.getHttpHeaders().getFirstHeaderStringValue("durability-level"));
             mantaClient.delete(gotObject.getPath());
         }
 

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaHttpHeadersIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaHttpHeadersIT.java
@@ -240,7 +240,7 @@ public class MantaHttpHeadersIT {
 
     @Test
     public void canSetDurability() throws IOException {
-        final int durability = 4;
+        final int durability = 3;
         final MantaHttpHeaders headers = new MantaHttpHeaders();
         headers.setDurabilityLevel(durability);
 


### PR DESCRIPTION
A smaller number lowers the burden for staging/test manta instances to
support a passing integration test run.