### PR TITLE
MBean interface and ThreadLocalSigner ownership

### DIFF
--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MBeanable.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MBeanable.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.manta.client;
+
+/**
+ * Interface for objects that can make themselves available as MBeans.
+ */
+public interface MBeanable {
+
+    /**
+     * Provide a bean to the {@link MantaMBeanSupervisor} that represents this object.
+     *
+     * @param supervisor the {@link MantaMBeanSupervisor} in charge of
+     *                   registering and deregistering the representative bean
+     */
+    void createExposedMBean(MantaMBeanSupervisor supervisor);
+}

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MBeanable.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MBeanable.java
@@ -7,13 +7,20 @@
  */
 package com.joyent.manta.client;
 
+import javax.management.DynamicMBean;
+
 /**
  * Interface for objects that can make themselves available as MBeans.
+ *
+ * @author <a href="https://github.com/tjcelaya">Tomas Celaya</a>
+ * @since 3.1.7
  */
 public interface MBeanable {
 
     /**
-     * Provide a bean to the {@link MantaMBeanSupervisor} that represents this object.
+     * Provide an MBean to the {@link MantaMBeanSupervisor} that represents this object for
+     * registration in JMX. Closing the supervisor will deregister the MBean. Implementations are expected
+     * to call {@link MantaMBeanSupervisor#expose(DynamicMBean)}.
      *
      * @param supervisor the {@link MantaMBeanSupervisor} in charge of
      *                   registering and deregistering the representative bean

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -247,8 +247,8 @@ public class MantaClient implements AutoCloseable {
 
         this.beanSupervisor = new MantaMBeanSupervisor();
 
-        this.config.createExposedMBean(beanSupervisor);
-        this.connectionFactory.createExposedMBean(beanSupervisor);
+        beanSupervisor.expose(this.config);
+        beanSupervisor.expose(connectionFactory);
     }
 
     /**

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -27,7 +27,6 @@ import com.joyent.manta.http.ContentTypeLookup;
 import com.joyent.manta.http.EncryptionHttpHelper;
 import com.joyent.manta.http.HttpHelper;
 import com.joyent.manta.http.MantaApacheHttpClientContext;
-import com.joyent.manta.http.MantaConnectionContext;
 import com.joyent.manta.http.MantaConnectionFactory;
 import com.joyent.manta.http.MantaContentTypes;
 import com.joyent.manta.http.MantaHttpHeaders;

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -165,7 +165,14 @@ public class MantaClient implements AutoCloseable {
             = (Collections.newSetFromMap(new ConcurrentWeakIdentityHashMap<>()));
 
     /**
-     * Signing object used for authentication and signed URL generation.
+     * Signing object used for authentication and signed URL generation. We wrap it in a {@link WeakReference}
+     * to avoid memory leaks which can occur when {@link ThreadLocal} objects are used inside of
+     * an application container.
+     *
+     * @see <a href="https://plumbr.eu/blog/locked-threads/how-to-shoot-yourself-in-foot-with-threadlocals">How to
+     * shoot yourself in the foot with ThreadLocals
+     *     </a>
+     * @see <a href="https://blog.codecentric.de/en/2008/09/a-threadlocal-memory-leak/">A ThreadLocal Memory Leak</a>
      */
     private final WeakReference<ThreadLocalSigner> signerRef;
 

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaMBeanSupervisor.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaMBeanSupervisor.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.manta.client;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.management.ManagementFactory;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.management.DynamicMBean;
+import javax.management.JMException;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+/**
+ * Helper class for keeping track of MBeans associated with a {@link MantaClient}.
+ */
+public class MantaMBeanSupervisor implements AutoCloseable {
+
+    @SuppressWarnings("JavaDocVariable")
+    private static final Logger LOGGER = LoggerFactory.getLogger(MantaMBeanSupervisor.class);
+
+    /**
+     * Format string for creating {@link ObjectName}s.
+     */
+    private static final String FMT_MBEAN_OBJECT_NAME = "com.joyent.manta.client:type=%s[%d]";
+
+    /**
+     * A running count of the times we have created new {@link MantaMBeanSupervisor}
+     * instances.
+     */
+    private static final AtomicInteger SUPERVISOR_COUNT = new AtomicInteger(0);
+
+    /**
+     * List of all MBeans to be added to JMX.
+     */
+    private final Map<ObjectName, DynamicMBean> beans;
+
+    /**
+     * Supervisor index. Used to avoid JMX {@link ObjectName} collisions.
+     */
+    private final int idx;
+
+    /**
+     * Create a new supervisor that will own an index and a set of beans.
+     */
+    MantaMBeanSupervisor() {
+        idx = SUPERVISOR_COUNT.incrementAndGet();
+        beans = new WeakHashMap<>();
+    }
+
+    /**
+     * Attempts to create an {@link ObjectName} for a {@link DynamicMBean} and register it with the platform's
+     * {@link MBeanServer}.
+     *
+     * @param bean the bean to attempt to register
+     */
+    public void expose(final DynamicMBean bean) {
+        final ObjectName name;
+        try {
+            name = new ObjectName(String.format(FMT_MBEAN_OBJECT_NAME, bean.getClass().getSimpleName(), idx));
+        } catch (final JMException e) {
+            LOGGER.warn("Error creating bean: " + bean.getClass().getSimpleName(), e);
+            return;
+        }
+
+        try {
+            ManagementFactory.getPlatformMBeanServer().registerMBean(bean, name);
+            beans.put(name, bean);
+        } catch (final JMException e) {
+            LOGGER.warn(String.format("Error registering [%s] MBean in JMX", name), e);
+        }
+    }
+
+    /**
+     * Deregisters the beans stored in {@code this.beans} so
+     * that they are no longer visible via JMX.
+     */
+    @Override
+    public void close() throws Exception {
+        final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+
+        for (final Map.Entry<ObjectName, DynamicMBean> bean : beans.entrySet()) {
+            try {
+                server.unregisterMBean(bean.getKey());
+            } catch (final JMException e) {
+                String msg = String.format("Error deregistering [%s] MBean in JMX",
+                        bean.getKey());
+                LOGGER.warn(msg, e);
+            }
+        }
+    }
+}

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaMBeanSupervisor.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaMBeanSupervisor.java
@@ -30,7 +30,7 @@ import javax.management.ObjectName;
  * @author <a href="https://github.com/tjcelaya">Tomas Celaya</a>
  * @since 3.1.7
  */
-public class MantaMBeanSupervisor implements AutoCloseable {
+class MantaMBeanSupervisor implements AutoCloseable {
 
     @SuppressWarnings("JavaDocVariable")
     private static final Logger LOGGER = LoggerFactory.getLogger(MantaMBeanSupervisor.class);
@@ -70,11 +70,21 @@ public class MantaMBeanSupervisor implements AutoCloseable {
      * Attempts to create an {@link ObjectName} for a {@link DynamicMBean} and register it with the platform's
      * {@link MBeanServer}.
      *
-     * @param bean the bean to attempt to register
+     * @param beanable the bean to attempt to register
      */
-    public void expose(final DynamicMBean bean) {
+    void expose(final MantaMBeanable beanable) {
         if (closed.get()) {
             throw new IllegalStateException("Cannot register MBeans, supervisor has been closed");
+        }
+
+        final DynamicMBean bean = beanable.toMBean();
+
+        if (bean == null) {
+            if (LOGGER.isWarnEnabled()) {
+                LOGGER.warn("MantaMBeanable object returned null");
+            }
+
+            return;
         }
 
         final ObjectName name;
@@ -94,11 +104,11 @@ public class MantaMBeanSupervisor implements AutoCloseable {
     }
 
     /**
-     * Prepare the supervisor for reuse
+     * Prepare the supervisor for reuse.
      *
      * @throws Exception if an exception is thrown by {@link #close()}
      */
-    public void reset() throws Exception {
+    void reset() throws Exception {
         if (!beans.isEmpty()) {
             close();
         }

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaMBeanSupervisor.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaMBeanSupervisor.java
@@ -21,6 +21,13 @@ import javax.management.ObjectName;
 
 /**
  * Helper class for keeping track of MBeans associated with a {@link MantaClient}.
+ *
+ * Note: The purpose of SUPERVISOR_COUNT is to avoid {@link ObjectName} collisions. Every instance of
+ * this class will have a unique index associated with it that will be used to register the MBeans it receives.
+ *
+ * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @author <a href="https://github.com/tjcelaya">Tomas Celaya</a>
+ * @since 3.1.7
  */
 public class MantaMBeanSupervisor implements AutoCloseable {
 

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaMBeanSupervisor.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaMBeanSupervisor.java
@@ -56,6 +56,9 @@ class MantaMBeanSupervisor implements AutoCloseable {
      */
     private final int idx;
 
+    /**
+     * Flag indicating if the supervisor has been "closed" (i.e. beans deregistered)
+     */
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
     /**

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaMBeanSupervisor.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaMBeanSupervisor.java
@@ -11,8 +11,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.management.ManagementFactory;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.management.DynamicMBean;
@@ -63,7 +63,7 @@ public class MantaMBeanSupervisor implements AutoCloseable {
      */
     MantaMBeanSupervisor() {
         idx = SUPERVISOR_COUNT.incrementAndGet();
-        beans = new WeakHashMap<>();
+        beans = new HashMap<>(2);
     }
 
     /**

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaMBeanable.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaMBeanable.java
@@ -15,7 +15,7 @@ import javax.management.DynamicMBean;
  * @author <a href="https://github.com/tjcelaya">Tomas Celaya</a>
  * @since 3.1.7
  */
-public interface MBeanable {
+public interface MantaMBeanable {
 
     /**
      * Provide an MBean to the {@link MantaMBeanSupervisor} that represents this object for

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaMBeanable.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaMBeanable.java
@@ -18,12 +18,9 @@ import javax.management.DynamicMBean;
 public interface MantaMBeanable {
 
     /**
-     * Provide an MBean to the {@link MantaMBeanSupervisor} that represents this object for
-     * registration in JMX. Closing the supervisor will deregister the MBean. Implementations are expected
-     * to call {@link MantaMBeanSupervisor#expose(DynamicMBean)}.
+     * Provide an MBean that represents this object for registration in JMX.
      *
-     * @param supervisor the {@link MantaMBeanSupervisor} in charge of
-     *                   registering and deregistering the representative bean
+     * @return The {@link DynamicMBean} that represents {@code this}
      */
-    void createExposedMBean(MantaMBeanSupervisor supervisor);
+    DynamicMBean toMBean();
 }

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/ConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/ConfigContext.java
@@ -7,12 +7,15 @@
  */
 package com.joyent.manta.config;
 
+import com.joyent.manta.client.MBeanable;
+import com.joyent.manta.client.MantaMBeanSupervisor;
 import com.joyent.manta.client.crypto.SupportedCiphersLookupMap;
 import com.joyent.manta.exception.ConfigurationException;
 import com.joyent.manta.util.MantaUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
 
 import java.io.File;
 import java.net.URI;
@@ -27,7 +30,7 @@ import java.util.List;
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  */
-public interface ConfigContext {
+public interface ConfigContext extends MBeanable {
     /**
      * @return Manta service endpoint.
      */
@@ -161,6 +164,13 @@ public interface ConfigContext {
      * @return private encryption key data (can't be used if private key path is not null)
      */
     byte[] getEncryptionPrivateKeyBytes();
+
+    /** {@inheritDoc} */
+    @Override
+    default void createExposedMBean(final MantaMBeanSupervisor beanSupervisor) {
+        Validate.notNull(beanSupervisor, "MantaMBeanSupervisor must not be null");
+        beanSupervisor.expose(new ConfigContextMBean(this));
+    }
 
     /**
      * Extracts the home directory based on the Manta account name.

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/ConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/ConfigContext.java
@@ -7,7 +7,7 @@
  */
 package com.joyent.manta.config;
 
-import com.joyent.manta.client.MBeanable;
+import com.joyent.manta.client.MantaMBeanable;
 import com.joyent.manta.client.MantaMBeanSupervisor;
 import com.joyent.manta.client.crypto.SupportedCiphersLookupMap;
 import com.joyent.manta.exception.ConfigurationException;
@@ -30,7 +30,7 @@ import java.util.List;
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  */
-public interface ConfigContext extends MBeanable {
+public interface ConfigContext extends MantaMBeanable {
     /**
      * @return Manta service endpoint.
      */

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/ConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/ConfigContext.java
@@ -8,14 +8,12 @@
 package com.joyent.manta.config;
 
 import com.joyent.manta.client.MantaMBeanable;
-import com.joyent.manta.client.MantaMBeanSupervisor;
 import com.joyent.manta.client.crypto.SupportedCiphersLookupMap;
 import com.joyent.manta.exception.ConfigurationException;
 import com.joyent.manta.util.MantaUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.Validate;
 
 import java.io.File;
 import java.net.URI;
@@ -23,6 +21,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
+import javax.management.DynamicMBean;
 
 /**
  * Interface representing the configuration properties needed to configure a
@@ -167,9 +166,8 @@ public interface ConfigContext extends MantaMBeanable {
 
     /** {@inheritDoc} */
     @Override
-    default void createExposedMBean(final MantaMBeanSupervisor beanSupervisor) {
-        Validate.notNull(beanSupervisor, "MantaMBeanSupervisor must not be null");
-        beanSupervisor.expose(new ConfigContextMBean(this));
+    default DynamicMBean toMBean() {
+        return new ConfigContextMBean(this);
     }
 
     /**

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaConnectionFactory.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaConnectionFactory.java
@@ -21,8 +21,6 @@ import org.apache.http.Header;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequestInterceptor;
-import org.apache.http.NameValuePair;
-import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.ConnectionConfig;

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaConnectionFactory.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaConnectionFactory.java
@@ -144,6 +144,9 @@ public class MantaConnectionFactory implements Closeable, MBeanable {
                 DefaultsConfigContext.DEFAULT_NO_AUTH);
 
         if (!authDisabled) {
+            Validate.notNull(keyPair, "KeyPair must not be null if authentication is enabled");
+            Validate.notNull(signer, "Signer must not be null if authentication is enabled");
+
             // pass true directly to the constructor because auth is enabled
             final HttpRequestInterceptor authInterceptor = new HttpSignatureRequestInterceptor(
                             new HttpSignatureAuthScheme(keyPair, signer),

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaConnectionFactory.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaConnectionFactory.java
@@ -10,7 +10,7 @@ package com.joyent.manta.http;
 import com.joyent.http.signature.ThreadLocalSigner;
 import com.joyent.http.signature.apache.httpclient.HttpSignatureAuthScheme;
 import com.joyent.http.signature.apache.httpclient.HttpSignatureRequestInterceptor;
-import com.joyent.manta.client.MBeanable;
+import com.joyent.manta.client.MantaMBeanable;
 import com.joyent.manta.client.MantaMBeanSupervisor;
 import com.joyent.manta.config.ConfigContext;
 import com.joyent.manta.config.DefaultsConfigContext;
@@ -78,7 +78,7 @@ import java.util.List;
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  * @since 3.0.0
  */
-public class MantaConnectionFactory implements Closeable, MBeanable {
+public class MantaConnectionFactory implements Closeable, MantaMBeanable {
     /**
      * Logger instance.
      */

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaConnectionFactory.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaConnectionFactory.java
@@ -11,7 +11,6 @@ import com.joyent.http.signature.ThreadLocalSigner;
 import com.joyent.http.signature.apache.httpclient.HttpSignatureAuthScheme;
 import com.joyent.http.signature.apache.httpclient.HttpSignatureRequestInterceptor;
 import com.joyent.manta.client.MantaMBeanable;
-import com.joyent.manta.client.MantaMBeanSupervisor;
 import com.joyent.manta.config.ConfigContext;
 import com.joyent.manta.config.DefaultsConfigContext;
 import com.joyent.manta.exception.ConfigurationException;
@@ -21,9 +20,9 @@ import org.apache.commons.lang3.Validate;
 import org.apache.http.Header;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpHost;
+import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.NameValuePair;
 import org.apache.http.auth.Credentials;
-import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpDelete;
@@ -69,6 +68,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import javax.management.DynamicMBean;
 
 /**
  * Factory class that creates instances of
@@ -492,14 +492,12 @@ public class MantaConnectionFactory implements Closeable, MantaMBeanable {
     }
 
     @Override
-    public void createExposedMBean(final MantaMBeanSupervisor beanSupervisor) {
-        Validate.notNull(beanSupervisor, "MantaMBeanSupervisor must not be null");
-
+    public DynamicMBean toMBean() {
         if (!(connectionManager instanceof PoolingHttpClientConnectionManager)) {
-            return;
+            return null;
         }
 
-        beanSupervisor.expose(new PoolStatsMBean((PoolingHttpClientConnectionManager) connectionManager));
+        return new PoolStatsMBean((PoolingHttpClientConnectionManager) connectionManager);
     }
 
     @Override

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/PoolStatsMBean.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/PoolStatsMBean.java
@@ -96,7 +96,6 @@ public class PoolStatsMBean implements DynamicMBean {
      */
     private final WeakReference<PoolingHttpClientConnectionManager> connectionManagerRef;
 
-
     /**
      * Creates a new MBean instance backed by the passed connection manager.
      * @param connectionManager instance to get statistics from


### PR DESCRIPTION
Extract MBean supervision responsibilites into MantaMBeanSupervisor and stop making MantaConnectionFactory responsible for ThreadLocalSigner.

This is the second PR that was split from the refactoring for #310 and #311. Primary goal was to make object lifecycles more explicit  (e.g. `ThreadLocalSigner` and MBean registration) and minimize data dependencies (`MantaConnectionFactory#createBuilder` doesn't need to check if auth is disabled for the third time, it can just create the builder and attach the auth interceptor in its constructor).