### PR TITLE
enhancement/connection-pool-TTL-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ left are overridden by values on the right.
 | false                                | manta.no_auth                      | MANTA_NO_AUTH                  |
 | false                                | manta.disable_native_sigs          | MANTA_NO_NATIVE_SIGS           |
 | 10000                                | manta.tcp_socket_timeout           | MANTA_TCP_SOCKET_TIMEOUT       |
+| -1                                   | manta.connection_pool_ttl          | MANTA_CONNECTION_POOL_TTL      |
 | true                                 | manta.verify_uploads               | MANTA_VERIFY_UPLOADS           |
 | 16384                                | manta.upload_buffer_size           | MANTA_UPLOAD_BUFFER_SIZE       |
 | false                                | manta.client_encryption            | MANTA_CLIENT_ENCRYPTION        |
@@ -118,6 +119,8 @@ only really useful when you are running the library as part of a Manta job.
 When set to true, this disables the use of native code libraries for cryptography.
 * `manta.tcp_socket_timeout` (**MANTA_TCP_SOCKET_TIMEOUT**)
 Time in milliseconds to wait for TCP socket's blocking operations - zero means wait forever.
+* `manta.connection_pool_ttl` (**MANTA_CONNECTION_POOL_TTL**)
+TODO: MORE STUFF
 * `manta.verify_uploads` (**MANTA_VERIFY_UPLOADS**)
 When set to true, the client calculates a MD5 checksum of the file being uploaded
 to Manta and then checks it against the result returned by Manta.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ When set to true, this disables the use of native code libraries for cryptograph
 * `manta.tcp_socket_timeout` (**MANTA_TCP_SOCKET_TIMEOUT**)
 Time in milliseconds to wait for TCP socket's blocking operations - zero means wait forever.
 * `manta.connection_pool_ttl` (**MANTA_CONNECTION_POOL_TTL**)
-TODO: MORE STUFF
+Time in seconds to keep persistent connections in the connection pool, `-1` means reuse connections indefinitely.
 * `manta.verify_uploads` (**MANTA_VERIFY_UPLOADS**)
 When set to true, the client calculates a MD5 checksum of the file being uploaded
 to Manta and then checks it against the result returned by Manta.

--- a/java-manta-client/src/main/java/com/joyent/manta/config/BaseChainedConfigContext.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/config/BaseChainedConfigContext.java
@@ -95,6 +95,11 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
     private Integer tcpSocketTimeout;
 
     /**
+     * TODO: copy and edit
+     */
+    private Integer connectionPoolTTLInSeconds;
+
+    /**
      * Flag indicating if we verify the uploaded file's checksum against the
      * server's checksum (MD5).
      */
@@ -253,6 +258,11 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
     }
 
     @Override
+    public Integer getConnectionPoolTTLInSeconds() {
+        return connectionPoolTTLInSeconds;
+    }
+
+    @Override
     public Boolean verifyUploads() {
         return verifyUploads;
     }
@@ -389,6 +399,10 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
             this.tcpSocketTimeout = context.getTcpSocketTimeout();
         }
 
+        if (context.getConnectionPoolTTLInSeconds() != null) {
+            this.connectionPoolTTLInSeconds = context.getConnectionPoolTTLInSeconds();
+        }
+
         if (context.verifyUploads() != null) {
             this.verifyUploads = context.verifyUploads();
         }
@@ -487,6 +501,10 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
 
         if (this.tcpSocketTimeout == null) {
             this.tcpSocketTimeout = context.getTcpSocketTimeout();
+        }
+
+        if (this.connectionPoolTTLInSeconds == null) {
+            this.connectionPoolTTLInSeconds = context.getConnectionPoolTTLInSeconds();
         }
 
         if (this.verifyUploads == null) {
@@ -653,6 +671,13 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
     }
 
     @Override
+    public BaseChainedConfigContext setConnectionPoolTTLInSeconds(Integer connectionPoolTTLInSeconds) {
+        this.connectionPoolTTLInSeconds = connectionPoolTTLInSeconds;
+
+        return this;
+    }
+
+    @Override
     public BaseChainedConfigContext setVerifyUploads(final Boolean verify) {
         this.verifyUploads = verify;
 
@@ -751,6 +776,7 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
                 && Objects.equals(noAuth, that.noAuth)
                 && Objects.equals(disableNativeSignatures, that.disableNativeSignatures)
                 && Objects.equals(tcpSocketTimeout, that.tcpSocketTimeout)
+                && Objects.equals(connectionPoolTTLInSeconds, that.connectionPoolTTLInSeconds)
                 && Objects.equals(verifyUploads, that.verifyUploads)
                 && Objects.equals(uploadBufferSize, that.uploadBufferSize)
                 && Objects.equals(clientEncryptionEnabled, that.clientEncryptionEnabled)
@@ -767,7 +793,7 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
         return Objects.hash(mantaURL, account, mantaKeyId, mantaKeyPath,
                 timeout, retries, maxConnections, privateKeyContent, password,
                 httpBufferSize, httpsProtocols, httpsCipherSuites, noAuth,
-                disableNativeSignatures, tcpSocketTimeout,
+                disableNativeSignatures, tcpSocketTimeout, connectionPoolTTLInSeconds,
                 verifyUploads, uploadBufferSize,
                 clientEncryptionEnabled, encryptionKeyId,
                 encryptionAlgorithm, permitUnencryptedDownloads,

--- a/java-manta-client/src/main/java/com/joyent/manta/config/BaseChainedConfigContext.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/config/BaseChainedConfigContext.java
@@ -95,7 +95,7 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
     private Integer tcpSocketTimeout;
 
     /**
-     * TODO: copy and edit
+     * Time in seconds to keep persistent connections in the connection pool.
      */
     private Integer connectionPoolTTLInSeconds;
 

--- a/java-manta-client/src/main/java/com/joyent/manta/config/ConfigContext.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/config/ConfigContext.java
@@ -110,6 +110,12 @@ public interface ConfigContext {
     Integer getTcpSocketTimeout();
 
     /**
+     * @see org.apache.http. PoolingClient
+     * @return time in seconds to hold on to connections in the connection pool
+     */
+    Integer getConnectionPoolTTLInSeconds();
+
+    /**
      * @return true when we verify the uploaded file's checksum against the
      *         server's checksum (MD5)
      */
@@ -200,6 +206,7 @@ public interface ConfigContext {
         sb.append(", noAuth=").append(context.noAuth());
         sb.append(", disableNativeSignatures=").append(context.disableNativeSignatures());
         sb.append(", tcpSocketTimeout=").append(context.getTcpSocketTimeout());
+        sb.append(", connectionPoolTTLInSeconds=").append(context.getConnectionPoolTTLInSeconds());
         sb.append(", verifyUploads=").append(context.verifyUploads());
         sb.append(", uploadBufferSize=").append(context.getUploadBufferSize());
         sb.append(", clientEncryptionEnabled=").append(context.isClientEncryptionEnabled());
@@ -247,6 +254,11 @@ public interface ConfigContext {
 
         if (config.getTimeout() != null && config.getTimeout() < 0) {
             failureMessages.add("Manta timeout must be 0 or greater");
+        }
+
+        if (!(config.getConnectionPoolTTLInSeconds() == -1
+                || 0 < config.getConnectionPoolTTLInSeconds())) {
+            failureMessages.add("Connection Pool TTL must be -1 or greater than 0");
         }
 
         if (config.noAuth() != null && !config.noAuth()) {
@@ -431,6 +443,9 @@ public interface ConfigContext {
             case MapConfigContext.MANTA_MAX_CONNS_KEY:
             case EnvVarConfigContext.MANTA_MAX_CONNS_ENV_KEY:
                 return config.getMaximumConnections();
+            case MapConfigContext.MANTA_CONNECTION_POOL_TTL_KEY:
+            case EnvVarConfigContext.MANTA_CONNECTION_POOL_TTL_ENV_KEY:
+                return config.getConnectionPoolTTLInSeconds();
             case MapConfigContext.MANTA_PRIVATE_KEY_CONTENT_KEY:
             case EnvVarConfigContext.MANTA_PRIVATE_KEY_CONTENT_ENV_KEY:
                 return config.getPrivateKeyContent();

--- a/java-manta-client/src/main/java/com/joyent/manta/config/ConfigContext.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/config/ConfigContext.java
@@ -110,8 +110,8 @@ public interface ConfigContext {
     Integer getTcpSocketTimeout();
 
     /**
-     * @see org.apache.http. PoolingClient
-     * @return time in seconds to hold on to connections in the connection pool
+     * @see org.apache.http.impl.conn.PoolingHttpClientConnectionManager
+     * @return Time in seconds to keep persistent connections in the connection pool.
      */
     Integer getConnectionPoolTTLInSeconds();
 

--- a/java-manta-client/src/main/java/com/joyent/manta/config/ConfigContextMBean.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/config/ConfigContextMBean.java
@@ -120,6 +120,10 @@ public class ConfigContextMBean implements DynamicMBean {
                         Integer.class.getName(),
                         "Time in milliseconds to wait to see if a TCP socket has timed out",
                         true, this.isSettable, false),
+                new MBeanAttributeInfo(MapConfigContext.MANTA_CONNECTION_POOL_TTL_KEY,
+                        Integer.class.getName(),
+                        "", // TODO: another slightly different description
+                        true, this.isSettable, false),
                 new MBeanAttributeInfo(MapConfigContext.MANTA_VERIFY_UPLOADS_KEY,
                         Boolean.class.getName(),
                         "Flag indicating the checksum verification of uploaded files is enabled",

--- a/java-manta-client/src/main/java/com/joyent/manta/config/ConfigContextMBean.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/config/ConfigContextMBean.java
@@ -122,7 +122,7 @@ public class ConfigContextMBean implements DynamicMBean {
                         true, this.isSettable, false),
                 new MBeanAttributeInfo(MapConfigContext.MANTA_CONNECTION_POOL_TTL_KEY,
                         Integer.class.getName(),
-                        "", // TODO: another slightly different description
+                        "Time in seconds to keep persistent connections in the connection pool.",
                         true, this.isSettable, false),
                 new MBeanAttributeInfo(MapConfigContext.MANTA_VERIFY_UPLOADS_KEY,
                         Boolean.class.getName(),

--- a/java-manta-client/src/main/java/com/joyent/manta/config/DefaultsConfigContext.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/config/DefaultsConfigContext.java
@@ -88,7 +88,8 @@ public class DefaultsConfigContext implements ConfigContext {
     public static final int DEFAULT_TCP_SOCKET_TIMEOUT = 10 * 1000;
 
     /**
-     * TODO: find a proper default TTL
+     * Time in seconds to keep persistent connections in the connection pool.
+     * -1 means indefinitely.
      */
     public static final int DEFAULT_CONNECTION_POOL_TTL = -1;
 

--- a/java-manta-client/src/main/java/com/joyent/manta/config/DefaultsConfigContext.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/config/DefaultsConfigContext.java
@@ -88,6 +88,11 @@ public class DefaultsConfigContext implements ConfigContext {
     public static final int DEFAULT_TCP_SOCKET_TIMEOUT = 10 * 1000;
 
     /**
+     * TODO: find a proper default TTL
+     */
+    public static final int DEFAULT_CONNECTION_POOL_TTL = -1;
+
+    /**
      * Default size of pre-streaming upload buffer (16K).
      */
     public static final int DEFAULT_UPLOAD_BUFFER_SIZE = 16_384;
@@ -185,6 +190,11 @@ public class DefaultsConfigContext implements ConfigContext {
     @Override
     public Integer getTcpSocketTimeout() {
         return DEFAULT_TCP_SOCKET_TIMEOUT;
+    }
+
+    @Override
+    public Integer getConnectionPoolTTLInSeconds() {
+        return DEFAULT_CONNECTION_POOL_TTL;
     }
 
     @Override

--- a/java-manta-client/src/main/java/com/joyent/manta/config/EnvVarConfigContext.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/config/EnvVarConfigContext.java
@@ -95,7 +95,7 @@ public class EnvVarConfigContext implements ConfigContext {
     public static final String MANTA_TCP_SOCKET_TIMEOUT_ENV_KEY = "MANTA_TCP_SOCKET_TIMEOUT";
 
     /**
-     * Property key for looking up connection pool TTLs in seconds.
+     * Property key for looking up connection pool TTL.
      */
     public static final String MANTA_CONNECTION_POOL_TTL_ENV_KEY = "MANTA_CONNECTION_POOL_TTL";
 
@@ -169,7 +169,6 @@ public class EnvVarConfigContext implements ConfigContext {
             MANTA_ENCRYPTION_PRIVATE_KEY_PATH_ENV_KEY,
             MANTA_ENCRYPTION_PRIVATE_KEY_BYTES_BASE64_ENV_KEY
     };
-
 
     static {
         // Sorts the properties so that we can do a binary search on them if needed
@@ -284,9 +283,9 @@ public class EnvVarConfigContext implements ConfigContext {
 
     @Override
     public Integer getConnectionPoolTTLInSeconds() {
-        String ttlString = getEnv(MANTA_CONNECTION_POOL_TTL_ENV_KEY);
+        String ttlValue = getEnv(MANTA_CONNECTION_POOL_TTL_ENV_KEY);
 
-        return MantaUtils.parseIntegerOrNull(ttlString);
+        return MantaUtils.parseIntegerOrNull(ttlValue);
     }
 
     @Override

--- a/java-manta-client/src/main/java/com/joyent/manta/config/EnvVarConfigContext.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/config/EnvVarConfigContext.java
@@ -95,6 +95,11 @@ public class EnvVarConfigContext implements ConfigContext {
     public static final String MANTA_TCP_SOCKET_TIMEOUT_ENV_KEY = "MANTA_TCP_SOCKET_TIMEOUT";
 
     /**
+     * Property key for looking up connection pool TTLs in seconds.
+     */
+    public static final String MANTA_CONNECTION_POOL_TTL_ENV_KEY = "MANTA_CONNECTION_POOL_TTL";
+
+    /**
      * Environment variable for enabling the checksum verification of uploaded files.
      */
     public static final String MANTA_VERIFY_UPLOADS_ENV_KEY = "MANTA_VERIFY_UPLOADS";
@@ -154,6 +159,7 @@ public class EnvVarConfigContext implements ConfigContext {
             MANTA_HTTPS_PROTOCOLS_ENV_KEY, MANTA_HTTPS_CIPHERS_ENV_KEY,
             MANTA_NO_AUTH_ENV_KEY, MANTA_NO_NATIVE_SIGS_ENV_KEY,
             MANTA_TCP_SOCKET_TIMEOUT_ENV_KEY,
+            MANTA_CONNECTION_POOL_TTL_ENV_KEY,
             MANTA_VERIFY_UPLOADS_ENV_KEY,
             MANTA_UPLOAD_BUFFER_SIZE_ENV_KEY,
             MANTA_CLIENT_ENCRYPTION_ENABLED_ENV_KEY,
@@ -163,6 +169,7 @@ public class EnvVarConfigContext implements ConfigContext {
             MANTA_ENCRYPTION_PRIVATE_KEY_PATH_ENV_KEY,
             MANTA_ENCRYPTION_PRIVATE_KEY_BYTES_BASE64_ENV_KEY
     };
+
 
     static {
         // Sorts the properties so that we can do a binary search on them if needed
@@ -273,6 +280,13 @@ public class EnvVarConfigContext implements ConfigContext {
         String timeoutString = getEnv(MANTA_TCP_SOCKET_TIMEOUT_ENV_KEY);
 
         return MantaUtils.parseIntegerOrNull(timeoutString);
+    }
+
+    @Override
+    public Integer getConnectionPoolTTLInSeconds() {
+        String ttlString = getEnv(MANTA_CONNECTION_POOL_TTL_ENV_KEY);
+
+        return MantaUtils.parseIntegerOrNull(ttlString);
     }
 
     @Override

--- a/java-manta-client/src/main/java/com/joyent/manta/config/MapConfigContext.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/config/MapConfigContext.java
@@ -98,6 +98,11 @@ public class MapConfigContext implements ConfigContext {
     public static final String MANTA_TCP_SOCKET_TIMEOUT_KEY = "manta.tcp_socket_timeout";
 
     /**
+     * Property key for looking up the connection pool TTL in seconds.
+     */
+    public static final String MANTA_CONNECTION_POOL_TTL_KEY = "manta.connection_pool_ttl";
+
+    /**
      * Property key for enabling the checksum verification of uploaded files.
      */
     public static final String MANTA_VERIFY_UPLOADS_KEY = "manta.verify_uploads";
@@ -166,6 +171,7 @@ public class MapConfigContext implements ConfigContext {
             MANTA_HTTPS_PROTOCOLS_KEY, MANTA_HTTPS_CIPHERS_KEY,
             MANTA_NO_AUTH_KEY, MANTA_NO_NATIVE_SIGS_KEY,
             MANTA_TCP_SOCKET_TIMEOUT_KEY,
+            MANTA_CONNECTION_POOL_TTL_KEY,
             MANTA_VERIFY_UPLOADS_KEY,
             MANTA_UPLOAD_BUFFER_SIZE_KEY,
             MANTA_CLIENT_ENCRYPTION_ENABLED_KEY,
@@ -326,6 +332,17 @@ public class MapConfigContext implements ConfigContext {
         }
 
         return MantaUtils.parseIntegerOrNull(backingMap.get(MANTA_TCP_SOCKET_TIMEOUT_ENV_KEY));
+    }
+
+    @Override
+    public Integer getConnectionPoolTTLInSeconds() {
+        Integer mapValue = MantaUtils.parseIntegerOrNull(backingMap.get(MANTA_CONNECTION_POOL_TTL_KEY));
+
+        if (mapValue != null) {
+            return mapValue;
+        }
+
+        return MantaUtils.parseIntegerOrNull(backingMap.get(MANTA_CONNECTION_POOL_TTL_ENV_KEY));
     }
 
     @Override

--- a/java-manta-client/src/main/java/com/joyent/manta/config/MapConfigContext.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/config/MapConfigContext.java
@@ -98,7 +98,7 @@ public class MapConfigContext implements ConfigContext {
     public static final String MANTA_TCP_SOCKET_TIMEOUT_KEY = "manta.tcp_socket_timeout";
 
     /**
-     * Property key for looking up the connection pool TTL in seconds.
+     * Property key for looking up the connection pool TTL.
      */
     public static final String MANTA_CONNECTION_POOL_TTL_KEY = "manta.connection_pool_ttl";
 

--- a/java-manta-client/src/main/java/com/joyent/manta/config/SettableConfigContext.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/config/SettableConfigContext.java
@@ -131,10 +131,18 @@ public interface SettableConfigContext<T> extends ConfigContext {
      * Sets the time in milliseconds to wait to see if a TCP socket has timed out.
      *
      * @see java.net.SocketOptions#SO_TIMEOUT
-     * @param tcpSocketTimeout time in milliseconds to cache HTTP signature headers
+     * @param tcpSocketTimeout time in milliseconds TODO: fix this thing
      * @return the current instance of {@link T}
      */
     T setTcpSocketTimeout(Integer tcpSocketTimeout);
+
+    /**
+     * Sets the time in seconds to hold on to DNS-resolved connections.
+     * TODO: poolingblah class
+     * @param ttlTimeout time in seconds to keep connections from DNS resolution
+     * @return the current instance of {@link T}
+     */
+    T setConnectionPoolTTLInSeconds(Integer ttlTimeout);
 
     /**
      * Sets if we verify the uploaded file's checksum against the server's
@@ -290,6 +298,9 @@ public interface SettableConfigContext<T> extends ConfigContext {
             case MapConfigContext.MANTA_TCP_SOCKET_TIMEOUT_KEY:
             case EnvVarConfigContext.MANTA_TCP_SOCKET_TIMEOUT_ENV_KEY:
                 config.setTcpSocketTimeout(MantaUtils.parseIntegerOrNull(value));
+            case MapConfigContext.MANTA_CONNECTION_POOL_TTL_KEY:
+            case EnvVarConfigContext.MANTA_CONNECTION_POOL_TTL_ENV_KEY:
+                config.setConnectionPoolTTLInSeconds(MantaUtils.parseIntegerOrNull(value));
                 break;
             case MapConfigContext.MANTA_CLIENT_ENCRYPTION_ENABLED_KEY:
             case EnvVarConfigContext.MANTA_CLIENT_ENCRYPTION_ENABLED_ENV_KEY:

--- a/java-manta-client/src/main/java/com/joyent/manta/config/SettableConfigContext.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/config/SettableConfigContext.java
@@ -131,18 +131,18 @@ public interface SettableConfigContext<T> extends ConfigContext {
      * Sets the time in milliseconds to wait to see if a TCP socket has timed out.
      *
      * @see java.net.SocketOptions#SO_TIMEOUT
-     * @param tcpSocketTimeout time in milliseconds TODO: fix this thing
+     * @param tcpSocketTimeout time in milliseconds to wait to see if a TCP socket has timed out
      * @return the current instance of {@link T}
      */
     T setTcpSocketTimeout(Integer tcpSocketTimeout);
 
     /**
-     * Sets the time in seconds to hold on to DNS-resolved connections.
-     * TODO: poolingblah class
+     * Sets the time in seconds to keep persistent connections in the connection pool.
+     *
      * @param ttlTimeout time in seconds to keep connections from DNS resolution
      * @return the current instance of {@link T}
      */
-    T setConnectionPoolTTLInSeconds(Integer ttlTimeout);
+    T setConnectionPoolTTLInSeconds(Integer connectionPoolTTLInSeconds);
 
     /**
      * Sets if we verify the uploaded file's checksum against the server's


### PR DESCRIPTION
Adding a configuration parameter for indicating how long to keep around a persistent connections. The current behavior is to omit the parameter which results in connections being held open indefinitely. We may decide on a different default but we'll need to include notes about the performance implications of changing this value.