### PR TITLE
Enable class-level parallelism for integration test suite

### DIFF
--- a/java-manta-it/pom.xml
+++ b/java-manta-it/pom.xml
@@ -287,6 +287,8 @@
                         </goals>
                         <configuration>
                             <skip>${maven.integration.test.skip}</skip>
+                            <parallel>classes</parallel>
+                            <threadCount>4</threadCount>
                             <suiteXmlFiles>
                                 <suiteXmlFile>src/test/resources/testng-it.xml</suiteXmlFile>
                             </suiteXmlFiles>


### PR DESCRIPTION
The integration test suite is taking several hours in some environments. Since I haven't had a chance to circle back to #364 perhaps we could enable at least class-level parallelism in the integration test suite. This shouldn't introduce too many odd effects since the completion of #337 and because most test cases use a single client per test class.