### PR TITLE
Fix listObjects connection leak

### DIFF
--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -792,6 +792,8 @@ public class MantaClient implements AutoCloseable {
 
         Stream<MantaObject> stream = backingStream.map(MantaObjectConversionFunction.INSTANCE);
 
+        stream.onClose(itr::close);
+
         danglingStreams.add(stream);
 
         return stream;


### PR DESCRIPTION
The newly added test fails reliably unless we connect the stream close with the iterator close.