### PR TITLE
Fix EncryptedServerSideMultipartManagerIT#cantUploadSmallMultipartString

### DIFF
--- a/java-manta-client/src/main/java/com/joyent/manta/client/multipart/EncryptedMultipartManager.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/multipart/EncryptedMultipartManager.java
@@ -262,18 +262,17 @@ public class EncryptedMultipartManager
         encryptionState.getLock().lock();
         try {
             validatePartNumber(partNumber);
-            if (encryptionState.getLastPartNumber() != -1
-                    && encryptionState.getLastPartNumber() + 1 != partNumber) {
-                final String message = String.format(
-                        "Encrypted MPU parts must be serial and sequential, expected: %d, found: %d",
-                        encryptionState.getLastPartNumber() + 1,
-                        partNumber);
-                throw new MantaMultipartException(new IllegalStateException(message));
-            } else {
+            if (encryptionState.getLastPartNumber() == EncryptionState.NOT_STARTED) {
                 encryptionState.setMultipartStream(new MultipartOutputStream(
                         encryptionContext.getCipherDetails().getBlockSizeInBytes()));
                 encryptionState.setCipherStream(EncryptingEntityHelper.makeCipherOutputForStream(
                         encryptionState.getMultipartStream(), encryptionContext));
+            } else if (encryptionState.getLastPartNumber() + 1 != partNumber) {
+                final String message = String.format(
+                        "Encrypted MPU parts must be serial and sequential, expected: %d, got %d",
+                        encryptionState.getLastPartNumber() + 1,
+                        partNumber);
+                throw new MantaMultipartException(new IllegalStateException(message));
             }
 
             final EncryptingPartEntity entity = new EncryptingPartEntity(

--- a/java-manta-client/src/main/java/com/joyent/manta/client/multipart/EncryptedMultipartManager.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/multipart/EncryptedMultipartManager.java
@@ -259,9 +259,13 @@ public class EncryptedMultipartManager
         encryptionState.getLock().lock();
         try {
             validatePartNumber(partNumber);
-            if (encryptionState.getLastPartNumber() != -1) {
-                Validate.isTrue(encryptionState.getLastPartNumber() + 1 == partNumber,
-                        "Encrypted MPU parts must be serial and sequential");
+            if (encryptionState.getLastPartNumber() != -1
+                    && encryptionState.getLastPartNumber() + 1 != partNumber) {
+                final String message = String.format(
+                        "Encrypted MPU parts must be serial and sequential, expected: %d, found: %d",
+                        encryptionState.getLastPartNumber() + 1,
+                        partNumber);
+                throw new MantaMultipartException(new IllegalStateException(message));
             } else {
                 encryptionState.setMultipartStream(new MultipartOutputStream(
                         encryptionContext.getCipherDetails().getBlockSizeInBytes()));

--- a/java-manta-client/src/main/java/com/joyent/manta/client/multipart/EncryptionState.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/multipart/EncryptionState.java
@@ -37,6 +37,11 @@ public class EncryptionState {
     private static final transient Logger LOGGER = LoggerFactory.getLogger(EncryptionState.class);
 
     /**
+     * Sentinel value for an EncryptionState which has not yet sent any parts.
+     */
+    static final int NOT_STARTED = -1;
+
+    /**
      * Encryption cipher state object.
      */
     private final EncryptionContext encryptionContext;
@@ -49,7 +54,7 @@ public class EncryptionState {
     /**
      * The number of the last part processed.
      */
-    private int lastPartNumber = -1;
+    private int lastPartNumber = NOT_STARTED;
 
     /**
      * The multipart stream that allows for attaching and detaching streams.

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
@@ -440,11 +440,11 @@ public class EncryptedServerSideMultipartManagerIT {
         for (int i = 1; i < parts.length; i++) {
             final int j = i;
             exception = Assert.expectThrows(MantaMultipartException.class,
-                                        () -> {
-                                            MantaMultipartUploadTuple uploaded = multipart.uploadPart(upload, j + 1, parts[j]);
-                                            uploadedParts.add(uploaded);
-                                        });
-            assert exception.getCause() instanceof IllegalStateException;
+                    () -> {
+                        MantaMultipartUploadTuple uploaded = multipart.uploadPart(upload, j + 1, parts[j]);
+                        uploadedParts.add(uploaded);
+                    });
+            Assert.assertTrue(exception.getCause() instanceof IllegalStateException);
         }
         Assert.assertEquals(uploadedParts.size(), 1, "only first small upload should succeed");
 


### PR DESCRIPTION
Straightforward implementation which fixes the test. Since the nested exception hides the fact that this sort of falls under the realm of "logical errors" I'm proposing we use a new exception type to signal that this is a _particular_ kind of MPU error and retrying the same part indefinitely wouldn't be helpful. Open to suggestions on exception name.