### PR TITLE
Fail MD5 validation if server MD5 is missing

### DIFF
--- a/java-manta-client/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -1057,6 +1057,7 @@ public class MantaClient implements AutoCloseable {
                                    final String string,
                                    final MantaHttpHeaders headers,
                                    final MantaMetadata metadata) throws IOException {
+        Validate.notNull(string, "String content must not be null");
         Validate.notNull(rawPath, "Path must not be null");
 
         String path = formatPath(rawPath);

--- a/java-manta-client/src/main/java/com/joyent/manta/http/StandardHttpHelper.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/http/StandardHttpHelper.java
@@ -351,9 +351,7 @@ public class StandardHttpHelper implements HttpHelper {
                                            final HttpRequest request,
                                            final HttpResponse response)
             throws MantaChecksumFailedException {
-        if (entity == null) {
-            return;
-        }
+        Validate.notNull(entity, "Request body missing checksum");
 
         if (serverMd5 == null || serverMd5.length == 0) {
             final String msg = "Server calculated MD5 is missing";

--- a/java-manta-client/src/main/java/com/joyent/manta/http/StandardHttpHelper.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/http/StandardHttpHelper.java
@@ -356,8 +356,9 @@ public class StandardHttpHelper implements HttpHelper {
         }
 
         if (serverMd5 == null || serverMd5.length == 0) {
-            LOGGER.warn("No cryptographic check performed by the server");
-            return;
+            final String msg = "Server calculated MD5 is missing";
+            final MantaChecksumFailedException e = new MantaChecksumFailedException(msg, request, response);
+            throw e;
         }
 
         final byte[] clientMd5 = entity.getDigest();

--- a/java-manta-client/src/main/java/com/joyent/manta/http/StandardHttpHelper.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/http/StandardHttpHelper.java
@@ -355,8 +355,7 @@ public class StandardHttpHelper implements HttpHelper {
 
         if (serverMd5 == null || serverMd5.length == 0) {
             final String msg = "Server calculated MD5 is missing";
-            final MantaChecksumFailedException e = new MantaChecksumFailedException(msg, request, response);
-            throw e;
+            throw new MantaChecksumFailedException(msg, request, response);
         }
 
         final byte[] clientMd5 = entity.getDigest();

--- a/java-manta-client/src/main/java/com/joyent/manta/http/StandardHttpHelper.java
+++ b/java-manta-client/src/main/java/com/joyent/manta/http/StandardHttpHelper.java
@@ -351,7 +351,7 @@ public class StandardHttpHelper implements HttpHelper {
                                            final HttpRequest request,
                                            final HttpResponse response)
             throws MantaChecksumFailedException {
-        Validate.notNull(entity, "Request body missing checksum");
+        Validate.notNull(entity, "Request body required");
 
         if (serverMd5 == null || serverMd5.length == 0) {
             final String msg = "Server calculated MD5 is missing";

--- a/java-manta-client/src/test/java/com/joyent/manta/http/StandardHttpHelperTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/http/StandardHttpHelperTest.java
@@ -1,15 +1,24 @@
 package com.joyent.manta.http;
 
+import com.joyent.manta.client.MantaObjectResponse;
 import com.joyent.manta.config.BaseChainedConfigContext;
 import com.joyent.manta.config.StandardConfigContext;
 import com.joyent.manta.exception.MantaChecksumFailedException;
 import com.joyent.manta.exception.MantaClientHttpResponseException;
 import com.joyent.manta.http.entity.NoContentEntity;
+import com.twmacinta.util.FastMD5Digest;
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicHeader;
+import org.bouncycastle.crypto.Digest;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -18,9 +27,12 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.Base64;
+
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
 /**
@@ -68,18 +80,110 @@ public class StandardHttpHelperTest {
     }
 
     @Test
-    public void testHttpPutValidatesResponseCode() throws Exception {
+    public void testHttpPutValidatesResponseCodeSuccessfully() throws Exception {
+        when(statusLine.getStatusCode())
+                .thenReturn(HttpStatus.SC_NO_CONTENT);
+
+        when(statusLine.getReasonPhrase())
+                .thenReturn("No Content");
+
+        config.setVerifyUploads(false);
+        final StandardHttpHelper helper = new StandardHttpHelper(connCtx, connectionFactory, config);
+
+        final MantaObjectResponse put =
+                helper.httpPut("/path", null, NoContentEntity.INSTANCE, null);
+
+        Assert.assertNotNull(put);
+    }
+
+    @Test
+    public void testHttpPutValidatesResponseCodeAndThrowsWhenInvalid() throws Exception {
         when(statusLine.getStatusCode())
                 .thenReturn(HttpStatus.SC_OK);
 
         when(statusLine.getReasonPhrase())
                 .thenReturn("OK");
 
-        StandardHttpHelper helper = new StandardHttpHelper(connCtx, connectionFactory, config);
+        final StandardHttpHelper helper = new StandardHttpHelper(connCtx, connectionFactory, config);
 
-        Assert.assertThrows(MantaClientHttpResponseException.class, () -> {
-            helper.httpPut("/path", null, NoContentEntity.INSTANCE, null);
-        });
+        Assert.assertThrows(MantaClientHttpResponseException.class, () ->
+                helper.httpPut("/path", null, NoContentEntity.INSTANCE, null));
+    }
+
+    @Test
+    public void testHttpPutChecksumsSuccessfully() throws Exception {
+        when(statusLine.getStatusCode())
+                .thenReturn(HttpStatus.SC_NO_CONTENT);
+
+        when(statusLine.getReasonPhrase())
+                .thenReturn("No Content");
+
+        reset(client);
+        when(client.execute(any()))
+                .then((invocationOnMock) -> {
+                    // checksum is calculated as entity is written to network
+                    final HttpPut request = invocationOnMock.getArgumentAt(0, HttpPut.class);
+                    request.getEntity().writeTo(NullOutputStream.NULL_OUTPUT_STREAM);
+                    return response;
+                });
+
+        final byte[] contentBytes = RandomUtils.nextBytes(100);
+        final Digest digest = new FastMD5Digest();
+        final byte[] checksumBytes = new byte[digest.getDigestSize()];
+        digest.update(contentBytes, 0, contentBytes.length);
+        digest.doFinal(checksumBytes, 0);
+
+        when(response.getAllHeaders())
+                .thenReturn(new Header[]{
+                        new BasicHeader(
+                                MantaHttpHeaders.COMPUTED_MD5,
+                                Base64.getEncoder().encodeToString(checksumBytes))
+                });
+
+        final StandardHttpHelper helper = new StandardHttpHelper(connCtx, connectionFactory, config);
+
+        // it's the default but let's just be explicit
+        config.setVerifyUploads(true);
+
+        final MantaObjectResponse put =
+                helper.httpPut("/path", null, new ByteArrayEntity(contentBytes), null);
+
+        Assert.assertNotNull(put);
+    }
+
+    @Test
+    public void testHttpPutChecksumsCompareDifferentlyFails() throws Exception {
+        when(statusLine.getStatusCode())
+                .thenReturn(HttpStatus.SC_NO_CONTENT);
+
+        when(statusLine.getReasonPhrase())
+                .thenReturn("No Content");
+
+        reset(client);
+        when(client.execute(any()))
+                .then((invocationOnMock) -> {
+                    // checksum is calculated as entity is written to network
+                    final HttpPut request = invocationOnMock.getArgumentAt(0, HttpPut.class);
+                    request.getEntity().writeTo(NullOutputStream.NULL_OUTPUT_STREAM);
+                    return response;
+                });
+
+        final byte[] contentBytes = StringUtils.repeat('a', 100).getBytes();
+
+        when(response.getAllHeaders())
+                .thenReturn(new Header[]{
+                        new BasicHeader(
+                                MantaHttpHeaders.COMPUTED_MD5,
+                                "YmFzZTY0Cg==") // "base64" encoded in base64
+                });
+
+        final StandardHttpHelper helper = new StandardHttpHelper(connCtx, connectionFactory, config);
+
+        // it's the default but let's just be explicit
+        config.setVerifyUploads(true);
+
+        Assert.assertThrows(MantaChecksumFailedException.class, () ->
+                helper.httpPut("/path", null, new ByteArrayEntity(contentBytes), null));
     }
 
 
@@ -91,14 +195,13 @@ public class StandardHttpHelperTest {
         when(statusLine.getReasonPhrase())
                 .thenReturn("No Content");
 
-        StandardHttpHelper helper = new StandardHttpHelper(connCtx, connectionFactory, config);
+        final StandardHttpHelper helper = new StandardHttpHelper(connCtx, connectionFactory, config);
 
         // it's the default but let's just be explicit
         config.setVerifyUploads(true);
 
-        Assert.assertThrows(MantaChecksumFailedException.class, () -> {
-            helper.httpPut("/path", null, NoContentEntity.INSTANCE, null);
-        });
+        Assert.assertThrows(MantaChecksumFailedException.class, () ->
+                helper.httpPut("/path", null, NoContentEntity.INSTANCE, null));
     }
 
 }

--- a/java-manta-client/src/test/java/com/joyent/manta/http/StandardHttpHelperTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/http/StandardHttpHelperTest.java
@@ -35,9 +35,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
-/**
- * Created by tomascelaya on 8/11/17.
- */
 public class StandardHttpHelperTest {
 
     @Mock
@@ -186,7 +183,6 @@ public class StandardHttpHelperTest {
                 helper.httpPut("/path", null, new ByteArrayEntity(contentBytes), null));
     }
 
-
     @Test
     public void testHttpPutThrowsWhenChecksumRequestedButNotReturned() throws Exception {
         when(statusLine.getStatusCode())
@@ -203,5 +199,4 @@ public class StandardHttpHelperTest {
         Assert.assertThrows(MantaChecksumFailedException.class, () ->
                 helper.httpPut("/path", null, NoContentEntity.INSTANCE, null));
     }
-
 }

--- a/java-manta-client/src/test/java/com/joyent/manta/http/StandardHttpHelperTest.java
+++ b/java-manta-client/src/test/java/com/joyent/manta/http/StandardHttpHelperTest.java
@@ -1,0 +1,104 @@
+package com.joyent.manta.http;
+
+import com.joyent.manta.config.BaseChainedConfigContext;
+import com.joyent.manta.config.StandardConfigContext;
+import com.joyent.manta.exception.MantaChecksumFailedException;
+import com.joyent.manta.exception.MantaClientHttpResponseException;
+import com.joyent.manta.http.entity.NoContentEntity;
+import org.apache.http.Header;
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.internal.util.reflection.Whitebox;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by tomascelaya on 8/11/17.
+ */
+public class StandardHttpHelperTest {
+
+    @Mock
+    private final MantaConnectionFactory connectionFactory = mock(MantaConnectionFactory.class);
+    @Mock
+    private final CloseableHttpClient client = mock(CloseableHttpClient.class);
+    @Mock
+    private final CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+    @Mock
+    private final MantaConnectionContext connCtx = mock(MantaConnectionContext.class);
+    @Mock
+    private final StatusLine statusLine = mock(StatusLine.class);
+
+    private BaseChainedConfigContext config;
+
+    @BeforeMethod
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        config = new StandardConfigContext().setMantaURL("");
+
+        Whitebox.setInternalState(connectionFactory, "config", config);
+
+        when(connCtx.getHttpClient())
+                .thenReturn(client);
+
+        when(client.execute(any()))
+                .thenReturn(response);
+
+        when(response.getStatusLine())
+                .thenReturn(statusLine);
+
+        when(response.getAllHeaders())
+                .thenReturn(new Header[]{});
+
+        when(connectionFactory.uriForPath(anyString()))
+                .thenCallRealMethod();
+
+        when(connectionFactory.put(Mockito.anyString()))
+                .thenCallRealMethod();
+    }
+
+    @Test
+    public void testHttpPutValidatesResponseCode() throws Exception {
+        when(statusLine.getStatusCode())
+                .thenReturn(HttpStatus.SC_OK);
+
+        when(statusLine.getReasonPhrase())
+                .thenReturn("OK");
+
+        StandardHttpHelper helper = new StandardHttpHelper(connCtx, connectionFactory, config);
+
+        Assert.assertThrows(MantaClientHttpResponseException.class, () -> {
+            helper.httpPut("/path", null, NoContentEntity.INSTANCE, null);
+        });
+    }
+
+
+    @Test
+    public void testHttpPutThrowsWhenChecksumRequestedButNotReturned() throws Exception {
+        when(statusLine.getStatusCode())
+                .thenReturn(HttpStatus.SC_NO_CONTENT);
+
+        when(statusLine.getReasonPhrase())
+                .thenReturn("No Content");
+
+        StandardHttpHelper helper = new StandardHttpHelper(connCtx, connectionFactory, config);
+
+        // it's the default but let's just be explicit
+        config.setVerifyUploads(true);
+
+        Assert.assertThrows(MantaChecksumFailedException.class, () -> {
+            helper.httpPut("/path", null, NoContentEntity.INSTANCE, null);
+        });
+    }
+
+}


### PR DESCRIPTION
#298

Updating this code path so we cover situations where we got back a response that is somehow missing an MD5. Minor detour while attempting to remove the `entity == null ` early return:

It's currently possible to call `put("/path", null)` and get a response. Some extra testing revealed that enabling client-side encryption and sending a null string causes the following exception:

```
java.lang.NullPointerException
	at com.joyent.manta.client.crypto.EncryptingEntity.<init>(EncryptingEntity.java:98)
	at com.joyent.manta.http.EncryptionHttpHelper.httpPut(EncryptionHttpHelper.java:189)
	at com.joyent.manta.client.MantaClient.put(MantaClient.java:1084)
	at com.joyent.manta.client.MantaClient.put(MantaClient.java:1134)
	at com.joyent.manta.client.MantaClientPutIT.testPutWithStringUTF8(MantaClientPutIT.java:79)
```

It seems like the simplest path forward is to disallow null strings from being sent as content (empty strings are fine).