### PR TITLE
make cli: get-file suitable for streaming

### DIFF
--- a/java-manta-cli/pom.xml
+++ b/java-manta-cli/pom.xml
@@ -40,6 +40,11 @@
             <version>${dependency.commons-lang.version}</version>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${dependency.commons-io.version}</version>
+        </dependency>
+        <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
             <version>${dependency.picocli.version}</version>


### PR DESCRIPTION
Instead of reading the entire object into a string and running out of
memory, write out bytes as they are downloaded.  This also makes it
easy to stream binary content to a local file.

Add a nascent info command to retain a way for the cli to show
http headers.

ref #312