### PR TITLE
Fixes #341

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,18 @@ This project aims to adhere to [Semantic Versioning](http://semver.org/).
 
 ## [3.1.7-SNAPSHOT] - Coming soon!
 ### Added
- - [Added method MantaClient.find() which allows for recursive directory listing](https://github.com/joyent/java-manta/issues/87). 
+ - [Added method MantaClient.find() which allows for recursive directory listing](https://github.com/joyent/java-manta/issues/87).
+ - Support for reading content-type and content-md5 header information from 
+ directory listings  
 ### Fixed
  - Clarify version history of `MantaInputStreamEntity`
  - MPU parts which were missing an ETag in their response were
    [not treated as errors](https://github.com/joyent/java-manta/issues/305).
  - NullPointerException as a result of some configuration parameters
-   [not being handled correctly unless explicity set](https://github.com/joyent/java-manta/issues/247).
+   [not being handled correctly unless explicitly set](https://github.com/joyent/java-manta/issues/247).
  - Setting `manta.retries`/`MANTA_HTTP_RETRIES` to 0 would print `Retry of failed requests is disabled` but
    leave the default Apache HttpClient [retry behavior](https://hc.apache.org/httpcomponents-client-4.5.x/tutorial/html/fundamentals.html#d5e316).
+ - [Content type is set for file object in directory listing when it isn't available](https://github.com/joyent/java-manta/issues/341)
 ### Changed
  - Validation of paths passed to `MantaClient` is now more consistently strict.
    More useful errors should be thrown sooner for invalid paths, without any

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaObjectConversionFunction.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaObjectConversionFunction.java
@@ -27,18 +27,63 @@ import static com.joyent.manta.util.MantaUtils.formatPath;
  */
 public class MantaObjectConversionFunction implements Function<Map<String, Object>, MantaObject> {
     /**
+     * Key for name property in directory listing results.
+     */
+    private static final String NAME_FIELD_KEY = "name";
+
+    /**
+     * Key for modification time property in directory listing results.
+     */
+    private static final String MTIME_FIELD_KEY = "mtime";
+
+    /**
+     * Key for object type (dir / file) property in directory listing results.
+     */
+    private static final String TYPE_FIELD_KEY = "type";
+
+    /**
+     * Key for injecting the path to the object in the results returned from apply().
+     */
+    private static final String PATH_FIELD_KEY = "path";
+
+    /**
+     * Key for content-type property in directory listing results.
+     */
+    private static final String CONTENT_TYPE_FIELD_KEY = "contentType";
+
+    /**
+     * Key for e-tag property in directory listing results.
+     */
+    private static final String ETAG_FIELD_KEY = "etag";
+
+    /**
+     * Key for object size property in directory listing results.
+     */
+    private static final String SIZE_FIELD_KEY = "size";
+
+    /**
+     * Key for durability (number of copies) property in directory listing results.
+     */
+    private static final String DURABILITY_FIELD_KEY = "durability";
+
+    /**
+     * Key for content-md5 property in directory listing results.
+     */
+    private static final String CONTENT_MD5_FIELD_KEY = "contentMD5";
+
+    /**
      * Static instance to be used as a singleton.
      */
     static final MantaObjectConversionFunction INSTANCE = new MantaObjectConversionFunction();
 
     @Override
     public MantaObject apply(final Map<String, Object> item) {
-        String name = Validate.notNull(item.get("name"), "Filename is null").toString();
-        String mtime = Validate.notNull(item.get("mtime"), "Modification time is null").toString();
-        String type = Validate.notNull(item.get("type"), "File type is null").toString();
+        String name = Validate.notNull(item.get(NAME_FIELD_KEY), "Filename is null").toString();
+        String mtime = Validate.notNull(item.get(MTIME_FIELD_KEY), "Modification time is null").toString();
+        String type = Validate.notNull(item.get(TYPE_FIELD_KEY), "File type is null").toString();
 
         String objPath = String.format("%s%s%s",
-                StringUtils.removeEnd(item.get("path").toString(), SEPARATOR),
+                StringUtils.removeEnd(item.get(PATH_FIELD_KEY).toString(), SEPARATOR),
                 SEPARATOR,
                 StringUtils.removeStart(name, SEPARATOR));
         MantaHttpHeaders headers = new MantaHttpHeaders();
@@ -47,24 +92,24 @@ public class MantaObjectConversionFunction implements Function<Map<String, Objec
         /* We look for contentType explicitly because it is being added to Manta
          * in a future version and this property may not be available on all
          * Manta installs for quite some time. */
-        if (item.containsKey("contentType")) {
-            String contentType = Objects.toString(item.get("contentType"), null);
+        if (item.containsKey(CONTENT_TYPE_FIELD_KEY)) {
+            String contentType = Objects.toString(item.get(CONTENT_TYPE_FIELD_KEY), null);
             headers.setContentType(contentType);
         } else if (type.equals(MantaObject.MANTA_OBJECT_TYPE_DIRECTORY)) {
             headers.setContentType(MantaObjectResponse.DIRECTORY_RESPONSE_CONTENT_TYPE);
         }
 
-        if (item.containsKey("etag")) {
-            headers.setETag(Objects.toString(item.get("etag")));
+        if (item.containsKey(ETAG_FIELD_KEY)) {
+            headers.setETag(Objects.toString(item.get(ETAG_FIELD_KEY)));
         }
 
-        if (item.containsKey("size")) {
-            long size = Long.parseLong(Objects.toString(item.get("size")));
+        if (item.containsKey(SIZE_FIELD_KEY)) {
+            long size = Long.parseLong(Objects.toString(item.get(SIZE_FIELD_KEY)));
             headers.setContentLength(size);
         }
 
-        if (item.containsKey("durability")) {
-            String durabilityString = Objects.toString(item.get("durability"));
+        if (item.containsKey(DURABILITY_FIELD_KEY)) {
+            String durabilityString = Objects.toString(item.get(DURABILITY_FIELD_KEY));
             if (durabilityString != null) {
                 int durability = Integer.parseInt(durabilityString);
                 headers.setDurabilityLevel(durability);
@@ -72,8 +117,8 @@ public class MantaObjectConversionFunction implements Function<Map<String, Objec
         }
 
         // This property may not be available on all Manta installs for quite some time
-        if (item.containsKey("contentMD5")) {
-            String contentMD5 = Objects.toString(item.get("contentMD5"), null);
+        if (item.containsKey(CONTENT_MD5_FIELD_KEY)) {
+            String contentMD5 = Objects.toString(item.get(CONTENT_MD5_FIELD_KEY), null);
             headers.setContentMD5(contentMD5);
         }
 


### PR DESCRIPTION
This fixes the issue where all file objects are given a header of application/octet-stream when listing a directories contents. Additionally, this change adds support for Content-MD5 and Content-Type
headers from directory listing (as supported by Manta).