### PR TITLE
always produce coverage reports for unit & integration tests

### DIFF
--- a/java-manta-it/pom.xml
+++ b/java-manta-it/pom.xml
@@ -112,7 +112,180 @@
     </dependencies>
 
     <build>
+        <!-- To generate code coverage reports (of either unit or
+             integration tests) jacoco needs access to both the
+             original (pre-instrumentation) class files, and the
+             source code.
+             <http://www.jacoco.org/jacoco/trunk/doc/classids.html>
+             describes how jacoco keeps track of classes in further
+             detail.  There exist goals that can traverse a
+             multi-module project and aggregate this information from
+             the standard maven locations, but they are confounded by
+             the shading+relocation step.  The final classes shipped
+             in the client jar are *only* in the shaded client jar,
+             and not in target/classes.
+
+             To work around this and provide the necessary information
+             requires jumping through several hoops to act as if the
+             java-manta-client source files were part of the
+             integration test module:
+
+              * Add a new source location to java-manta-it to hold the
+              "upstream" .java files from java-manta-client
+              * Copy the source files there
+              * Make sure the source are removed when not needed so
+              they are never actually compiled.
+              * Unpack the final relocated class files so they are
+              available outside of just a jar.
+
+             This scheme depends on there being no "src/main" classes
+             in this integration test module.
+        -->
         <plugins>
+            <plugin>
+                <!-- This property is generated so we can refer to
+                     another module in a multi-module project without
+                     brittle relative paths. -->
+                <groupId>org.commonjava.maven.plugins</groupId>
+                <artifactId>directory-maven-plugin</artifactId>
+                <version>${maven-directory-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>directory-of-property</id>
+                        <goals>
+                            <goal>directory-of</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                        <configuration>
+                            <property>multi.module.root</property>
+                            <project>
+                                <groupId>com.joyent.manta</groupId>
+                                <artifactId>java-manta</artifactId>
+                            </project>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <executions>
+                    <!-- Remove src/shade-workaround after use.  This
+                         is for tidyness but not correctness.  Note
+                         that since this is bound to
+                         post-integration-test it will run when
+                         invoking verify, but not intgration-test -->
+                    <execution>
+                        <id>clean-shade-workaround-src-post</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <configuration>
+                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                            <filesets>
+                                <fileset>
+                                    <directory>src/shade-workaround</directory>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </execution>
+                    <!-- Ensure that src/shade-workaround is *always*
+                         removed before a compile phase runs.  This is
+                         for correctness. -->
+                    <execution>
+                        <id>clean-shade-workaround-src-pre</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <configuration>
+                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                            <filesets>
+                                <fileset>
+                                    <directory>src/shade-workaround</directory>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>${maven-build-helper-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>add-shade-workaround-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/shade-workaround</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>${maven-maven-resources-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>copy-shade-workaround-src</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>src/shade-workaround</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${multi.module.root}/java-manta-client-unshaded/src/main/java</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!-- unpack the modified-by-relocation classes from
+                     the client jar -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven-build-helper-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>unpack-relocated-classes</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.joyent.manta</groupId>
+                                    <artifactId>java-manta-client</artifactId>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                                    <includes>**/*.class</includes>
+                                    <excludes>com/joyent/manta/com/**,com/joyent/manta/org/**,com/joyent/manta/io/**,com/joyent/manta/http/signature/**</excludes>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.joyent.manta</groupId>
+                                    <artifactId>java-manta-client-kryo-serialization</artifactId>
+                                    <type>jar</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                                    <includes>**/*.class</includes>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/java-manta-it/src/.gitignore
+++ b/java-manta-it/src/.gitignore
@@ -1,0 +1,1 @@
+shade-workaround/

--- a/pom.xml
+++ b/pom.xml
@@ -135,9 +135,14 @@
         <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>2.19.1</maven-failsafe-plugin.version>
         <maven-exec-plugin.version>1.4.0</maven-exec-plugin.version>
-        <maven-jacoco-plugin.version>0.7.8</maven-jacoco-plugin.version>
+        <maven-jacoco-plugin.version>0.7.9</maven-jacoco-plugin.version>
         <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
         <maven-replacer-plugin-plugin.version>1.5.3</maven-replacer-plugin-plugin.version>
+        <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
+        <maven-directory-maven-plugin.version>0.2</maven-directory-maven-plugin.version>
+        <maven-build-helper-maven-plugin.version>3.0.0</maven-build-helper-maven-plugin.version>
+        <maven-maven-resources-plugin.version>3.0.2</maven-maven-resources-plugin.version>
+        <maven-build-helper-maven-plugin.version>3.0.0</maven-build-helper-maven-plugin.version>
 
         <!-- Maven plugin dependency versions -->
         <maven-plexus-compiler-javac-errorprone.version>2.8.2</maven-plexus-compiler-javac-errorprone.version>
@@ -436,17 +441,40 @@
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${maven-jacoco-plugin.version}</version>
                 <executions>
+                    <!-- unit test coverage-->
                     <execution>
+                        <id>pre-unit-test</id>
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
                     </execution>
                     <execution>
-                        <id>report</id>
-                        <phase>prepare-package</phase>
+                        <id>unit-test-report</id>
+                        <phase>test</phase>
                         <goals>
                             <goal>report</goal>
                         </goals>
+                    </execution>
+                    <!-- integration test coverage-->
+                    <execution>
+                        <id>pre-integration-test</id>
+                        <goals>
+                            <goal>prepare-agent-integration</goal>
+                        </goals>
+                        <configuration>
+                            <destFile>${project.build.directory}/jacoco-it.exec</destFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>integration-test-report</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>report-integration</goal>
+                        </goals>
+                        <configuration>
+                            <dataFileIncludes>**/jacoco-it.exec</dataFileIncludes>
+                            <outputDirectory>${project.reporting.outputDirectory}/jacoco-it</outputDirectory>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Previously code coverage reports were only generated as part of the
`site` goal, and were thus rarely looked at.  Binding the reports to
the same phase ensures they are always available for inspection.

Due to shading, several hoops need to be jumped through so that the
integration test report can refer to the source and classes under test.
Actions are bound to several maven phases to move files around, acting
as if java-manta-client was part of the integration test module.

ref #317