### PR TITLE
EncryptingEntity and EncryptedPartEntity should not close writeTo(OutputStream)

### DIFF
--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/EncryptingEntity.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/EncryptingEntity.java
@@ -154,29 +154,26 @@ public class EncryptingEntity implements HttpEntity {
 
         OutputStream out = EncryptingEntityHelper.makeCipherOutputForStream(
                 httpOut, encryptionContext);
-        try {
-            copyContentToOutputStream(out);
-            /* We don't close quietly because we want the operation to fail if
-             * there is an error closing out the CipherOutputStream. */
-            out.close();
 
-            if (out instanceof HmacOutputStream) {
-                final HMac hmac = ((HmacOutputStream) out).getHmac();
-                final int hmacSize = hmac.getMacSize();
-                final byte[] hmacBytes = new byte[hmacSize];
-                hmac.doFinal(hmacBytes, 0);
+        copyContentToOutputStream(out);
+        /* We don't close quietly because we want the operation to fail if
+         * there is an error closing out the CipherOutputStream. */
+        out.close();
 
-                Validate.isTrue(hmacBytes.length == hmacSize,
-                        "HMAC actual bytes doesn't equal the number of bytes expected");
+        if (out instanceof HmacOutputStream) {
+            final HMac hmac = ((HmacOutputStream) out).getHmac();
+            final int hmacSize = hmac.getMacSize();
+            final byte[] hmacBytes = new byte[hmacSize];
+            hmac.doFinal(hmacBytes, 0);
 
-                if (LOGGER.isTraceEnabled()) {
-                    LOGGER.trace("HMAC: {}", Hex.encodeHexString(hmacBytes));
-                }
+            Validate.isTrue(hmacBytes.length == hmacSize,
+                    "HMAC actual bytes doesn't equal the number of bytes expected");
 
-                httpOut.write(hmacBytes);
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.trace("HMAC: {}", Hex.encodeHexString(hmacBytes));
             }
-        } finally {
-            IOUtils.closeQuietly(httpOut);
+
+            httpOut.write(hmacBytes);
         }
     }
 

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/EncryptingEntity.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/EncryptingEntity.java
@@ -166,7 +166,6 @@ public class EncryptingEntity implements HttpEntity {
             final byte[] hmacBytes = new byte[hmacSize];
             hmac.doFinal(hmacBytes, 0);
 
-            // TODO: this test will NEVER fail since it's just checking hmacBytes.length which was initialized from hmacSize
             Validate.isTrue(hmacBytes.length == hmacSize,
                     "HMAC actual bytes doesn't equal the number of bytes expected");
 

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/EncryptingEntity.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/EncryptingEntity.java
@@ -166,6 +166,7 @@ public class EncryptingEntity implements HttpEntity {
             final byte[] hmacBytes = new byte[hmacSize];
             hmac.doFinal(hmacBytes, 0);
 
+            // TODO: this test will NEVER fail since it's just checking hmacBytes.length which was initialized from hmacSize
             Validate.isTrue(hmacBytes.length == hmacSize,
                     "HMAC actual bytes doesn't equal the number of bytes expected");
 

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/EncryptingPartEntity.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/EncryptingPartEntity.java
@@ -140,7 +140,6 @@ public class EncryptingPartEntity implements HttpEntity {
                 }
             }
         } finally {
-            IOUtils.closeQuietly(httpOut);
             IOUtils.closeQuietly(contentStream);
         }
     }

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/crypto/EncryptingEntityTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/crypto/EncryptingEntityTest.java
@@ -172,7 +172,7 @@ public class EncryptingEntityTest {
         }
     }
 
-    public void doesNotCloseSuppliedOutputStreamWhenFailureOccurs() throws Exception {
+    public void doesNotCloseSuppliedOutputStreamWhenWrittenSuccessfully() throws Exception {
         final SupportedCipherDetails cipherDetails = DefaultsConfigContext.DEFAULT_CIPHER;
         final SecretKey secretKey = SecretKeyUtils.generate(cipherDetails);
         final String content = RandomStringUtils.randomAlphanumeric(RandomUtils.nextInt(500, 1500));
@@ -190,7 +190,7 @@ public class EncryptingEntityTest {
         Mockito.verify(output, Mockito.never()).close();
     }
 
-    public void doesNotCloseSuppliedOutputStreamWhenWrittenSuccessfully() throws Exception {
+    public void doesNotCloseSuppliedOutputStreamWhenFailureOccurs() throws Exception {
         final SupportedCipherDetails cipherDetails = DefaultsConfigContext.DEFAULT_CIPHER;
         final SecretKey secretKey = SecretKeyUtils.generate(cipherDetails);
         final EncryptingEntity encryptingEntity = new EncryptingEntity(

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/multipart/EncryptingPartEntityTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/multipart/EncryptingPartEntityTest.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.joyent.manta.client.multipart;
 
 import com.joyent.manta.client.crypto.EncryptingEntityHelper;

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/multipart/EncryptingPartEntityTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/multipart/EncryptingPartEntityTest.java
@@ -1,0 +1,81 @@
+package com.joyent.manta.client.multipart;
+
+import com.joyent.manta.client.crypto.EncryptingEntityHelper;
+import com.joyent.manta.client.crypto.EncryptingPartEntity;
+import com.joyent.manta.client.crypto.EncryptionContext;
+import com.joyent.manta.client.crypto.SecretKeyUtils;
+import com.joyent.manta.client.crypto.SupportedCipherDetails;
+import com.joyent.manta.config.DefaultsConfigContext;
+import com.joyent.manta.http.entity.ExposedStringEntity;
+import org.apache.commons.io.input.BrokenInputStream;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.http.entity.InputStreamEntity;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+@Test
+public class EncryptingPartEntityTest {
+
+    private EncryptionState state;
+
+    private static final ByteArrayOutputStream BYTE_ARRAY_OUTPUT_STREAM_EMPTY = new ByteArrayOutputStream(0);
+
+    private static final EncryptingPartEntity.LastPartCallback CALLBACK_NOOP =
+            new EncryptingPartEntity.LastPartCallback() {
+                @Override
+                public ByteArrayOutputStream call(final long uploadedBytes) throws IOException {
+                    return BYTE_ARRAY_OUTPUT_STREAM_EMPTY;
+                }
+            };
+
+    @BeforeMethod
+    public void setup() throws Exception {
+        final SupportedCipherDetails cipherDetails = DefaultsConfigContext.DEFAULT_CIPHER;
+        state = new EncryptionState(new EncryptionContext(SecretKeyUtils.generate(cipherDetails), cipherDetails));
+
+        state.setMultipartStream(
+                new MultipartOutputStream(
+                        state.getEncryptionContext().getCipherDetails().getBlockSizeInBytes()));
+        state.setCipherStream(
+                EncryptingEntityHelper.makeCipherOutputForStream(
+                        state.getMultipartStream(),
+                        state.getEncryptionContext()));
+    }
+
+    public void doesNotCloseSuppliedOutputStreamWhenFailureOccurs() throws Exception {
+        final ExposedStringEntity contentEntity = new ExposedStringEntity(
+                RandomStringUtils.randomAlphanumeric(RandomUtils.nextInt(500, 1500)),
+                StandardCharsets.UTF_8);
+
+        final EncryptingPartEntity encryptingPartEntity = new EncryptingPartEntity(
+                state.getCipherStream(),
+                state.getMultipartStream(),
+                contentEntity,
+                CALLBACK_NOOP);
+
+        final OutputStream output = Mockito.mock(OutputStream.class);
+        encryptingPartEntity.writeTo(output);
+        Mockito.verify(output, Mockito.never()).close();
+    }
+
+    public void doesNotCloseSuppliedOutputStreamWhenWrittenSuccessfully() throws Exception {
+        final EncryptingPartEntity encryptingPartEntity = new EncryptingPartEntity(
+                state.getCipherStream(),
+                state.getMultipartStream(),
+                new InputStreamEntity(new BrokenInputStream(new IOException("bad input"))),
+                CALLBACK_NOOP);
+
+        final OutputStream output = Mockito.mock(OutputStream.class);
+        Assert.assertThrows(IOException.class, () -> encryptingPartEntity.writeTo(output));
+        Mockito.verify(output, Mockito.never()).close();
+    }
+
+}

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
@@ -9,7 +9,6 @@ package com.joyent.manta.client.multipart;
 
 import com.joyent.manta.client.MantaClient;
 import com.joyent.manta.client.MantaMetadata;
-import com.joyent.manta.client.MantaObject;
 import com.joyent.manta.client.MantaObjectInputStream;
 import com.joyent.manta.client.crypto.MantaEncryptedObjectInputStream;
 import com.joyent.manta.config.ConfigContext;
@@ -43,7 +42,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import static org.testng.Assert.assertEquals;
@@ -577,28 +575,5 @@ public class EncryptedServerSideMultipartManagerIT {
             AssertJUnit.assertArrayEquals("Uploaded multipart data doesn't equal actual object data",
                     content, out.toByteArray());
         }
-    }
-
-    public final void willFailToCreatePartWhenErrorOccursDuringUpload() throws Exception {
-        final String path = testPathPrefix + UUID.randomUUID().toString();
-        final byte[] content = RandomUtils.nextBytes(2048);
-
-        EncryptedMultipartUpload<ServerSideMultipartUpload> upload = multipart.initiateUpload(path);
-
-        Assert.assertThrows(IOException.class, () -> {
-            // partial read of content1
-            multipart.uploadPart(upload, 1, new FailingInputStream(new ByteArrayInputStream(content), 1024));
-        });
-
-        // listing the directory immediately after MPU creation is likely to return no results
-        // this is being reported upstream
-        TimeUnit.SECONDS.sleep(1);
-
-        final long partCount;
-        try (final Stream<MantaObject> receivedParts = mantaClient.listObjects(upload.getWrapped().getPartsDirectory())) {
-            partCount = receivedParts.count();
-        }
-
-        Assert.assertEquals(partCount, 0L);
     }
 }

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
@@ -41,6 +41,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -595,9 +596,13 @@ public class EncryptedServerSideMultipartManagerIT {
                 + "/" + upload.getId();
         System.err.println("listing upload directory " + uploadDirectoryPath);
 
-        final long partCount;
+        long partCount = 0;
         try (final Stream<MantaObject> receivedParts = mantaClient.listObjects(uploadDirectoryPath)) {
-            partCount = receivedParts.count();
+            Iterator<MantaObject> it = receivedParts.iterator();
+            while (it.hasNext()) {
+                it.next();
+                partCount++;
+            }
         }
 
         Assert.assertEquals(partCount, 0);

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
@@ -580,8 +580,7 @@ public class EncryptedServerSideMultipartManagerIT {
     }
 
     public final void willFailToCreatePartWhenErrorOccursDuringUpload() throws Exception {
-        final String name = UUID.randomUUID().toString();
-        final String path = testPathPrefix + name;
+        final String path = testPathPrefix + UUID.randomUUID().toString();
         final byte[] content = RandomUtils.nextBytes(2048);
 
         EncryptedMultipartUpload<ServerSideMultipartUpload> upload = multipart.initiateUpload(path);

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
@@ -9,6 +9,7 @@ package com.joyent.manta.client.multipart;
 
 import com.joyent.manta.client.MantaClient;
 import com.joyent.manta.client.MantaMetadata;
+import com.joyent.manta.client.MantaObject;
 import com.joyent.manta.client.MantaObjectInputStream;
 import com.joyent.manta.client.crypto.MantaEncryptedObjectInputStream;
 import com.joyent.manta.config.ConfigContext;
@@ -575,5 +576,30 @@ public class EncryptedServerSideMultipartManagerIT {
             AssertJUnit.assertArrayEquals("Uploaded multipart data doesn't equal actual object data",
                     content, out.toByteArray());
         }
+    }
+
+    public final void willFailToCreatePartWhenErrorOccursDuringUpload() throws Exception {
+        final String name = UUID.randomUUID().toString();
+        final String path = testPathPrefix + name;
+        final byte[] content = RandomUtils.nextBytes(2048);
+
+        EncryptedMultipartUpload<ServerSideMultipartUpload> upload = multipart.initiateUpload(path);
+
+        Assert.assertThrows(IOException.class, () -> {
+            // partial read of content1
+            multipart.uploadPart(upload, 1, new FailingInputStream(new ByteArrayInputStream(content), 1024));
+        });
+
+        final String uploadDirectoryPath = mantaClient.getContext().getMantaHomeDirectory()
+                + "/uploads/" + upload.getId().toString().charAt(0)
+                + "/" + upload.getId();
+        System.err.println("listing upload directory " + uploadDirectoryPath);
+
+        final long partCount;
+        try (final Stream<MantaObject> receivedParts = mantaClient.listObjects(uploadDirectoryPath)) {
+            partCount = receivedParts.count();
+        }
+
+        Assert.assertEquals(partCount, 0);
     }
 }


### PR DESCRIPTION
This PR adds test cases for `EncryptingEntity` and an integration test for `EncryptingPartEntity`. 

Apologies for the large segment of changes in `EncryptingEntityTest.java` I noticed the last test case I previously added (`canBeWrittenIdempotently`) was after the utility methods so I moved it to the right place before adding `doesNotCloseSuppliedOutputStreamWhenFailureOccurs` and `doesNotCloseSuppliedOutputStreamWhenWrittenSuccessfully`.

These entities should be writing content to the provided `OutputStream` but *not* closing it, otherwise requests using chunked encoding (those backed by an `InputStream`) complete successfully even if they were intended to fail. This results in intermittent test failures during the MPU commit operation where the intentionally-failing payloads in `EncryptedServerSideMultipartManagerIT#canRetryUploadPart` can "win out" over the full part content. This is visible in the following directory listing of an upload directory for a commit which failed on 409 Conflict as described in #332:

```
mls -l ~~/uploads/2/20c5f2f5-efe3-cc72-fe73-e89a7a4bc123
-rwxr-xr-x 1 java.manta.ci          1024 Sep 11 15:30 0
-rwxr-xr-x 1 java.manta.ci       5242880 Sep 11 15:30 1
-rwxr-xr-x 1 java.manta.ci           512 Sep 11 15:30 2
```

The `1024` byte part 0 would not have been created if `EncryptingPartEntity` had left the `OutputStream` intact (so that HttpClient could terminate the request correctly).