### PR TITLE
per-run integration test directories with cleanup param

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -48,6 +48,10 @@ makes it possible to isolate entire runs of the test suite, e.g.
 mvn verify -Dmanta.it.path="$MANTA_USER/stor/$(git rev-parse HEAD)"
 ```
 
+By default integration tests cleanup after completion and delete the objects
+they created.  This can be disabled with the `manta.it.no_cleanup` system
+property or `MANTA_IT_NO_CLEANUP` environment variable.
+
 # Running Tests
 
 Run `mvn verify` from the project root to run all tests. Some Maven goals will

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientDirectoriesIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientDirectoriesIT.java
@@ -44,15 +44,12 @@ public class MantaClientDirectoriesIT {
         ConfigContext config = new IntegrationTestConfigContext(usingEncryption);
 
         mantaClient = new MantaClient(config);
-        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config);
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
     }
 
     @AfterClass
     public void afterClass() throws IOException {
-        if (mantaClient != null) {
-            mantaClient.deleteRecursive(testPathPrefix);
-            mantaClient.closeWithWarning();
-        }
+        IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
     @Test

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientErrorIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientErrorIT.java
@@ -50,16 +50,13 @@ public class MantaClientErrorIT {
         config = new IntegrationTestConfigContext(usingEncryption);
 
         mantaClient = new MantaClient(config);
-        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config);
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
         mantaClient.putDirectory(testPathPrefix, true);
     }
 
     @AfterClass
     public void afterClass() throws IOException {
-        if (mantaClient != null) {
-            mantaClient.deleteRecursive(testPathPrefix);
-            mantaClient.closeWithWarning();
-        }
+        IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
     @Test

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
@@ -67,16 +67,13 @@ public class MantaClientIT {
         ConfigContext config = new IntegrationTestConfigContext(usingEncryption);
 
         mantaClient = new MantaClient(config);
-        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config);
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
         mantaClient.putDirectory(testPathPrefix, true);
     }
 
     @AfterClass
     public void afterClass() throws IOException {
-        if (mantaClient != null) {
-            mantaClient.deleteRecursive(testPathPrefix);
-            mantaClient.closeWithWarning();
-        }
+        IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
     @Test

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientMetadataIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientMetadataIT.java
@@ -43,16 +43,13 @@ public class MantaClientMetadataIT {
         ConfigContext config = new IntegrationTestConfigContext(usingEncryption);
 
         mantaClient = new MantaClient(config);
-        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config);
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
         mantaClient.putDirectory(testPathPrefix, true);
     }
 
     @AfterClass
     public void cleanup() throws IOException {
-        if (mantaClient != null) {
-            mantaClient.deleteRecursive(testPathPrefix);
-            mantaClient.closeWithWarning();
-        }
+        IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
     public final void verifyAddMetadataToObjectOnPut() throws IOException {

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientPutIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientPutIT.java
@@ -58,16 +58,13 @@ public class MantaClientPutIT {
         ConfigContext config = new IntegrationTestConfigContext(usingEncryption);
 
         mantaClient = new MantaClient(config);
-        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config);
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
         mantaClient.putDirectory(testPathPrefix, true);
     }
 
     @AfterClass
     public void afterClass() throws IOException {
-        if (mantaClient != null) {
-            mantaClient.deleteRecursive(testPathPrefix);
-            mantaClient.closeWithWarning();
-        }
+        IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
     @Test

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientRangeIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientRangeIT.java
@@ -68,18 +68,13 @@ public class MantaClientRangeIT {
 
         mantaClient = new MantaClient(config);
         this.config = config;
-        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config);
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
         mantaClient.putDirectory(testPathPrefix, true);
     }
 
     @AfterClass
     public void afterClass() throws IOException {
-        if (mantaClient == null) {
-            return;
-        }
-
-        mantaClient.deleteRecursive(testPathPrefix);
-        mantaClient.closeWithWarning();
+        IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
     public final void canGetWithRangeHeader() throws IOException {

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSeekableByteChannelIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSeekableByteChannelIT.java
@@ -59,16 +59,13 @@ public class MantaClientSeekableByteChannelIT {
         }
 
         mantaClient = new MantaClient(config);
-        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config);
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
         mantaClient.putDirectory(testPathPrefix, true);
     }
 
     @AfterClass
     public void afterClass() throws IOException {
-        if (mantaClient != null) {
-            mantaClient.deleteRecursive(testPathPrefix);
-            mantaClient.closeWithWarning();
-        }
+        IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
     @Test

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSigningIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSigningIT.java
@@ -52,17 +52,13 @@ public class MantaClientSigningIT {
         config = new IntegrationTestConfigContext();
 
         mantaClient = new MantaClient(config);
-        testPathPrefix = String.format("%s/stor/%s/",
-                config.getMantaHomeDirectory(), UUID.randomUUID());
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
         mantaClient.putDirectory(testPathPrefix, null);
     }
 
     @AfterClass
     public void afterClass() throws IOException {
-        if (mantaClient != null) {
-            mantaClient.deleteRecursive(testPathPrefix);
-            mantaClient.closeWithWarning();
-        }
+        IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
     @Test

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorIT.java
@@ -46,7 +46,7 @@ public class MantaDirectoryListingIteratorIT {
         config = new IntegrationTestConfigContext(usingEncryption);
 
         mantaClient = new MantaClient(config);
-        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config);
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
         mantaClient.putDirectory(testPathPrefix, true);
 
         final KeyPairFactory keyPairFactory = new KeyPairFactory(config);
@@ -55,10 +55,7 @@ public class MantaDirectoryListingIteratorIT {
 
     @AfterClass
     public void afterClass() throws IOException {
-        if (mantaClient != null) {
-            mantaClient.deleteRecursive(testPathPrefix);
-            mantaClient.closeWithWarning();
-        }
+        IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
     @Test

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaHttpHeadersIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaHttpHeadersIT.java
@@ -63,16 +63,13 @@ public class MantaHttpHeadersIT {
         ConfigContext config = new IntegrationTestConfigContext();
 
         mantaClient = new MantaClient(config);
-        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config);
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
         mantaClient.putDirectory(testPathPrefix, true);
     }
 
     @AfterClass
     public void cleanup() throws IOException {
-        if (mantaClient != null) {
-            mantaClient.deleteRecursive(testPathPrefix);
-            mantaClient.closeWithWarning();
-        }
+        IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
     @Test

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaObjectOutputStreamIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaObjectOutputStreamIT.java
@@ -43,16 +43,13 @@ public class MantaObjectOutputStreamIT {
         ConfigContext config = new IntegrationTestConfigContext(usingEncryption);
 
         mantaClient = new MantaClient(config);
-        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config);
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
         mantaClient.putDirectory(testPathPrefix, true);
     }
 
     @AfterClass
     public void afterClass() throws IOException {
-        if (mantaClient != null) {
-            mantaClient.deleteRecursive(testPathPrefix);
-            mantaClient.closeWithWarning();
-        }
+        IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
     public void canUploadSmallString() throws IOException {

--- a/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaClientJobIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaClientJobIT.java
@@ -57,16 +57,13 @@ public class MantaClientJobIT {
 
         mantaClient = new MantaClient(config);
 
-        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config);
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
         mantaClient.putDirectory(testPathPrefix, true);
     }
 
     @AfterClass
     public void cleanup() throws IOException {
-        if (mantaClient != null) {
-            mantaClient.deleteRecursive(testPathPrefix);
-            mantaClient.closeWithWarning();
-        }
+        IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
     @Test

--- a/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaJobBuilderIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaJobBuilderIT.java
@@ -56,16 +56,13 @@ public class MantaJobBuilderIT {
 
         mantaClient = new MantaClient(config);
 
-        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config);
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
         mantaClient.putDirectory(testPathPrefix, true);
     }
 
     @AfterClass
     public void cleanup() throws IOException {
-        if (mantaClient != null) {
-            mantaClient.deleteRecursive(testPathPrefix);
-            mantaClient.closeWithWarning();
-        }
+        IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
     @Test

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedJobsMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedJobsMultipartManagerIT.java
@@ -73,18 +73,13 @@ public class EncryptedJobsMultipartManagerIT {
         this.mantaClient = new MantaClient(config);
         this.multipart = new EncryptedJobsMultipartManager(this.mantaClient);
 
-        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config);
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
         mantaClient.putDirectory(testPathPrefix, true);
     }
 
     @AfterClass
     public void afterClass() throws IOException {
-        if (this.mantaClient != null) {
-            this.mantaClient.deleteRecursive(testPathPrefix);
-            this.mantaClient.closeWithWarning();
-            this.multipart = null;
-            this.mantaClient = null;
-        }
+        IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
     public void canUploadSmallMultipartString() throws IOException {

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
@@ -84,16 +84,13 @@ public class EncryptedServerSideMultipartManagerIT {
         }
 
         multipart = new EncryptedServerSideMultipartManager(this.mantaClient);
-        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config);
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
         mantaClient.putDirectory(testPathPrefix, true);
     }
 
     @AfterClass
     public void afterClass() throws IOException {
-        if (mantaClient != null) {
-            mantaClient.deleteRecursive(testPathPrefix);
-            mantaClient.closeWithWarning();
-        }
+        IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
     public void nonExistentFileHasNotStarted() throws IOException {

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerSerializationIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerSerializationIT.java
@@ -69,16 +69,13 @@ public class EncryptedServerSideMultipartManagerSerializationIT {
         }
 
         multipart = new EncryptedServerSideMultipartManager(this.mantaClient);
-        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config);
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
         mantaClient.putDirectory(testPathPrefix, true);
     }
 
     @AfterClass
     public void afterClass() throws IOException {
-        if (mantaClient != null) {
-            mantaClient.deleteRecursive(testPathPrefix);
-            mantaClient.closeWithWarning();
-        }
+        IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
     public final void canResumeUploadWithByteArrayAndMultipleParts() throws Exception {

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/JobsMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/JobsMultipartManagerIT.java
@@ -67,19 +67,13 @@ public class JobsMultipartManagerIT {
 
         this.multipart = new JobsMultipartManager(this.mantaClient);
 
-        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config);
-
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
         mantaClient.putDirectory(testPathPrefix, true);
     }
 
     @AfterClass
     public void afterClass() throws IOException {
-        if (this.mantaClient != null) {
-            this.mantaClient.deleteRecursive(testPathPrefix);
-            this.mantaClient.closeWithWarning();
-            this.multipart = null;
-            this.mantaClient = null;
-        }
+        IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
     public void nonExistentFileHasNotStarted() throws IOException {

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/ServerSideMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/ServerSideMultipartManagerIT.java
@@ -60,16 +60,13 @@ public class ServerSideMultipartManagerIT {
         }
 
         multipart = new ServerSideMultipartManager(this.mantaClient);
-        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config);
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
         mantaClient.putDirectory(testPathPrefix, true);
     }
 
     @AfterClass
     public void afterClass() throws IOException {
-        if (mantaClient != null) {
-            mantaClient.deleteRecursive(testPathPrefix);
-            mantaClient.closeWithWarning();
-        }
+        IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
     public void nonExistentFileHasNotStarted() throws IOException {

--- a/java-manta-it/src/test/java/com/joyent/test/util/MantaPathSuiteListener.java
+++ b/java-manta-it/src/test/java/com/joyent/test/util/MantaPathSuiteListener.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.test.util;
+
+import com.joyent.manta.client.MantaClient;
+import com.joyent.manta.config.ConfigContext;
+import com.joyent.manta.config.IntegrationTestConfigContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.ISuite;
+import org.testng.ISuiteListener;
+
+import java.io.IOException;
+
+public class MantaPathSuiteListener implements ISuiteListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MantaPathSuiteListener.class);
+
+    private ConfigContext config;
+
+    @Override
+    public void onStart(ISuite suite) {
+        config = new IntegrationTestConfigContext();
+        LOG.info("Base manta path for suite {}: {}", suite.getName(),
+                 IntegrationTestConfigContext.generateSuiteBasePath(config));
+    }
+
+    @Override
+    public void onFinish(ISuite suite) {
+        MantaClient mantaClient = new MantaClient(config);
+        String path = IntegrationTestConfigContext.generateSuiteBasePath(config);
+        try {
+            if (mantaClient.isDirectoryEmpty(path)) {
+                LOG.info("Removing base suite path: {}", path);
+                mantaClient.delete(path);
+            } else {
+                LOG.warn("Base suite directory {} is not empty; leaving in place", path);
+            }
+        } catch (IOException e) {
+            LOG.warn("Unable to check on base suite path: {}", path, e);
+        }
+    }
+
+}

--- a/java-manta-it/src/test/resources/testng-it.xml
+++ b/java-manta-it/src/test/resources/testng-it.xml
@@ -1,6 +1,10 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite name="Java Manta SDK Integration Test Suite" verbose="1">
 
+    <listeners>
+        <listener class-name="com.joyent.test.util.MantaPathSuiteListener" />
+    </listeners>
+
     <test name="Manta Client Integration Test Helper Class Tests">
         <classes>
             <class name="com.joyent.test.util.FailingInputStreamTest" />


### PR DESCRIPTION
Move integration test files from
  ~~/stor/java-manta-integration-tests/$UUID_PER_CLASS/
 to
  ~~/stor/java-manta-integration-tests/$UUID_PER_RUN/$CLASS_NAME/

This makes it easier for some manual debugging, and managing data
retention after many integration test runs.  In centralizing cleanup
it was also convenient added a way to *not* cleanup after test runs.

ref #180 #320