### PR TITLE
Fixes #403

### DIFF
--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/domain/ObjectType.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/domain/ObjectType.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2018, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.manta.domain;
+
+/**
+ * Enum representing the different types of objects available on Manta.
+ *
+ * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @since 3.2.2
+ */
+public enum ObjectType {
+    /**
+     * A remote object that is a logical file.
+     */
+    FILE,
+    /**
+     * A remote object that is a logical directory.
+     */
+    DIRECTORY
+}

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/exception/MantaUnexpectedObjectTypeException.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/exception/MantaUnexpectedObjectTypeException.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2018, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.manta.exception;
+
+import com.joyent.manta.domain.ObjectType;
+import com.joyent.manta.http.MantaHttpHeaders;
+import org.apache.commons.lang3.Validate;
+
+/**
+ * Exception indicating that an unexpected object type was encountered with a
+ * remote object.
+ *
+ * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @since 3.2.2
+ */
+public class MantaUnexpectedObjectTypeException extends MantaClientException {
+    private static final long serialVersionUID = -1028368819651385028L;
+
+    /**
+     * Expected object type.
+     */
+    private final ObjectType expected;
+
+    /**
+     * Actual object type.
+     */
+    private final ObjectType actual;
+
+    /**
+     * Optional server response headers object.
+     */
+    private MantaHttpHeaders responseHeaders;
+
+    /**
+     * Creates a new instance with the expected properties.
+     *
+     * @param expected expected object type
+     * @param actual actual object type
+     */
+    public MantaUnexpectedObjectTypeException(final ObjectType expected,
+                                              final ObjectType actual) {
+        super(msg(expected, actual));
+        this.expected = expected;
+        this.actual = actual;
+        updateContext();
+    }
+
+    /**
+     * Creates a new instance with the expected properties.
+     *
+     * @param message the detail message. The detail message is saved for
+    *                 later retrieval by the {@link #getMessage()} method.
+     * @param expected expected object type
+     * @param actual actual object type
+     */
+    public MantaUnexpectedObjectTypeException(final String message,
+                                              final ObjectType expected,
+                                              final ObjectType actual) {
+        super(message);
+        this.expected = expected;
+        this.actual = actual;
+        updateContext();
+    }
+
+    /**
+     * Creates a new instance with the expected properties.
+     *
+     * @param cause the cause (which is saved for later retrieval by the
+     *              {@link #getCause()} method).  (A <tt>null</tt> value is
+     *              permitted, and indicates that the cause is nonexistent or
+     *              unknown.)
+     * @param expected expected object type
+     * @param actual actual object type
+     */
+    public MantaUnexpectedObjectTypeException(final Throwable cause,
+                                              final ObjectType expected,
+                                              final ObjectType actual) {
+        super(msg(expected, actual), cause);
+        this.expected = expected;
+        this.actual = actual;
+        updateContext();
+    }
+
+    /**
+     * Creates a new instance with the expected properties.
+     *
+     * @param message the detail message. The detail message is saved for
+     *                later retrieval by the {@link #getMessage()} method.
+     * @param cause the cause (which is saved for later retrieval by the
+     *              {@link #getCause()} method).  (A <tt>null</tt> value is
+     *              permitted, and indicates that the cause is nonexistent or
+     *              unknown.)
+     * @param expected expected object type
+     * @param actual actual object type
+     */
+    public MantaUnexpectedObjectTypeException(final String message,
+                                              final Throwable cause,
+                                              final ObjectType expected,
+                                              final ObjectType actual) {
+        super(message, cause);
+        this.expected = expected;
+        this.actual = actual;
+        updateContext();
+    }
+
+    public ObjectType getExpected() {
+        return expected;
+    }
+
+    public ObjectType getActual() {
+        return actual;
+    }
+
+    public MantaHttpHeaders getResponseHeaders() {
+        return responseHeaders;
+    }
+
+    /**
+     * Sets the response headers of the failed request. This is useful for
+     * debugging the reason of why the objects didn't match the expectation.
+     *
+     * @param responseHeaders headers object to attach to exception
+     */
+    public void setResponseHeaders(final MantaHttpHeaders responseHeaders) {
+        this.responseHeaders = responseHeaders;
+        this.setContextValue("responseHeaders", responseHeaders.toString());
+    }
+
+    /**
+     * Updates the exception context with the object type expectations.
+     */
+    private void updateContext() {
+        Validate.notNull(expected, "Expected value should not be null");
+        Validate.notNull(actual, "Actual value should not be null");
+        Validate.isTrue(!expected.equals(actual),
+                "Expected and actual shouldn't be equal. If they "
+                    + "were equal - we wouldn't have an exception.");
+
+        setContextValue("expectedObjectType", expected);
+        setContextValue("actualObjectType", actual);
+    }
+
+    /**
+     * Formats a default error message based on the object type expectations.
+     *
+     * @param expected expected object type
+     * @param actual actual object type
+     *
+     * @return formatted error message
+     */
+    private static String msg(final ObjectType expected, final ObjectType actual) {
+        final String format = "Expected the object type [%s] actually [%s]";
+        return String.format(format, expected, actual);
+    }
+}

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/StandardHttpHelper.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/StandardHttpHelper.java
@@ -13,10 +13,12 @@ import com.joyent.manta.client.MantaObjectInputStream;
 import com.joyent.manta.client.MantaObjectResponse;
 import com.joyent.manta.config.ConfigContext;
 import com.joyent.manta.config.DefaultsConfigContext;
+import com.joyent.manta.domain.ObjectType;
 import com.joyent.manta.exception.MantaChecksumFailedException;
 import com.joyent.manta.exception.MantaClientException;
 import com.joyent.manta.exception.MantaClientHttpResponseException;
 import com.joyent.manta.exception.MantaObjectException;
+import com.joyent.manta.exception.MantaUnexpectedObjectTypeException;
 import com.joyent.manta.http.entity.DigestedEntity;
 import com.joyent.manta.http.entity.NoContentEntity;
 import com.joyent.manta.util.MantaUtils;
@@ -339,8 +341,14 @@ public class StandardHttpHelper implements HttpHelper {
             if (metadata.isDirectory()) {
                 final String msg = "Directories do not have data, so data streams "
                         + "from directories are not possible.";
-                final MantaClientException exception = new MantaClientException(msg);
+                final MantaUnexpectedObjectTypeException exception =
+                        new MantaUnexpectedObjectTypeException(msg,
+                            ObjectType.FILE, ObjectType.DIRECTORY);
                 exception.setContextValue("path", path);
+
+                if (metadata.getHttpHeaders() != null) {
+                    exception.setResponseHeaders(metadata.getHttpHeaders());
+                }
 
                 throw exception;
             }

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/util/MantaVersion.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/util/MantaVersion.java
@@ -22,7 +22,7 @@ public final class MantaVersion {
     /**
      * Release version of the SDK.
      */
-    public static final String VERSION = "3.2.2-SNAPSHOT";
+    public static final String VERSION = "3.1.7-SNAPSHOT";
 
     /**
      * Minimum version of client-side encryption supported.

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/util/MantaVersion.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/util/MantaVersion.java
@@ -22,7 +22,7 @@ public final class MantaVersion {
     /**
      * Release version of the SDK.
      */
-    public static final String VERSION = "3.1.7-SNAPSHOT";
+    public static final String VERSION = "3.2.2-SNAPSHOT";
 
     /**
      * Minimum version of client-side encryption supported.

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2018, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.manta.client;
+
+import com.joyent.manta.exception.MantaUnexpectedObjectTypeException;
+import com.joyent.manta.http.HttpHelper;
+import com.joyent.manta.http.MantaHttpRequestFactory;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.entity.ContentType;
+import org.apache.http.message.BasicHeader;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import static com.joyent.manta.client.MantaDirectoryListingIterator.MAX_RESULTS;
+import static org.apache.http.HttpHeaders.CONTENT_TYPE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@Test
+public class MantaDirectoryListingIteratorTest {
+
+    public static final int EOF = -1;
+
+    @Mock
+    private HttpHelper httpHelper;
+
+    @Mock
+    private CloseableHttpResponse response;
+
+    @Mock
+    private HttpEntity responseEntity;
+
+    @BeforeMethod
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        String url = "http://localhost";
+        MantaHttpRequestFactory requestFactory = new MantaHttpRequestFactory(url);
+
+        when(httpHelper.getRequestFactory()).thenReturn(requestFactory);
+        when(httpHelper.executeRequest(any(), any())).thenReturn(response);
+        when(response.getEntity()).thenReturn(responseEntity);
+    }
+
+    @AfterMethod
+    public void teardown() throws Exception {
+        Mockito.validateMockitoUsage();
+    }
+
+    public void allowsSkippingFirstResult() throws Exception {
+        String dirListing =
+                "{\"name\":\".joyent\",\"type\":\"directory\",\"mtime\":\"2015-04-16T22:50:11.353Z\"}\n"
+              + "{\"name\":\"foo\",\"etag\":\"2968452a-9f78-edbe-a5fa-fe167963f4cf\",\"type\":\"object\",\"contentType\":\"text/plain\",\"contentMD5\":\"1B2M2Y8AsgTpgAmY7PhCfg==\",\"mtime\":\"2017-04-16T23:20:12.393Z\"}";
+        final Header contentTypeHeader = new BasicHeader(CONTENT_TYPE,
+                MantaObjectResponse.DIRECTORY_RESPONSE_CONTENT_TYPE);
+        when(responseEntity.getContentType()).thenReturn(contentTypeHeader);
+        when(response.getAllHeaders()).thenReturn( new Header[] {contentTypeHeader});
+        when(responseEntity.getContent()).thenReturn(IOUtils.toInputStream(
+                dirListing, StandardCharsets.UTF_8));
+
+        final MantaDirectoryListingIterator itr = new MantaDirectoryListingIterator(
+                "/usr/stor/dir", httpHelper, MAX_RESULTS);
+
+        itr.next();
+        Map<String, Object> secondResult = itr.next();
+
+        Assert.assertEquals(secondResult.get("name"), "foo");
+        Assert.assertEquals(secondResult.get("etag"), "2968452a-9f78-edbe-a5fa-fe167963f4cf");
+        Assert.assertEquals(secondResult.get("type"), "object");
+        Assert.assertEquals(secondResult.get("contentType"), "text/plain");
+        Assert.assertEquals(secondResult.get("contentMD5"), "1B2M2Y8AsgTpgAmY7PhCfg==");
+        Assert.assertEquals(secondResult.get("mtime"), "2017-04-16T23:20:12.393Z");
+        Assert.expectThrows(NoSuchElementException.class, itr::next);
+    }
+
+    public void throwsAppropriateExceptionWhenListingObject() throws Exception {
+        final String dirPath = "/user/stor/directory";
+        final Header contentTypeHeader = new BasicHeader(CONTENT_TYPE, ContentType.APPLICATION_OCTET_STREAM.toString());
+
+        when(responseEntity.getContentType()).thenReturn(contentTypeHeader);
+        when(response.getFirstHeader(CONTENT_TYPE)).thenReturn(contentTypeHeader);
+        when(response.getAllHeaders()).thenReturn( new Header[] {contentTypeHeader});
+
+        // uncomment once it's okay to call next before hasNext
+        Assert.expectThrows(MantaUnexpectedObjectTypeException.class, () ->
+                new MantaDirectoryListingIterator(dirPath, httpHelper, MAX_RESULTS).next());
+
+        Assert.expectThrows(MantaUnexpectedObjectTypeException.class, () ->
+                new MantaDirectoryListingIterator(dirPath, httpHelper, MAX_RESULTS).hasNext());
+    }
+
+}

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
@@ -198,27 +198,6 @@ public class MantaClientIT {
     }
 
     @Test
-    public final void willErrorGracefullyFailWhenAttemptingToStreamADirectory() throws IOException {
-        final String name = UUID.randomUUID().toString();
-        final String path = testPathPrefix + name;
-
-        mantaClient.putDirectory(path);
-
-        boolean thrown = false;
-
-        try (InputStream in = mantaClient.getAsInputStream(path)) {
-            Assert.assertNotNull(in);
-        } catch (MantaUnexpectedObjectTypeException e) {
-            Assert.assertEquals(e.getExpected(), ObjectType.FILE);
-            Assert.assertEquals(e.getActual(), ObjectType.DIRECTORY);
-
-            thrown = true;
-        }
-
-        Assert.assertTrue(thrown, "Expected exception not thrown");
-    }
-
-    @Test
     public final void testCRUDWithByteArray() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorIT.java
@@ -179,24 +179,6 @@ public class MantaDirectoryListingIteratorIT {
         }
     }
 
-    public void willErrorGracefullyFailWhenAttemptingToListAFile() throws IOException {
-        String file = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
-        mantaClient.put(file, "");
-
-        boolean thrown = false;
-
-        try (MantaDirectoryListingIterator itr = mantaClient.streamingIterator(file, 10)) {
-            Assert.assertFalse(itr.hasNext());
-        } catch (MantaUnexpectedObjectTypeException e) {
-            Assert.assertEquals(e.getExpected(), ObjectType.DIRECTORY);
-            Assert.assertEquals(e.getActual(), ObjectType.FILE);
-
-            thrown = true;
-        }
-
-        Assert.assertTrue(thrown, "Expected exception not thrown");
-    }
-
     private void listDirectoryUsingSmallPagingSize(final String dir) throws IOException {
         mantaClient.putDirectory(dir, true);
 


### PR DESCRIPTION
The exception type returned when downloading a dir as a stream is too generic.

We now throw a specific exception type when we encounter states where the
wrong object type is encountered.