### PR TITLE
Resolve #400 by closing the iterator before returning early

### DIFF
--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -773,6 +773,7 @@ public class MantaClient implements AutoCloseable {
          */
         try {
             if (!itr.hasNext()) {
+                itr.close();
                 return Stream.empty();
             }
         } catch (UncheckedIOException e) {

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/MantaClientTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/MantaClientTest.java
@@ -23,11 +23,28 @@ public class MantaClientTest {
     }
 
     @Test
-    public void listObjectsDoesNotLeakConnections() throws IOException {
+    public void listObjectsDoesNotLeakConnectionsWhenThereAreResults() throws IOException {
         // BasicHttpClientConnectionManager maintains a single connection
 
         final MantaDirectoryListingIterator iteratorMock = mock(MantaDirectoryListingIterator.class);
         when(iteratorMock.hasNext()).thenReturn(true);
+
+        final MantaClient client = new MantaClient(new TestConfigContext());
+        final MantaClient clientSpy = spy(client);
+        doReturn(iteratorMock).when(clientSpy).streamingIterator(anyString());
+
+        final Stream<MantaObject> listing = clientSpy.listObjects("/");
+        listing.close();
+
+        verify(iteratorMock).close();
+    }
+
+    @Test
+    public void listObjectsDoesNotLeakConnectionsWhenNoResults() throws IOException {
+        // BasicHttpClientConnectionManager maintains a single connection
+
+        final MantaDirectoryListingIterator iteratorMock = mock(MantaDirectoryListingIterator.class);
+        when(iteratorMock.hasNext()).thenReturn(false);
 
         final MantaClient client = new MantaClient(new TestConfigContext());
         final MantaClient clientSpy = spy(client);


### PR DESCRIPTION
Listing empty directories leaks connections if you don't construct the `MantaDirectoryListingIterator` yourself but use `MantaClient#listObjects` instead.

(`MantaDirectoryListingIteratorIT#canListEmptyDirectory` doesn't catch it because it constructs and closes the iterator directly.)