### PR TITLE
Fix MD5 mismatch during retry

### DIFF
--- a/java-manta-client/src/main/java/com/joyent/manta/http/entity/DigestedEntity.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/http/entity/DigestedEntity.java
@@ -83,6 +83,8 @@ public class DigestedEntity implements HttpEntity {
 
     @Override
     public void writeTo(final OutputStream out) throws IOException {
+        digest.reset(); // reset the digest state in case we're in a retry
+
         // If our wrapped entity is backed by a buffer of some form
         // we can read easily read the whole buffer into our message digest.
         if (wrapped instanceof MemoryBackedEntity) {

--- a/java-manta-client/src/test/java/com/joyent/manta/http/entity/DigestedEntityTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/http/entity/DigestedEntityTest.java
@@ -1,0 +1,50 @@
+package com.joyent.manta.http.entity;
+
+import com.twmacinta.util.FastMD5Digest;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+
+/**
+ * Created by tomascelaya on 6/29/17.
+ */
+@Test
+public class DigestedEntityTest {
+
+    public void testWriteToProducesReliableDigest() throws Exception {
+        String content = RandomStringUtils.randomAlphanumeric(100);
+        DigestedEntity entity = new DigestedEntity(
+                new ExposedStringEntity(content, StandardCharsets.UTF_8),
+                new FastMD5Digest());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        entity.writeTo(out);
+        byte[] initialDigest = entity.getDigest();
+
+        // connection reset, httpclient performs a retry reusing the same entity
+        out.reset();
+        entity.writeTo(out);
+        byte[] retryDigest = entity.getDigest();
+
+        Assert.assertTrue(
+                Arrays.equals(initialDigest, retryDigest),
+                "Reuse of DigestedEntity produced differing digest for first retry");
+
+
+        // connection reset again
+        out.reset();
+        entity.writeTo(out);
+        byte[] extraRetryDigest = entity.getDigest();
+
+        Assert.assertTrue(
+                Arrays.equals(initialDigest, extraRetryDigest),
+                "Reuse of DigestedEntity produced differing digest for second retry");
+    }
+
+}

--- a/java-manta-client/src/test/java/com/joyent/manta/http/entity/DigestedEntityTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/http/entity/DigestedEntityTest.java
@@ -1,7 +1,13 @@
+/*
+ * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.joyent.manta.http.entity;
 
 import com.twmacinta.util.FastMD5Digest;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -10,10 +16,6 @@ import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
-
-/**
- * Created by tomascelaya on 6/29/17.
- */
 @Test
 public class DigestedEntityTest {
 
@@ -35,7 +37,6 @@ public class DigestedEntityTest {
         Assert.assertTrue(
                 Arrays.equals(initialDigest, retryDigest),
                 "Reuse of DigestedEntity produced differing digest for first retry");
-
 
         // connection reset again
         out.reset();


### PR DESCRIPTION
Since we allow retries for most sensible cases it is possible that a HttpEntity is used to write output more than once. `DigestedEntity` accepts a `digest` object which keeps internal state that was not being cleaned up between calls to `writeTo`. Some manual testing with a proxy revealed that `HttpEntity` objects are reused as-is when performing a retry. This can lead to an actually-successful retry failing on the client when comparing the client-calculated MD5 with the server's MD5 response header. This will manifest itself in an exception like the following:

```
Caused by: com.joyent.manta.exception.MantaChecksumFailedException: Client calculated MD5 and server calculated MD5 do not match
Exception Context:
        [1:mantaSdkVersion=3.1.2]
        [2:serverMd5=29d7cf482158399d1d83dddf44af1511]
        [3:clientMd5=e85d394ceb64b5e745bad680705ee1c7]
---------------------------------
        at com.joyent.manta.http.StandardHttpHelper.validateChecksum(StandardHttpHelper.java:363)
        at com.joyent.manta.http.StandardHttpHelper.httpPut(StandardHttpHelper.java:222)
        at com.joyent.manta.http.EncryptionHttpHelper.httpPut(EncryptionHttpHelper.java:217)
        at com.joyent.manta.client.MantaClient.put(MantaClient.java:1218)
        at com.joyent.manta.client.MantaClient.put(MantaClient.java:1163)
```

Verified that there are no changes that need to be made for `EncryptingEntity` since it doesn't have any of its own internal state and builds a new `CipherOutputStream` at the beginning of `writeTo`.