### PR TITLE
Fix MD5 mismatch request ID missing

### DIFF
--- a/java-manta-client/src/main/java/com/joyent/manta/client/crypto/EncryptingEntity.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/crypto/EncryptingEntity.java
@@ -197,7 +197,11 @@ public class EncryptingEntity implements HttpEntity {
             InputStream contentStream = getContent();
             bytesCopied = IOUtils.copy(contentStream, out, bufferSize);
             out.flush();
-            IOUtils.closeQuietly(contentStream);
+            try {
+                contentStream.close();
+            } catch (IOException e) {
+                LOGGER.error("Failed to close content stream in EncryptingEntity.", e);
+            }
         }
 
         /* If we don't know the length of the underlying content stream, we

--- a/java-manta-client/src/main/java/com/joyent/manta/exception/MantaChecksumFailedException.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/exception/MantaChecksumFailedException.java
@@ -7,6 +7,11 @@
  */
 package com.joyent.manta.exception;
 
+import com.joyent.manta.http.HttpHelper;
+import com.joyent.manta.http.MantaHttpHeaders;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+
 /**
  * Exception thrown when the checksum for a file that is being uploaded doesn't
  * match the server-side generated checksum.
@@ -65,4 +70,10 @@ public class MantaChecksumFailedException extends MantaIOException {
     public MantaChecksumFailedException(final Throwable cause) {
         super(cause);
     }
+
+    public MantaChecksumFailedException(final String message, final HttpRequest request, final HttpResponse response) {
+        super(message);
+        HttpHelper.annotateContextedException(this, request, response);
+    }
+
 }

--- a/java-manta-client/src/main/java/com/joyent/manta/exception/MantaChecksumFailedException.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/exception/MantaChecksumFailedException.java
@@ -8,7 +8,6 @@
 package com.joyent.manta.exception;
 
 import com.joyent.manta.http.HttpHelper;
-import com.joyent.manta.http.MantaHttpHeaders;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 
@@ -71,6 +70,15 @@ public class MantaChecksumFailedException extends MantaIOException {
         super(cause);
     }
 
+    /**
+     * Builds a client exception object that is annotated with all of the
+     * relevant request and response debug information.
+     *
+     * @param message  The detail message (which is saved for later retrieval
+     *                 by the {@link #getMessage()} method)
+     * @param request  HTTP request object
+     * @param response HTTP response object
+     */
     public MantaChecksumFailedException(final String message, final HttpRequest request, final HttpResponse response) {
         super(message);
         HttpHelper.annotateContextedException(this, request, response);

--- a/java-manta-client/src/main/java/com/joyent/manta/http/StandardHttpHelper.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/http/StandardHttpHelper.java
@@ -208,6 +208,10 @@ public class StandardHttpHelper implements HttpHelper {
                 throw new MantaClientHttpResponseException(put, response,
                         put.getURI().getPath());
             }
+
+            if (validateUploadsEnabled()) {
+                validateChecksum(md5DigestedEntity, obj.getMd5Bytes(), put, response);
+            }
         }
 
         /* We set the content type on the result object from the entity
@@ -218,9 +222,6 @@ public class StandardHttpHelper implements HttpHelper {
             obj.setContentType(entity.getContentType().getValue());
         }
 
-        if (validateUploadsEnabled()) {
-            validateChecksum(md5DigestedEntity, obj.getMd5Bytes());
-        }
 
         return obj;
     }
@@ -343,7 +344,9 @@ public class StandardHttpHelper implements HttpHelper {
      * @throws MantaChecksumFailedException thrown if the MD5 values do not match
      */
     protected static void validateChecksum(final DigestedEntity entity,
-                                           final byte[] serverMd5)
+                                           final byte[] serverMd5,
+                                           final HttpRequest request,
+                                           final HttpResponse response)
             throws MantaChecksumFailedException {
         if (entity == null) {
             return;
@@ -358,9 +361,8 @@ public class StandardHttpHelper implements HttpHelper {
         final boolean areMd5sTheSame = Arrays.equals(serverMd5, clientMd5);
 
         if (!areMd5sTheSame) {
-            String msg = "Client calculated MD5 and server calculated "
-                    + "MD5 do not match";
-            MantaChecksumFailedException e = new MantaChecksumFailedException(msg);
+            String msg = "Client calculated MD5 and server calculated MD5 do not match";
+            MantaChecksumFailedException e = new MantaChecksumFailedException(msg, request, response);
             e.setContextValue("serverMd5", MantaUtils.byteArrayAsHexString(serverMd5));
             e.setContextValue("clientMd5", MantaUtils.byteArrayAsHexString(clientMd5));
 

--- a/java-manta-client/src/main/java/com/joyent/manta/http/StandardHttpHelper.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/http/StandardHttpHelper.java
@@ -342,6 +342,8 @@ public class StandardHttpHelper implements HttpHelper {
      *
      * @param entity null or the entity object
      * @param serverMd5 service side computed MD5 value
+     * @param request HTTP request object
+     * @param response HTTP response object
      * @throws MantaChecksumFailedException thrown if the MD5 values do not match
      */
     protected static void validateChecksum(final DigestedEntity entity,

--- a/java-manta-client/src/main/java/com/joyent/manta/http/StandardHttpHelper.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/http/StandardHttpHelper.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
+import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;

--- a/java-manta-client/src/test/java/com/joyent/manta/exception/MantaChecksumFailedExceptionTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/exception/MantaChecksumFailedExceptionTest.java
@@ -1,0 +1,32 @@
+package com.joyent.manta.exception;
+
+import com.joyent.manta.util.MantaVersion;
+import org.apache.http.HttpRequest;
+import org.apache.http.client.methods.HttpPut;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Created by tomascelaya on 6/28/17.
+ */
+public class MantaChecksumFailedExceptionTest {
+
+    @Test
+    public void containsExpectedFields() throws URISyntaxException {
+        HttpRequest request = new HttpPut(new URI("http://test.manta.io/account/file"));
+
+
+        MantaChecksumFailedException e = new MantaChecksumFailedException();
+        String sdkVersion = e.getContextValues("mantaSdkVersion").get(0).toString();
+        Assert.assertNotNull(sdkVersion,
+                "SDK version data should be in exception context");
+        Assert.assertEquals(sdkVersion, MantaVersion.VERSION,
+                "SDK version should equal value coded");
+    }
+
+
+
+}

--- a/java-manta-client/src/test/java/com/joyent/manta/exception/MantaChecksumFailedExceptionTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/exception/MantaChecksumFailedExceptionTest.java
@@ -1,13 +1,19 @@
 package com.joyent.manta.exception;
 
+import com.joyent.manta.http.MantaHttpHeaders;
 import com.joyent.manta.util.MantaVersion;
-import org.apache.http.HttpRequest;
+import org.apache.http.*;
 import org.apache.http.client.methods.HttpPut;
+import org.apache.http.impl.DefaultHttpResponseFactory;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.http.protocol.HTTP;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.UUID;
 
 /**
  * Created by tomascelaya on 6/28/17.
@@ -16,10 +22,22 @@ public class MantaChecksumFailedExceptionTest {
 
     @Test
     public void containsExpectedFields() throws URISyntaxException {
-        HttpRequest request = new HttpPut(new URI("http://test.manta.io/account/file"));
+        String dummyRequestId = UUID.randomUUID().toString();
+        String dummyUri = "http://test.manta.io/account/file";
 
+        HttpRequest request = new HttpPut(new URI(dummyUri));
+        HttpResponse response = DefaultHttpResponseFactory.INSTANCE.newHttpResponse(
+                new BasicStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_NO_CONTENT, null), null);
 
-        MantaChecksumFailedException e = new MantaChecksumFailedException();
+        // requestId is extracted from the response, not the request
+        response.setHeader(MantaHttpHeaders.REQUEST_ID, dummyRequestId);
+
+        MantaChecksumFailedException e = new MantaChecksumFailedException("", request, response);
+
+        Assert.assertEquals(e.getFirstContextValue("requestId"), dummyRequestId);
+        Assert.assertEquals(e.getFirstContextValue("requestURL"), dummyUri);
+        Assert.assertEquals(e.getFirstContextValue("responseStatusCode"), HttpStatus.SC_NO_CONTENT);
+
         String sdkVersion = e.getContextValues("mantaSdkVersion").get(0).toString();
         Assert.assertNotNull(sdkVersion,
                 "SDK version data should be in exception context");


### PR DESCRIPTION
Found another exception that's missing a request ID. Not sure if `HttpHelper.annotateContextedException` might be overkill in this case.