### PR TITLE
Fixes #87 - Adds recursive directory listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project aims to adhere to [Semantic Versioning](http://semver.org/).
 
 ## [3.1.7-SNAPSHOT] - Coming soon!
+### Added
+ - [Added method MantaClient.find() which allows for recursive directory listing](https://github.com/joyent/java-manta/issues/87). 
 ### Fixed
  - Clarify version history of `MantaInputStreamEntity`
  - MPU parts which were missing an ETag in their response were

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -833,7 +833,11 @@ public class MantaClient implements AutoCloseable {
 
         /* Due to the way we concatenate the results will be quite out of order
          * if a consumer needs sorted results that is their responsibility. */
-        return Stream.concat(objectStream, dirStream);
+        final Stream<MantaObject> stream = Stream.concat(objectStream, dirStream);
+
+        danglingStreams.add(stream);
+
+        return stream;
     }
 
     /**

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -781,9 +781,11 @@ public class MantaClient implements AutoCloseable {
      * @throws IOException thrown when we are unable to list the directory over the network
      */
     public Stream<MantaObject> find(final String path) throws IOException {
+
         return listObjects(path).flatMap(obj -> {
             if (obj.isDirectory()) {
                 try {
+                    System.out.println("");
                     return Stream.concat(Stream.of(obj), find(obj.getPath()));
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -40,7 +40,6 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
@@ -95,6 +94,7 @@ import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -720,47 +720,14 @@ public class MantaClient implements AutoCloseable {
             }
         }
 
+        final int additionalCharacteristics = Spliterator.CONCURRENT
+                | Spliterator.ORDERED | Spliterator.NONNULL | Spliterator.DISTINCT;
+
         Stream<Map<String, Object>> backingStream =
                 StreamSupport.stream(Spliterators.spliteratorUnknownSize(
-                        itr, Spliterator.ORDERED | Spliterator.NONNULL), false);
+                        itr, additionalCharacteristics), true);
 
-        Stream<MantaObject> stream = backingStream.map(item -> {
-            String name = Objects.toString(item.get("name"));
-            String mtime = Objects.toString(item.get("mtime"));
-            String type = Objects.toString(item.get("type"));
-            Validate.notNull(name, "File name must not be null");
-            String objPath = String.format("%s%s%s",
-                    StringUtils.removeEnd(path, SEPARATOR),
-                    SEPARATOR,
-                    StringUtils.removeStart(name, SEPARATOR));
-            MantaHttpHeaders headers = new MantaHttpHeaders();
-            headers.setLastModified(mtime);
-
-            if (type.equals("directory")) {
-                headers.setContentType(MantaObjectResponse.DIRECTORY_RESPONSE_CONTENT_TYPE);
-            } else {
-                headers.setContentType(ContentType.APPLICATION_OCTET_STREAM.toString());
-            }
-
-            if (item.containsKey("etag")) {
-                headers.setETag(Objects.toString(item.get("etag")));
-            }
-
-            if (item.containsKey("size")) {
-                long size = Long.parseLong(Objects.toString(item.get("size")));
-                headers.setContentLength(size);
-            }
-
-            if (item.containsKey("durability")) {
-                String durabilityString = Objects.toString(item.get("durability"));
-                if (durabilityString != null) {
-                    int durability = Integer.parseInt(durabilityString);
-                    headers.setDurabilityLevel(durability);
-                }
-            }
-
-            return new MantaObjectResponse(formatPath(objPath), headers);
-        });
+        Stream<MantaObject> stream = backingStream.map(MantaObjectConversionFunction.INSTANCE);
 
         danglingStreams.add(stream);
 
@@ -772,28 +739,101 @@ public class MantaClient implements AutoCloseable {
      * this method returns a {@link Stream}, consumers can add their own
      * additional filtering based on path, object type or other criteria.</p>
      *
+     * <p>This method will make each request to each subdirectory in parallel.
+     * Parallelism settings are set by JDK system property:
+     * <code>java.util.concurrent.ForkJoinPool.common.parallelism</code></p>
+     *
      * <p><strong>WARNING:</strong> this method is not atomic and thereby not
      * safe if other operations are performed on the directory structure while
      * it is running.</p>
      *
      * @param path directory path
-     * @return A recursive {@link Stream} of {@link MantaObjectResponse} listing the contents of the directory.
+     * @return A recursive unsorted {@link Stream} of {@link MantaObject}
+     *         instances representing the contents of all subdirectories.
      * @throws IOException thrown when we are unable to list the directory over the network
      */
-    public Stream<MantaObject> find(final String path) throws IOException {
+    public Stream<MantaObject> find(final String path) {
+        return find(path, null);
+    }
 
-        return listObjects(path).flatMap(obj -> {
-            if (obj.isDirectory()) {
-                try {
-                    System.out.println("");
-                    return Stream.concat(Stream.of(obj), find(obj.getPath()));
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
+    /**
+     * <p>Finds all directories and files recursively under a given path. Since
+     * this method returns a {@link Stream}, consumers can add their own
+     * additional filtering based on path, object type or other criteria.</p>
+     *
+     * <p>This method will make each request to each subdirectory in parallel.
+     * Parallelism settings are set by JDK system property:
+     * <code>java.util.concurrent.ForkJoinPool.common.parallelism</code></p>
+     *
+     * <p>When using a filter with this method, if the filter matches a directory,
+     * then all subdirectory results for that directory will be excluded. If you
+     * want to perform a match against all results, then use {@link #find(String)}
+     * and then filter on the stream returned.</p>
+     *
+     * <p><strong>WARNING:</strong> this method is not atomic and thereby not
+     * safe if other operations are performed on the directory structure while
+     * it is running.</p>
+     *
+     * @param path directory path
+     * @param filter predicate class used to filter all results returned
+     * @return A recursive unsorted {@link Stream} of {@link MantaObject}
+     *         instances representing the contents of all subdirectories.
+     * @throws IOException thrown when we are unable to list the directory over the network
+     */
+    public Stream<MantaObject> find(final String path,
+                                    final Predicate<? super MantaObject> filter) {
+        /* We read directly from the iterator here to reduce the total stack
+         * frames and to reduce the amount of abstraction to a minimum.
+         *
+         * Within this loop, we store all of the objects found in memory so
+         * that we can later query find() methods for the directory objects
+         * in parallel. */
+        final Stream.Builder<MantaObject> objectBuilder = Stream.builder();
+        final Stream.Builder<MantaObject> dirBuilder = Stream.builder();
+
+        try (MantaDirectoryListingIterator itr = streamingIterator(path)) {
+            while (itr.hasNext()) {
+                final Map<String, Object> item = itr.next();
+                final MantaObject obj = MantaObjectConversionFunction.INSTANCE.apply(item);
+
+                /* We take a predicate as a method parameter because it allows
+                 * us to filter at the highest level within this iterator. If
+                 * we just passed the stream as is back to the user, then
+                 * they would have to filter the results *after* all of the
+                 * HTTP requests were made. This way the filter can help limit
+                 * the total number of HTTP requests made to Manta. */
+                if (filter == null || filter.test(obj)) {
+                    objectBuilder.accept(obj);
+
+                    if (obj.isDirectory()) {
+                        dirBuilder.accept(obj);
+                    }
                 }
-            } else {
-                return Stream.of(obj);
             }
-        });
+        }
+
+        /* All objects within this directory should be included in the results,
+         * so we have a stream stored here that will later be concatenated. */
+        final Stream<MantaObject> objectStream = objectBuilder.build();
+
+        /* Directories are processed in parallel because it is the only unit
+         * within our abstractions that can be properly done in parallel.
+         * MantaDirectoryListingIterator forces all paging of directory
+         * listings to be sequential requests. However, it works fine to
+         * run multiple MantaDirectoryListingIterator instances per request.
+         * That is exactly what we are doing here using streams which is
+         * allowing us to do the recursive calls in a lazy fashion.
+         *
+         * From a HTTP request perspective, this means that only the listing for
+         * this current highly directory is performed and no other listing
+         * will be performed until the stream is read.
+         */
+        final Stream<MantaObject> dirStream = dirBuilder.build()
+                .parallel().flatMap(obj -> find(obj.getPath(), filter));
+
+        /* Due to the way we concatenate the results will be quite out of order
+         * if a consumer needs sorted results that is their responsibility. */
+        return Stream.concat(objectStream, dirStream);
     }
 
     /**

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaDirectoryListingIterator.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaDirectoryListingIterator.java
@@ -227,6 +227,11 @@ public class MantaDirectoryListingIterator implements Iterator<Map<String, Objec
 
             Validate.notNull(name, "Name must not be null in JSON input");
 
+            /* Explicitly set the path of the object here so that we don't need
+             * to create a new instance of MantaObjectConversionFunction per
+             * object being read. */
+            lookup.put("path", path);
+
             this.lastMarker = name;
 
             return lookup;

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaObjectConversionFunction.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaObjectConversionFunction.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.manta.client;
+
+import com.joyent.manta.http.MantaHttpHeaders;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
+import org.apache.http.entity.ContentType;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+import static com.joyent.manta.client.MantaClient.SEPARATOR;
+import static com.joyent.manta.util.MantaUtils.formatPath;
+
+/**
+ * Function class that provides the conversion method for mapping a {@link Map}
+ * to a {@link MantaObject}.
+ *
+ * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @since 3.1.7
+ */
+public class MantaObjectConversionFunction implements Function<Map<String, Object>, MantaObject> {
+    /**
+     * Static instance to be used as a singleton.
+     */
+    static final MantaObjectConversionFunction INSTANCE = new MantaObjectConversionFunction();
+
+    @Override
+    public MantaObject apply(final Map<String, Object> item) {
+        String name = Objects.toString(item.get("name"));
+        String mtime = Objects.toString(item.get("mtime"));
+        String type = Objects.toString(item.get("type"));
+        Validate.notNull(name, "File name must not be null");
+        String objPath = String.format("%s%s%s",
+                StringUtils.removeEnd(item.get("path").toString(), SEPARATOR),
+                SEPARATOR,
+                StringUtils.removeStart(name, SEPARATOR));
+        MantaHttpHeaders headers = new MantaHttpHeaders();
+        headers.setLastModified(mtime);
+
+        if (type.equals(MantaObject.MANTA_OBJECT_TYPE_DIRECTORY)) {
+            headers.setContentType(MantaObjectResponse.DIRECTORY_RESPONSE_CONTENT_TYPE);
+        } else {
+            headers.setContentType(ContentType.APPLICATION_OCTET_STREAM.toString());
+        }
+
+        if (item.containsKey("etag")) {
+            headers.setETag(Objects.toString(item.get("etag")));
+        }
+
+        if (item.containsKey("size")) {
+            long size = Long.parseLong(Objects.toString(item.get("size")));
+            headers.setContentLength(size);
+        }
+
+        if (item.containsKey("durability")) {
+            String durabilityString = Objects.toString(item.get("durability"));
+            if (durabilityString != null) {
+                int durability = Integer.parseInt(durabilityString);
+                headers.setDurabilityLevel(durability);
+            }
+        }
+
+        return new MantaObjectResponse(formatPath(objPath), headers);
+    }
+}

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientDirectoriesIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientDirectoriesIT.java
@@ -14,8 +14,6 @@ import com.joyent.test.util.MantaFunction;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Optional;
-import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -38,10 +36,9 @@ public class MantaClientDirectoriesIT {
     private String testPathPrefix;
 
     @BeforeClass
-    @Parameters({"usingEncryption"})
-    public void beforeClass(@Optional Boolean usingEncryption) throws IOException {
+    public void beforeClass() throws IOException {
         // Let TestNG configuration take precedence over environment variables
-        ConfigContext config = new IntegrationTestConfigContext(usingEncryption);
+        ConfigContext config = new IntegrationTestConfigContext();
 
         mantaClient = new MantaClient(config);
         testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientFindIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientFindIT.java
@@ -112,27 +112,27 @@ public class MantaClientFindIT {
             mantaClient.put(file, TEST_DATA, StandardCharsets.UTF_8);
         }
 
-        int totalObjects = level1Dirs.size() + level1Files.size() + level2Files.size();
+        List<String> allObjects = new LinkedList<>();
+        allObjects.addAll(level1Dirs);
+        allObjects.addAll(level1Files);
+        allObjects.addAll(level2Files);
+
+        final List<MantaObject> results;
 
         try (Stream<MantaObject> stream = mantaClient.find(testPathPrefix)) {
-            List<MantaObject> results = stream.collect(Collectors.toList());
+            results = stream.collect(Collectors.toList());
+        }
 
-            Assert.assertFalse(results.isEmpty(),
-                    "We should have many objects returned");
-            Assert.assertEquals(results.size(), totalObjects,
-                    "We should return exactly as many objects as added");
+        Assert.assertFalse(results.isEmpty(),
+                "We should have many objects returned");
+        Assert.assertEquals(results.size(), allObjects.size(),
+                "We should return exactly as many objects as added");
 
-            Stream<MantaObject> resultsStream = results.stream();
-
-            List<String> allObjects = new LinkedList<>();
-            allObjects.addAll(level1Dirs);
-            allObjects.addAll(level1Files);
-            allObjects.addAll(level2Files);
-
-            for (String dir : level1Dirs) {
-                Assert.assertEquals(
-                        resultsStream.filter(obj -> obj.getPath().equals(dir)).count(),
-                        1);
+        for (String expectedObject : allObjects) {
+            try (Stream<MantaObject> resultsStream = results.stream()) {
+                long count = resultsStream
+                        .filter(obj -> obj.getPath().equals(expectedObject)).count();
+                Assert.assertEquals(count, 1L);
             }
         }
     }

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientFindIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientFindIT.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.manta.client;
+
+import com.joyent.manta.config.ConfigContext;
+import com.joyent.manta.config.IntegrationTestConfigContext;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.joyent.manta.client.MantaClient.SEPARATOR;
+
+/**
+ * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @since 3.0.0
+ */
+@Test
+public class MantaClientFindIT {
+    private static final String TEST_DATA = "EPISODEII_IS_BEST_EPISODE";
+
+    private MantaClient mantaClient;
+
+    private String testPathPrefix;
+
+    @BeforeClass
+    @Parameters({"usingEncryption"})
+    public void beforeClass(@Optional Boolean usingEncryption) throws IOException {
+        // Let TestNG configuration take precedence over environment variables
+        ConfigContext config = new IntegrationTestConfigContext(usingEncryption);
+
+        mantaClient = new MantaClient(config);
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
+        mantaClient.putDirectory(testPathPrefix, true);
+    }
+
+    @AfterClass
+    public void afterClass() throws IOException {
+        IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
+    }
+
+    @AfterMethod
+    public void cleanUp() throws IOException {
+        mantaClient.deleteRecursive(testPathPrefix);
+        mantaClient.putDirectory(testPathPrefix, true);
+    }
+
+    public void canFindASingleFile() throws IOException {
+        String filePath = testPathPrefix + UUID.randomUUID();
+        mantaClient.put(filePath, TEST_DATA, StandardCharsets.UTF_8);
+
+        try (Stream<MantaObject> stream = mantaClient.find(testPathPrefix)) {
+            List<MantaObject> results = stream.collect(Collectors.toList());
+
+            Assert.assertFalse(results.isEmpty(), "We should have at least one file returned");
+            Assert.assertEquals(results.get(0).getPath(), filePath);
+            Assert.assertFalse(results.get(0).isDirectory());
+        }
+    }
+
+    public void canFindASingleDirectory() throws IOException {
+        String dirPath = testPathPrefix + UUID.randomUUID();
+        mantaClient.putDirectory(dirPath);
+
+        try (Stream<MantaObject> stream = mantaClient.find(testPathPrefix)) {
+            List<MantaObject> results = stream.collect(Collectors.toList());
+
+            Assert.assertFalse(results.isEmpty(), "We should have at least one directory returned");
+            Assert.assertEquals(results.get(0).getPath(), dirPath);
+            Assert.assertTrue(results.get(0).isDirectory());
+        }
+    }
+
+    public void canFindRecursiveDirectoriesAndFiles() throws IOException {
+        List<String> level1Dirs = Arrays.asList(
+                testPathPrefix + UUID.randomUUID(), testPathPrefix + UUID.randomUUID(),
+                testPathPrefix + UUID.randomUUID()
+        );
+
+        List<String> level1Files = Arrays.asList(
+                testPathPrefix + UUID.randomUUID(), testPathPrefix + UUID.randomUUID()
+        );
+
+        for (String dir : level1Dirs) {
+            mantaClient.putDirectory(dir);
+        }
+
+        for (String file : level1Files) {
+            mantaClient.put(file, TEST_DATA, StandardCharsets.UTF_8);
+        }
+
+        List<String> level2Files = level1Dirs
+                .stream()
+                .flatMap(dir -> Stream.of(dir + SEPARATOR + UUID.randomUUID(),
+                                          dir + SEPARATOR + UUID.randomUUID()))
+                .collect(Collectors.toList());
+
+        for (String file : level2Files) {
+            mantaClient.put(file, TEST_DATA, StandardCharsets.UTF_8);
+        }
+
+        int totalObjects = level1Dirs.size() + level1Files.size() + level2Files.size();
+
+        try (Stream<MantaObject> stream = mantaClient.find(testPathPrefix)) {
+            List<MantaObject> results = stream.collect(Collectors.toList());
+
+            Assert.assertFalse(results.isEmpty(),
+                    "We should have many objects returned");
+            Assert.assertEquals(results.size(), totalObjects,
+                    "We should return exactly as many objects as added");
+
+            Stream<MantaObject> resultsStream = results.stream();
+
+            List<String> allObjects = new LinkedList<>();
+            allObjects.addAll(level1Dirs);
+            allObjects.addAll(level1Files);
+            allObjects.addAll(level2Files);
+
+            for (String dir : level1Dirs) {
+                Assert.assertEquals(
+                        resultsStream.filter(obj -> obj.getPath().equals(dir)).count(),
+                        1);
+            }
+        }
+    }
+}

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientFindIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientFindIT.java
@@ -9,20 +9,24 @@ package com.joyent.manta.client;
 
 import com.joyent.manta.config.ConfigContext;
 import com.joyent.manta.config.IntegrationTestConfigContext;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Optional;
-import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
 import java.util.UUID;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -37,10 +41,9 @@ public class MantaClientFindIT {
     private String testPathPrefix;
 
     @BeforeClass
-    @Parameters({"usingEncryption"})
-    public void beforeClass(@Optional Boolean usingEncryption) throws IOException {
+    public void beforeClass() throws IOException {
         // Let TestNG configuration take precedence over environment variables
-        ConfigContext config = new IntegrationTestConfigContext(usingEncryption);
+        ConfigContext config = new IntegrationTestConfigContext();
 
         mantaClient = new MantaClient(config);
         testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
@@ -84,6 +87,10 @@ public class MantaClientFindIT {
         }
     }
 
+    /**
+     * This test determines if the find() method can find a trivial amount of
+     * files and directories.
+     */
     public void canFindRecursiveDirectoriesAndFiles() throws IOException {
         List<String> level1Dirs = Arrays.asList(
                 testPathPrefix + UUID.randomUUID(), testPathPrefix + UUID.randomUUID(),
@@ -135,5 +142,152 @@ public class MantaClientFindIT {
                 Assert.assertEquals(count, 1L);
             }
         }
+    }
+
+    /**
+     * This test determines that we are filtering results as per our expection
+     * when using a filter predicate with find().
+     */
+    public void canFindRecursivelyWithFilter() throws IOException {
+        List<String> level1Dirs = Arrays.asList(
+                testPathPrefix + "aaa_bbb_ccc", testPathPrefix + "aaa_111_ccc",
+                testPathPrefix + UUID.randomUUID()
+        );
+
+        List<String> level1Files = Arrays.asList(
+                testPathPrefix + UUID.randomUUID(), testPathPrefix + "aaa_222_ccc"
+        );
+
+        for (String dir : level1Dirs) {
+            mantaClient.putDirectory(dir);
+        }
+
+        for (String file : level1Files) {
+            mantaClient.put(file, TEST_DATA, StandardCharsets.UTF_8);
+        }
+
+        List<String> level2Files = level1Dirs
+                .stream()
+                .flatMap(dir -> Stream.of(
+                        dir + SEPARATOR + "aaa_333_ccc",
+                        dir + SEPARATOR + "aaa_444_ccc",
+                        dir + SEPARATOR + UUID.randomUUID()))
+                .collect(Collectors.toList());
+
+        for (String file : level2Files) {
+            mantaClient.put(file, TEST_DATA, StandardCharsets.UTF_8);
+        }
+
+        final String[] results;
+
+        Predicate<? super MantaObject> filter = (Predicate<MantaObject>) obj ->
+                FilenameUtils.getName(obj.getPath()).startsWith("aaa_");
+
+        try (Stream<MantaObject> stream = mantaClient.find(testPathPrefix, filter)) {
+            Stream<String> paths = stream.map(MantaObject::getPath);
+            Stream<String> sorted = paths.sorted();
+            results = sorted.toArray(String[]::new);
+        }
+
+        String[] expected = new String[] {
+                testPathPrefix + "aaa_111_ccc",
+                testPathPrefix + "aaa_111_ccc" + SEPARATOR + "aaa_333_ccc",
+                testPathPrefix + "aaa_111_ccc" + SEPARATOR + "aaa_444_ccc",
+                testPathPrefix + "aaa_222_ccc",
+                testPathPrefix + "aaa_bbb_ccc",
+                testPathPrefix + "aaa_bbb_ccc" + SEPARATOR + "aaa_333_ccc",
+                testPathPrefix + "aaa_bbb_ccc" + SEPARATOR + "aaa_444_ccc",
+        };
+
+        try {
+            Assert.assertEqualsNoOrder(results, expected);
+        } catch (AssertionError e) {
+            System.err.println("ACTUAL:   " + StringUtils.join(results, ", "));
+            System.err.println("EXPECTED: " + StringUtils.join(expected, ", "));
+            throw e;
+        }
+    }
+
+    /**
+     * This test determines that the find() method can recurse to a reasonable
+     * number of subdirectories without throwing a {@link StackOverflowError}.
+     *
+     * As you go over 70 subdirectories, Manta will throw a 500 error. We should
+     * be able to recurse to a stack depth far deeper than Manta can support
+     * for subdirectories.
+     */
+    public void findCanDeeplyRecurse() throws IOException {
+        final int depth = 70;
+        final StringBuilder path = new StringBuilder(testPathPrefix);
+        mantaClient.putDirectory(path.toString());
+
+        final int currentDepth = StringUtils.countMatches(testPathPrefix, SEPARATOR);
+
+        // We start with i=currentDepth because we are already currentDepth levels deep
+        for (int i = currentDepth; i < depth; i++) {
+            path.append(UUID.randomUUID() + SEPARATOR);
+            mantaClient.putDirectory(path.toString());
+            String file = path + String.format("subdirectory-file-%d.txt", i);
+            mantaClient.put(file, TEST_DATA, StandardCharsets.UTF_8);
+        }
+
+        mantaClient.find(path.toString());
+    }
+
+    /**
+     * This test sees if find() can find a large number of files spread across
+     * many directories. It validates the results against the node.js Manta CLI
+     * tool mls.
+     *
+     * This test is disabled by default because it is difficult to know if the
+     * running system has the node.js CLI tools properly installed. Please run
+     * this test manually on an as-needed basis.
+     */
+    @Test(enabled = false)
+    public void findMatchesMfind() throws SecurityException, IOException, InterruptedException {
+        ConfigContext context = mantaClient.getContext();
+        String reports = context.getMantaHomeDirectory()
+                + SEPARATOR + "reports" + SEPARATOR + "usage" + SEPARATOR + "summary";
+        String[] cmd = new String[] { "mfind", reports };
+
+        ProcessBuilder processBuilder = new ProcessBuilder(cmd);
+
+        Map<String, String> env = processBuilder.environment();
+        env.put("MANTA_URL", context.getMantaURL());
+        env.put("MANTA_USER", context.getMantaUser());
+        env.put("MANTA_KEY_ID", context.getMantaKeyId());
+
+        long mFindStart = System.nanoTime();
+        Process process = processBuilder.start();
+
+        String charsetName = StandardCharsets.UTF_8.name();
+
+        List<String> objects = new LinkedList<>();
+
+        try (Scanner scanner = new Scanner(process.getInputStream(), charsetName)) {
+            while (scanner.hasNextLine()) {
+                objects.add(scanner.nextLine());
+            }
+        }
+
+        System.err.println("Waiting for mfind to complete");
+        Assert.assertEquals(process.waitFor(), 0,
+                "mfind exited with an error");
+        long mFindEnd = System.nanoTime();
+        System.err.printf("mfind process completed in %d ms\n",
+                Duration.ofNanos(mFindEnd - mFindStart).toMillis());
+
+        long findStart = System.nanoTime();
+
+        List<String> foundObjects;
+        try (Stream<MantaObject> findStream = mantaClient.find(reports)) {
+            foundObjects= findStream.map(MantaObject::getPath).collect(Collectors.toList());
+        }
+
+        long findEnd = System.nanoTime();
+        System.err.printf("find() completed in %d ms\n",
+                Duration.ofNanos(findEnd - findStart).toMillis());
+
+        Assert.assertEqualsNoOrder(objects.toArray(), foundObjects.toArray());
     }
 }

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientFindIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientFindIT.java
@@ -28,10 +28,6 @@ import java.util.stream.Stream;
 
 import static com.joyent.manta.client.MantaClient.SEPARATOR;
 
-/**
- * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
- * @since 3.0.0
- */
 @Test
 public class MantaClientFindIT {
     private static final String TEST_DATA = "EPISODEII_IS_BEST_EPISODE";

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorIT.java
@@ -9,7 +9,6 @@ package com.joyent.manta.client;
 
 import com.joyent.manta.config.ConfigContext;
 import com.joyent.manta.config.IntegrationTestConfigContext;
-import com.joyent.manta.config.KeyPairFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -18,7 +17,6 @@ import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
-import java.security.KeyPair;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.UUID;
@@ -36,21 +34,16 @@ public class MantaDirectoryListingIteratorIT {
 
     private String testPathPrefix;
 
-    private ConfigContext config;
-
     @BeforeClass
     @Parameters({"usingEncryption"})
     public void beforeClass(@Optional Boolean usingEncryption) throws IOException {
 
         // Let TestNG configuration take precedence over environment variables
-        config = new IntegrationTestConfigContext(usingEncryption);
+        ConfigContext config = new IntegrationTestConfigContext(usingEncryption);
 
         mantaClient = new MantaClient(config);
         testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
         mantaClient.putDirectory(testPathPrefix, true);
-
-        final KeyPairFactory keyPairFactory = new KeyPairFactory(config);
-        final KeyPair keyPair = keyPairFactory.createKeyPair();
     }
 
     @AfterClass

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -2,6 +2,7 @@
 <!DOCTYPE suppressions PUBLIC "-//Puppy Crawl//DTD Suppressions 1.1//EN" "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
     <suppress checks="DesignForExtension" files="MantaClient.java" />
+    <suppress checks="FileLength" files="MantaClient.java" />
     <suppress checks="LineLength" files="MantaCLI.java" />
     <suppress checks="MagicNumber" files="MantaCLI.java" />
     <suppress checks="MagicNumber" files="Benchmark.java" />


### PR DESCRIPTION
I needed to write this code for adding Manta support to [Presto](https://prestodb.io) and we had an old issue for it in the client, so I went ahead and did it in the client. We may want to bump the version to 3.2.0 if we do accept this change.

This change adds a new method to MantaClient called find(). This method
allows you to recursively find all objects under a given directory path.