### PR TITLE
Actually disable automatic retries when set in ConfigContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project aims to adhere to [Semantic Versioning](http://semver.org/).
 ### Fixed
  - NullPointerException as a result of some configuration parameters
    [not being handled correctly unless explicity set](https://github.com/joyent/java-manta/issues/247).
+ - Setting `manta.retries`/`MANTA_HTTP_RETRIES` to 0 would print `Retry of failed requests is disabled` but
+   leave the default Apache HttpClient [retry behavior](https://hc.apache.org/httpcomponents-client-4.5.x/tutorial/html/fundamentals.html#d5e316).
 ### Changed
  - Core library code has has been extracted from `java-manta-client` into a separate module named
    `java-manta-client-unshaded` allowing users to incorporate the library into their project without bundled dependencies.

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaConnectionFactory.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaConnectionFactory.java
@@ -393,6 +393,7 @@ public class MantaConnectionFactory implements Closeable {
                    .setServiceUnavailableRetryStrategy(new MantaServiceUnavailableRetryStrategy(config));
         } else {
             LOGGER.info("Retry of failed requests is disabled");
+            builder.disableAutomaticRetries();
         }
 
         final HttpHost proxyHost = findProxyServer();


### PR DESCRIPTION
Unless explicitly disabled, automatic retries will be configured by `HttpClientBuilder`

https://github.com/apache/httpcomponents-client/blob/4.5.x/httpclient/src/main/java/org/apache/http/impl/client/HttpClientBuilder.java#L1128