### PR TITLE
Fixes #383

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project aims to adhere to [Semantic Versioning](http://semver.org/).
 ## [3.2.2-SNAPSHOT] - Coming soon!
 ### Fixed
  - [Misleading log message is shown for retrying requests that are unretryable](https://github.com/joyent/java-manta/issues/388)
+ - [`MantaClientHttpResponseException` provide to way to get the response headers](https://github.com/joyent/java-manta/issues/383)
 
 ## [3.2.1] - 2017-12-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project aims to adhere to [Semantic Versioning](http://semver.org/).
 ## [3.2.2-SNAPSHOT] - Coming soon!
 ### Fixed
  - [Misleading log message is shown for retrying requests that are unretryable](https://github.com/joyent/java-manta/issues/388)
- - [`MantaClientHttpResponseException` provide to way to get the response headers](https://github.com/joyent/java-manta/issues/383)
+ - [`MantaClientHttpResponseException` provide a way to get the response headers](https://github.com/joyent/java-manta/issues/383)
 
 ## [3.2.1] - 2017-12-01
 ### Added

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/exception/MantaClientHttpResponseException.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/exception/MantaClientHttpResponseException.java
@@ -168,6 +168,15 @@ public class MantaClientHttpResponseException extends MantaIOException {
         }
 
         HttpHelper.annotateContextedException(this, request, response);
+
+        /* We don't want any problems processing headers to get in the way of
+         * properly throwing an exception, so we warn if we hit any error cases
+         * instead of raise the exception. */
+        try {
+            setHeaders(new MantaHttpHeaders(response.getAllHeaders()));
+        } catch (RuntimeException e) {
+            LOGGER.warn("Error setting response headers on exception", e);
+        }
     }
 
     /**


### PR DESCRIPTION
We now correctly populate the headers property when creating a
MantaClientHttpResponseException instance.