### PR TITLE
Fix #388

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project aims to adhere to [Semantic Versioning](http://semver.org/).
 
 ## [3.2.2-SNAPSHOT] - Coming soon!
+### Fixed
+ - [Misleading log message is shown for retrying requests that are unretryable](https://github.com/joyent/java-manta/issues/388)
 
 ## [3.2.1] - 2017-11-29
 ### Added

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaHttpRequestRetryHandler.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaHttpRequestRetryHandler.java
@@ -68,16 +68,18 @@ public class MantaHttpRequestRetryHandler extends DefaultHttpRequestRetryHandler
             return false;
         }
 
+        final boolean toBeRetried = super.retryRequest(exception, executionCount, context);
+
         if (logger.isDebugEnabled()) {
-            if (NON_RETRIABLE.contains(exception.getClass())) {
-                logger.debug("Request failed, unable to retry.", exception);
-            } else if (executionCount <= getRetryCount()) {
+            if (toBeRetried) {
                 String msg = String.format("Request failed, %d/%d retry.",
                         executionCount, getRetryCount());
                 logger.debug(msg, exception);
+            } else {
+                logger.debug("Request failed, unable to retry.", exception);
             }
         }
 
-        return super.retryRequest(exception, executionCount, context);
+        return toBeRetried;
     }
 }

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaHttpRequestRetryHandler.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaHttpRequestRetryHandler.java
@@ -68,10 +68,14 @@ public class MantaHttpRequestRetryHandler extends DefaultHttpRequestRetryHandler
             return false;
         }
 
-        if (logger.isDebugEnabled() && executionCount <= getRetryCount()) {
-            String msg = String.format("Request failed, %d/%d retry.",
-                    executionCount, getRetryCount());
-            logger.debug(msg, exception);
+        if (logger.isDebugEnabled()) {
+            if (NON_RETRIABLE.contains(exception)) {
+                logger.debug("Request failed, unable to retry.", exception);
+            } else if (executionCount <= getRetryCount()) {
+                String msg = String.format("Request failed, %d/%d retry.",
+                        executionCount, getRetryCount());
+                logger.debug(msg, exception);
+            }
         }
 
         return super.retryRequest(exception, executionCount, context);

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaHttpRequestRetryHandler.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaHttpRequestRetryHandler.java
@@ -69,7 +69,7 @@ public class MantaHttpRequestRetryHandler extends DefaultHttpRequestRetryHandler
         }
 
         if (logger.isDebugEnabled()) {
-            if (NON_RETRIABLE.contains(exception)) {
+            if (NON_RETRIABLE.contains(exception.getClass())) {
                 logger.debug("Request failed, unable to retry.", exception);
             } else if (executionCount <= getRetryCount()) {
                 String msg = String.format("Request failed, %d/%d retry.",


### PR DESCRIPTION
We now log a discrete message indicating that the failed request can't be retried.