### PR TITLE
Resolve connection pool leak when making encrypted range requests

### DIFF
--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStream.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStream.java
@@ -14,7 +14,6 @@ import com.joyent.manta.exception.MantaIOException;
 import com.joyent.manta.http.MantaHttpHeaders;
 import com.joyent.manta.util.NotThreadSafe;
 import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.Validate;
@@ -721,7 +720,7 @@ public class MantaEncryptedObjectInputStream extends MantaObjectInputStream {
         readRemainingBytes();
 
         try {
-            IOUtils.closeQuietly(cipherInputStream);
+            cipherInputStream.close();
         } catch (Exception e) {
             LOGGER.warn("Error closing CipherInputStream", e);
         }
@@ -752,6 +751,8 @@ public class MantaEncryptedObjectInputStream extends MantaObjectInputStream {
                 e.setContextValue("checksum", Hex.encodeHexString(checksum));
                 throw e;
             }
+        } else {
+            super.close();
         }
     }
 

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/crypto/IncompleteByteReadInputStream.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/crypto/IncompleteByteReadInputStream.java
@@ -43,4 +43,9 @@ public class IncompleteByteReadInputStream extends InputStream {
             return wrapped.read(b, off, len);
         }
     }
+
+    @Override
+    public void close() throws IOException {
+        wrapped.close();
+    }
 }

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStreamTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStreamTest.java
@@ -887,8 +887,10 @@ public class MantaEncryptedObjectInputStreamTest {
         EncryptedFile encryptedFile = encryptedFile(key, cipherDetails, this.plaintextSize);
         long ciphertextSize = encryptedFile.file.length();
 
-        FileInputStream in = new FileInputStream(encryptedFile.file);
-        MantaEncryptedObjectInputStream min = createEncryptedObjectInputStream(key, in,
+        final FileInputStream in = new FileInputStream(encryptedFile.file);
+        final FileInputStream inSpy = Mockito.spy(in);
+
+        MantaEncryptedObjectInputStream min = createEncryptedObjectInputStream(key, inSpy,
                 ciphertextSize, cipherDetails, encryptedFile.cipher.getIV(), authenticate,
                 (long)this.plaintextSize);
 
@@ -900,6 +902,8 @@ public class MantaEncryptedObjectInputStreamTest {
         } finally {
             min.close();
         }
+
+        Mockito.verify(inSpy, Mockito.times(1)).close();
     }
 
     /**

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStreamTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/crypto/MantaEncryptedObjectInputStreamTest.java
@@ -827,7 +827,7 @@ public class MantaEncryptedObjectInputStreamTest {
         }
 
         AssertJUnit.assertArrayEquals(sourceBytes, out.toByteArray());
-        Mockito.verify(inSpy, Mockito.times(1)).close();
+        Mockito.verify(inSpy, Mockito.atLeastOnce()).close();
     }
 
     /**
@@ -906,7 +906,7 @@ public class MantaEncryptedObjectInputStreamTest {
             min.close();
         }
 
-        Mockito.verify(inSpy, Mockito.times(1)).close();
+        Mockito.verify(inSpy, Mockito.atLeastOnce()).close();
     }
 
     /**
@@ -1018,7 +1018,7 @@ public class MantaEncryptedObjectInputStreamTest {
             readBytes.readAll(min, actual);
 
             min.close();
-            Mockito.verify(binSpy, Mockito.times(1)).close();
+            Mockito.verify(binSpy, Mockito.atLeastOnce()).close();
 
             try {
                 AssertJUnit.assertArrayEquals("Byte range output doesn't match",
@@ -1050,7 +1050,7 @@ public class MantaEncryptedObjectInputStreamTest {
             readBytes.readAll(min, actual);
         } finally {
             min.close();
-            Mockito.verify(inSpy, Mockito.times(1)).close();
+            Mockito.verify(inSpy, Mockito.atLeastOnce()).close();
         }
     }
 
@@ -1083,7 +1083,7 @@ public class MantaEncryptedObjectInputStreamTest {
             min.close();
         }  catch (MantaClientEncryptionCiphertextAuthenticationException e) {
             thrown = true;
-            Mockito.verify(inSpy, Mockito.times(1)).close();
+            Mockito.verify(inSpy, Mockito.atLeastOnce()).close();
         }
 
         Assert.assertTrue(thrown, "Ciphertext authentication exception wasn't thrown");
@@ -1138,7 +1138,7 @@ public class MantaEncryptedObjectInputStreamTest {
             IOUtils.copy(min, out);
         }
 
-        Mockito.verify(finSpy, Mockito.times(1)).close();
+        Mockito.verify(finSpy, Mockito.atLeastOnce()).close();
     }
 
     private EncryptedFile encryptedFile(

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientRangeIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientRangeIT.java
@@ -198,13 +198,11 @@ public class MantaClientRangeIT {
                 String rangeHeader = "bytes=" + start + "-" + end;
                 headers.setRange(rangeHeader);
 
-                MantaClient getClient = new MantaClient(this.config);
-                try (final InputStream min = getClient.getAsInputStream(path, headers)) {
+                try (final InputStream min = mantaClient.getAsInputStream(path, headers)) {
                     String actual = IOUtils.toString(min, Charset.defaultCharset());
                     System.out.println("Range: " + rangeHeader);
                     Assert.assertEquals(actual, expected, "Didn't receive correct range value for range: " + rangeHeader);
                 }
-                getClient.closeQuietly();
             }
         }
     }


### PR DESCRIPTION
# Summary
We need to close the stream even when we don't read the authentication tag from the end. Sometimes `EofSensorInputStream` does it for us (GCM) but most of the time we're leaving the backing stream open in `MantaEncryptedObjectInputStream#close`.

# Changes
- Modification of several test helper methods to `Mockito.verify` a spy for each `InputStream` is closed
- Stop creating new `MantaClient`s just for downloading in `canGetAllRanges` (this was hiding the issue)
- closed `MantaEncryptedObjectInputStream` instances which were not being closed by the tests.
- some investigation into why the unauthenticated GCM test cases were still passing without the fix uncovered that in _some cases_ `EofSensorInputStream` automatically closes the stream once EOF is reached. This is confusing but unrelated.

# Questions
- Would an else for the `hmac != null && authenticateCiphertext` check be a more appropriate way of calling `super.close()` than the `finally`?