### PR TITLE
Add retry metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ This project aims to adhere to [Semantic Versioning](http://semver.org/).
  - [Underlying stream is not closed by `MantaEncryptedObjectInputStream` for range requests with certain ciphers](https://github.com/joyent/java-manta/issues/398)
  - [Exceptions relating to object type expectations are too generic](https://github.com/joyent/java-manta/issues/403)
 
+### Added
+ - Client metrics can now be enabled by selecting a reporting mode with the
+   [`manta.metric_reporter.mode`/`MANTA_METRIC_REPORTER_MODE`](/USAGE.md#parameters) setting. [JMX and SLF4J are
+   available, though others may be added in the future.](https://github.com/joyent/java-manta/issues/410#issuecomment-384751882)
+ - [Retry rate metric](https://github.com/joyent/java-manta/issues/410).
+
+### Changed
+ - MBeans registered in JMX no longer use an incrementing integer and instead are created under
+   [unique IDs for each client](https://user-images.githubusercontent.com/1973223/38774088-6a08861e-4014-11e8-8951-287ecd70032f.png).
+ - JMX is no longer used to expose configuration and pool stats by default. To reenable JMX,
+   set `manta.metric_reporter.mode`/`MANTA_METRIC_REPORTER_MODE` to `JMX`.
+
 ## [3.2.1] - 2017-12-01
 ### Added
  - [Load balancer IP](https://github.com/joyent/java-manta/pull/378) has been added

--- a/USAGE.md
+++ b/USAGE.md
@@ -168,7 +168,7 @@ Note: Dynamic Updates marked with an asterisk (*) are enabled by the `AuthAwareC
     (only `SLF4J` at present) requires also setting an output interval.
     See [the section on monitoring](#monitoring) for more information about reporting modes.
 * `manta.metric_reporter.output_interval` (**MANTA_METRIC_REPORTER_OUTPUT_INTERVAL**)
-    Integer interval at which metrics are reported by periodic reporters.
+    Integer interval in milliseconds at which metrics are reported by periodic reporters.
     This number must be set and greater than zero if `manta.metric_reporter.mode`/`MANTA_METRIC_REPORTER_MODE`
     is set to `SLF4J`.
 * `manta.client_encryption` (**MANTA_CLIENT_ENCRYPTION**)

--- a/USAGE.md
+++ b/USAGE.md
@@ -168,7 +168,7 @@ Note: Dynamic Updates marked with an asterisk (*) are enabled by the `AuthAwareC
     (only `SLF4J` at present) requires also setting an output interval.
     See [the section on monitoring](#monitoring) for more information about reporting modes.
 * `manta.metric_reporter.output_interval` (**MANTA_METRIC_REPORTER_OUTPUT_INTERVAL**)
-    Integer interval in milliseconds at which metrics are reported by periodic reporters.
+    Integer interval in seconds at which metrics are reported by periodic reporters.
     This number must be set and greater than zero if `manta.metric_reporter.mode`/`MANTA_METRIC_REPORTER_MODE`
     is set to `SLF4J`.
 * `manta.client_encryption` (**MANTA_CLIENT_ENCRYPTION**)
@@ -383,11 +383,23 @@ This requires selecting a reporting mode using the following settings:
             and count of retries the client has attempted, in addition to 1-, 5-, and 15-minute moving averages.
     - `SLF4J`: reporters metrics through the generic logging interface provided by [SLF4J](http://www.slf4j.org/).
     This setting requires users to also supply a reporting output interval.
-- `manta.metric_reporter.output_interval` specify the amount of time in milliseconds between reporting metrics for
+- `manta.metric_reporter.output_interval` specify the amount of time in seconds between reporting metrics for
     periodic reporters. Required by `SLF4J`. Setting this value too low may lead to excessive disk usage. A value of
-    `60000` (60s) provides minute-by-minute granularity in combination with the 1-minute moving average provided
+    60 affords minute-by-minute granularity in combination with the 1-minute moving average provided
     by certain metric values. Logging is done at the `INFO` level using a logger named
-    `com.joyent.manta.client.metrics`.
+    `com.joyent.manta.client.metrics`. An example metric output for client ID `c16a2f85-90f7-4e7c-b0f3-b8993eca18d1`
+    would look like the following (newlines added for clarity):
+    ```
+    [metrics-logger-reporter-1-thread-1] INFO  com.joyent.manta.client.metrics [ ] -
+    type=METER,
+    name=c16a2f85-90f7-4e7c-b0f3-b8993eca18d1.retries,
+    count=2,
+    mean_rate=0.07982106952096357,
+    m1=0.028248726311583667,
+    m5=0.006448405864180696,
+    m15=0.0021976788366558607,
+    rate_unit=events/second
+    ```
 
 ### Customizing the client further
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -95,6 +95,8 @@ Below is a table of available configuration parameters followed by detailed desc
 | manta.expect_continue_timeout      | MANTA_EXPECT_CONTINUE_TIMEOUT  |                                      |                          |
 | manta.upload_buffer_size           | MANTA_UPLOAD_BUFFER_SIZE       | 16384                                |                          |
 | manta.skip_directory_depth         | MANTA_SKIP_DIRECTORY_DEPTH     |                                      |                          |
+| manta.metric_reporter.mode         | MANTA_METRIC_REPORTER_MODE     |                                      |                          |
+| manta.metric_reporter.output_interval | MANTA_METRIC_REPORTER_OUTPUT_INTERVAL |                            |                          |
 | manta.client_encryption            | MANTA_CLIENT_ENCRYPTION        | false                                |                          |
 | manta.encryption_key_id            | MANTA_CLIENT_ENCRYPTION_KEY_ID |                                      |                          |
 | manta.encryption_algorithm         | MANTA_ENCRYPTION_ALGORITHM     | AES128/CTR/NoPadding                 |                          |
@@ -160,6 +162,15 @@ Note: Dynamic Updates marked with an asterisk (*) are enabled by the `AuthAwareC
 * `manta.skip_directory_depth` (**MANTA_SKIP_DIRECTORY_DEPTH**)
     Integer indicating the number of **non-system** directory levels to attempt to skip for recursive `putDirectory`
     operation (i.e. `/$MANTA_USER` and `/$MANTA_USER/stor` would not be counted). A detailed explanation and example are provided [later in this document](/USAGE.md#skipping-directories)
+* `manta.metric_reporter.mode` (**MANTA_METRIC_REPORTER_MODE**)
+    Enum type indicating how metrics should be reported. Options include `DISABLED`, `JMX`, and `SLF4J`. Leaving this value
+    unset or selecting `DISABLED` will prevent the client from gathering and reporting metrics. Certain reporters
+    (only `SLF4J` at present) requires also setting an output interval.
+    See [the section on monitoring](#monitoring) for more information about reporting modes.
+* `manta.metric_reporter.output_interval` (**MANTA_METRIC_REPORTER_OUTPUT_INTERVAL**)
+    Integer interval at which metrics are reported by periodic reporters.
+    This number must be set and greater than zero if `manta.metric_reporter.mode`/`MANTA_METRIC_REPORTER_MODE`
+    is set to `SLF4J`.
 * `manta.client_encryption` (**MANTA_CLIENT_ENCRYPTION**)
     Boolean indicating if client-side encryption is enabled.
 * `manta.encryption_key_id` (**MANTA_CLIENT_ENCRYPTION_KEY_ID**)
@@ -355,6 +366,28 @@ and you wish to debug the establishment and leasing of HTTP connections:
 Please note that the Commons Logger adaptor is not a dependency of `java-manta-client-unshaded` and it is the user's
 responsibility to add their own dependency if they wish to collect Apache HttpClient logs. For more information on log
 bridging in SLF4J please review [this page](https://www.slf4j.org/legacy.html).
+
+### Monitoring
+
+Users can enable monitoring in order to provide better visibility into behavior and performance of a `MantaClient`.
+This requires selecting a reporting mode using the following settings:
+
+- `manta.metric_reporter.mode` select the method by which metrics are exported. Unset by default. Options include:
+    - `DISABLED`: explicitly disables monitoring.
+    - `JMX`: registers MBeans in [JMX](https://en.wikipedia.org/wiki/Java_Management_Extensions). MBeans are created
+    for the following at present:
+        - `ConfigContextMBean` displays the `ConfigContext` settings used to build the client.
+        - `PoolStatsMBean` displays statistics about the client's connection pool.
+        - Additional metrics tracked:
+            - `retries`: A [meter](http://metrics.dropwizard.io/4.0.0/manual/core.html#meters) measuring the rate
+            and count of retries the client has attempted, in addition to 1-, 5-, and 15-minute moving averages.
+    - `SLF4J`: reporters metrics through the generic logging interface provided by [SLF4J](http://www.slf4j.org/).
+    This setting requires users to also supply a reporting output interval.
+- `manta.metric_reporter.output_interval` specify the amount of time in milliseconds between reporting metrics for
+    periodic reporters. Required by `SLF4J`. Setting this value too low may lead to excessive disk usage. A value of
+    `60000` (60s) provides minute-by-minute granularity in combination with the 1-minute moving average provided
+    by certain metric values. Logging is done at the `INFO` level using a logger named
+    `com.joyent.manta.client.metrics`.
 
 ### Customizing the client further
 

--- a/java-manta-client-unshaded/pom.xml
+++ b/java-manta-client-unshaded/pom.xml
@@ -178,6 +178,12 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>${dependency.dropwizard-metrics.version}</version>
+        </dependency>
+
         <!-- These dependencies are declared at the module level because we can not
              inherit exclusions from the parent. -->
         <dependency>

--- a/java-manta-client-unshaded/pom.xml
+++ b/java-manta-client-unshaded/pom.xml
@@ -184,6 +184,12 @@
             <version>${dependency.dropwizard-metrics.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-jmx</artifactId>
+            <version>${dependency.dropwizard-metrics.version}</version>
+        </dependency>
+
         <!-- These dependencies are declared at the module level because we can not
              inherit exclusions from the parent. -->
         <dependency>

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -168,7 +168,7 @@ public class MantaClient implements AutoCloseable {
     private final ForkJoinPool findForkJoinPool;
 
     /**
-     * MBean agent used when metrics and JMX are enabled.
+     * Reporting agent used when metrics and JMX are enabled.
      */
     private final MantaClientAgent agent;
 

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -214,7 +214,7 @@ public class MantaClient implements AutoCloseable {
         }
 
         final MetricRegistry metricRegistry;
-        if (this.config.getMonitoringEnabled()) {
+        if (BooleanUtils.isTrue(this.config.getMonitoringEnabled())) {
             metricRegistry = new MetricRegistry();
         } else {
             metricRegistry = null;

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClientAgent.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClientAgent.java
@@ -7,10 +7,10 @@
  */
 package com.joyent.manta.client;
 
-import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.ObjectNameFactory;
 import com.codahale.metrics.Reporter;
+import com.codahale.metrics.jmx.JmxReporter;
+import com.codahale.metrics.jmx.ObjectNameFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MetricReporterSupplier.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MetricReporterSupplier.java
@@ -31,10 +31,10 @@ final class MetricReporterSupplier implements Supplier<Closeable> {
      * The logger name to use for SLF4J reporting.
      */
     public static final String FMT_METRIC_LOGGER_NAME = "com.joyent.manta.client.metrics";
+
     /**
      * A metric reporter constructed and configured with settings from the supplied configuration.
      */
-
     private final Closeable reporter;
 
     /**

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MetricReporterSupplier.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MetricReporterSupplier.java
@@ -1,0 +1,86 @@
+package com.joyent.manta.client;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Reporter;
+import com.codahale.metrics.Slf4jReporter;
+import com.codahale.metrics.jmx.JmxReporter;
+import com.joyent.manta.config.MantaClientMetricConfiguration;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import static org.apache.commons.lang3.Validate.inclusiveBetween;
+import static org.apache.commons.lang3.Validate.notNull;
+
+final class MetricReporterSupplier implements Supplier<Closeable> {
+
+    private final Closeable reporter;
+
+    MetricReporterSupplier(final MantaClientMetricConfiguration metricConfig) {
+        notNull(metricConfig);
+
+        switch (metricConfig.getReporterMode()) {
+            case JMX:
+                final JmxReporter jmxReporter = buildJmxReporter(metricConfig);
+                jmxReporter.start();
+                this.reporter = jmxReporter;
+                break;
+            case SLF4J:
+                final Slf4jReporter slf4jReporter = buildSlf4jReporter(metricConfig);
+                slf4jReporter.start(metricConfig.getPeriodicReporterOutputInterval(), TimeUnit.MILLISECONDS);
+                this.reporter = slf4jReporter;
+                break;
+            case DISABLED:
+            default:
+                this.reporter = null;
+        }
+    }
+
+    @Override
+    public Closeable get() {
+        return this.reporter;
+    }
+
+    private static Slf4jReporter buildSlf4jReporter(final MantaClientMetricConfiguration metricConfig) {
+        return Slf4jReporter.forRegistry(metricConfig.getRegistry())
+                .convertRatesTo(TimeUnit.SECONDS)
+                .convertDurationsTo(TimeUnit.MILLISECONDS)
+                .prefixedWith(metricConfig.getClientId().toString())
+                .outputTo(LoggerFactory.getLogger("com.joyent.manta.client.metrics"))
+                // .shutdownExecutorOnStop()
+                // .markWith()
+                // .withLoggingLevel()
+                .build();
+    }
+
+    private static JmxReporter buildJmxReporter(final MantaClientMetricConfiguration metricConfig) {
+        return JmxReporter.forRegistry(metricConfig.getRegistry())
+                .convertRatesTo(TimeUnit.SECONDS)
+                .convertDurationsTo(TimeUnit.MILLISECONDS)
+                .createsObjectNamesWith(
+                        (type, domain, name) -> {
+                            final String metricJmxObjectName = String.format(
+                                    MantaClientAgent.FMT_MBEAN_OBJECT_NAME,
+                                    name,
+                                    metricConfig.getClientId());
+
+                            try {
+                                return new ObjectName(metricJmxObjectName);
+                            } catch (final MalformedObjectNameException e) {
+                                final String msg = String.format(
+                                        "Unable to create JMX object name for metric: %s (name=%s, clientId=%s)",
+                                        metricJmxObjectName,
+                                        name,
+                                        metricConfig.getClientId());
+                                throw new RuntimeException(msg, e);
+                            }
+                        }
+                )
+                .build();
+    }
+}

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MetricReporterSupplier.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MetricReporterSupplier.java
@@ -1,26 +1,42 @@
+/*
+ * Copyright (c) 2018, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.joyent.manta.client;
 
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Reporter;
 import com.codahale.metrics.Slf4jReporter;
 import com.codahale.metrics.jmx.JmxReporter;
 import com.joyent.manta.config.MantaClientMetricConfiguration;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
-import static org.apache.commons.lang3.Validate.inclusiveBetween;
 import static org.apache.commons.lang3.Validate.notNull;
 
+/**
+ * Helper class for building and starting a metric reporter given a {@link MantaClientMetricConfiguration}.
+ *
+ * @author <a href="https://github.com/tjcelaya">Tomas Celaya</a>
+ */
 final class MetricReporterSupplier implements Supplier<Closeable> {
 
+    /**
+     * A metric reporter constructed and configured with settings from the supplied configuration.
+     */
     private final Closeable reporter;
 
+    /**
+     * Constructing an instance of this class prepares the desired metric reporter based on the supplied configuration.
+     *
+     * @param metricConfig details about the type of reporter to construct and any necessary additional parameters
+     */
     MetricReporterSupplier(final MantaClientMetricConfiguration metricConfig) {
         notNull(metricConfig);
 

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MetricReporterSupplier.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MetricReporterSupplier.java
@@ -28,8 +28,13 @@ import static org.apache.commons.lang3.Validate.notNull;
 final class MetricReporterSupplier implements Supplier<Closeable> {
 
     /**
+     * The logger name to use for SLF4J reporting.
+     */
+    public static final String FMT_METRIC_LOGGER_NAME = "com.joyent.manta.client.metrics";
+    /**
      * A metric reporter constructed and configured with settings from the supplied configuration.
      */
+
     private final Closeable reporter;
 
     /**
@@ -67,7 +72,7 @@ final class MetricReporterSupplier implements Supplier<Closeable> {
                 .convertRatesTo(TimeUnit.SECONDS)
                 .convertDurationsTo(TimeUnit.MILLISECONDS)
                 .prefixedWith(metricConfig.getClientId().toString())
-                .outputTo(LoggerFactory.getLogger("com.joyent.manta.client.metrics"))
+                .outputTo(LoggerFactory.getLogger(FMT_METRIC_LOGGER_NAME))
                 // .shutdownExecutorOnStop()
                 // .markWith()
                 // .withLoggingLevel()

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MetricReporterSupplier.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MetricReporterSupplier.java
@@ -53,7 +53,7 @@ final class MetricReporterSupplier implements Supplier<Closeable> {
                 break;
             case SLF4J:
                 final Slf4jReporter slf4jReporter = buildSlf4jReporter(metricConfig);
-                slf4jReporter.start(metricConfig.getPeriodicReporterOutputInterval(), TimeUnit.MILLISECONDS);
+                slf4jReporter.start(metricConfig.getPeriodicReporterOutputInterval(), TimeUnit.SECONDS);
                 this.reporter = slf4jReporter;
                 break;
             case DISABLED:

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/AuthAwareConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/AuthAwareConfigContext.java
@@ -282,6 +282,15 @@ public class AuthAwareConfigContext
     }
 
     @Override
+    public AuthAwareConfigContext setMonitoringEnabled(final Boolean monitoringEnabled) {
+        synchronized (lock) {
+            super.setMonitoringEnabled(monitoringEnabled);
+        }
+
+        return this;
+    }
+
+    @Override
     public AuthAwareConfigContext setTimeout(final Integer timeout) {
         synchronized (lock) {
             super.setTimeout(timeout);

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/AuthAwareConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/AuthAwareConfigContext.java
@@ -282,9 +282,9 @@ public class AuthAwareConfigContext
     }
 
     @Override
-    public AuthAwareConfigContext setMonitoringEnabled(final Boolean monitoringEnabled) {
+    public AuthAwareConfigContext setMonitoringEnabled(final Boolean monitoring) {
         synchronized (lock) {
-            super.setMonitoringEnabled(monitoringEnabled);
+            super.setMonitoringEnabled(monitoring);
         }
 
         return this;

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/AuthAwareConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/AuthAwareConfigContext.java
@@ -282,15 +282,6 @@ public class AuthAwareConfigContext
     }
 
     @Override
-    public AuthAwareConfigContext setMonitoringEnabled(final Boolean monitoring) {
-        synchronized (lock) {
-            super.setMonitoringEnabled(monitoring);
-        }
-
-        return this;
-    }
-
-    @Override
     public AuthAwareConfigContext setTimeout(final Integer timeout) {
         synchronized (lock) {
             super.setTimeout(timeout);
@@ -411,6 +402,24 @@ public class AuthAwareConfigContext
     public AuthAwareConfigContext setUploadBufferSize(final Integer size) {
         synchronized (lock) {
             super.setUploadBufferSize(size);
+        }
+
+        return this;
+    }
+
+    @Override
+    public AuthAwareConfigContext setMetricReporterMode(final MetricReporterMode metricReporterMode) {
+        synchronized (lock) {
+            super.setMetricReporterMode(metricReporterMode);
+        }
+
+        return this;
+    }
+
+    @Override
+    public AuthAwareConfigContext setMetricReporterOutputInterval(final Integer metricReporterOutputInterval) {
+        synchronized (lock) {
+            super.setMetricReporterOutputInterval(metricReporterOutputInterval);
         }
 
         return this;

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/BaseChainedConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/BaseChainedConfigContext.java
@@ -40,11 +40,6 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
     private volatile String mantaKeyPath;
 
     /**
-     * Whether metrics and MBeans should be tracked and exposed.
-     */
-    private volatile Boolean monitoringEnabled;
-
-    /**
      * General connection timeout for the Manta service.
      */
     private volatile Integer timeout;
@@ -119,6 +114,16 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
      * Number of directories to assume exist when recursively creating directories.
      */
     private Integer skipDirectoryDepth;
+
+    /**
+     * Whether metrics and MBeans should be tracked and exposed.
+     */
+    private volatile MetricReporterMode metricReporterMode;
+
+    /**
+     * Whether metrics and MBeans should be tracked and exposed.
+     */
+    private volatile Integer metricReporterOutputInterval;
 
     /**
      * Number of bytes to read into memory for a streaming upload before
@@ -213,11 +218,6 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
     }
 
     @Override
-    public Boolean getMonitoringEnabled() {
-        return this.monitoringEnabled;
-    }
-
-    @Override
     public Integer getTimeout() {
         return this.timeout;
     }
@@ -290,6 +290,16 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
     @Override
     public Integer getSkipDirectoryDepth() {
         return this.skipDirectoryDepth;
+    }
+
+    @Override
+    public MetricReporterMode getMetricReporterMode() {
+        return this.metricReporterMode;
+    }
+
+    @Override
+    public Integer getMetricReporterOutputInterval() {
+        return this.metricReporterOutputInterval;
     }
 
     @Override
@@ -375,8 +385,12 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
             this.mantaKeyPath = context.getMantaKeyPath();
         }
 
-        if (context.getMonitoringEnabled() != null) {
-            this.monitoringEnabled = context.getMonitoringEnabled();
+        if (context.getMetricReporterMode() != null) {
+            this.metricReporterMode = context.getMetricReporterMode();
+        }
+
+        if (context.getMetricReporterOutputInterval() != null) {
+            this.metricReporterOutputInterval = context.getMetricReporterOutputInterval();
         }
 
         if (context.getTimeout() != null) {
@@ -448,6 +462,14 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
             this.skipDirectoryDepth = context.getSkipDirectoryDepth();
         }
 
+        if (context.getMetricReporterMode() != null) {
+            this.metricReporterMode = context.getMetricReporterMode();
+        }
+
+        if (context.getMetricReporterOutputInterval() != null) {
+            this.metricReporterOutputInterval = context.getMetricReporterOutputInterval();
+        }
+
         if (context.isClientEncryptionEnabled() != null) {
             this.clientEncryptionEnabled = context.isClientEncryptionEnabled();
         }
@@ -498,10 +520,6 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
         if (!isPresent(this.getMantaKeyPath()) && !isPresent(this.getPrivateKeyContent())) {
             this.mantaKeyPathSetOnlyByDefaults = true;
             this.mantaKeyPath = context.getMantaKeyPath();
-        }
-
-        if (this.getMonitoringEnabled() == null) {
-            this.monitoringEnabled = context.getMonitoringEnabled();
         }
 
         if (this.getTimeout() == null) {
@@ -562,6 +580,14 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
 
         if (this.skipDirectoryDepth == null) {
             this.skipDirectoryDepth = context.getSkipDirectoryDepth();
+        }
+
+        if (this.getMetricReporterMode() == null) {
+            this.metricReporterMode = context.getMetricReporterMode();
+        }
+
+        if (this.getMetricReporterOutputInterval() == null) {
+            this.metricReporterOutputInterval = context.getMetricReporterOutputInterval();
         }
 
         if (this.clientEncryptionEnabled == null) {
@@ -629,12 +655,6 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
         }
 
         this.mantaKeyPath = mantaKeyPath;
-        return this;
-    }
-
-    @Override
-    public BaseChainedConfigContext setMonitoringEnabled(final Boolean monitoringEnabled) {
-        this.monitoringEnabled = monitoringEnabled;
         return this;
     }
 
@@ -761,6 +781,18 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
     }
 
     @Override
+    public BaseChainedConfigContext setMetricReporterMode(final MetricReporterMode metricReporterMode) {
+        this.metricReporterMode = metricReporterMode;
+        return this;
+    }
+
+    @Override
+    public BaseChainedConfigContext setMetricReporterOutputInterval(final Integer metricReporterOutputInterval) {
+        this.metricReporterOutputInterval = metricReporterOutputInterval;
+        return this;
+    }
+
+    @Override
     public BaseChainedConfigContext setClientEncryptionEnabled(final Boolean clientEncryptionEnabled) {
         this.clientEncryptionEnabled = clientEncryptionEnabled;
 
@@ -850,6 +882,8 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
                 && Objects.equals(verifyUploads, that.verifyUploads)
                 && Objects.equals(uploadBufferSize, that.uploadBufferSize)
                 && Objects.equals(skipDirectoryDepth, that.skipDirectoryDepth)
+                && Objects.equals(metricReporterMode, that.metricReporterMode)
+                && Objects.equals(metricReporterOutputInterval, that.metricReporterOutputInterval)
                 && Objects.equals(clientEncryptionEnabled, that.clientEncryptionEnabled)
                 && Objects.equals(encryptionKeyId, that.encryptionKeyId)
                 && Objects.equals(encryptionAlgorithm, that.encryptionAlgorithm)
@@ -867,6 +901,8 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
                 disableNativeSignatures, tcpSocketTimeout, connectionRequestTimeout, expectContinueTimeout,
                 verifyUploads, uploadBufferSize,
                 skipDirectoryDepth,
+                metricReporterMode,
+                metricReporterOutputInterval,
                 clientEncryptionEnabled, encryptionKeyId,
                 encryptionAlgorithm, permitUnencryptedDownloads,
                 encryptionAuthenticationMode, encryptionPrivateKeyPath,

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/BaseChainedConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/BaseChainedConfigContext.java
@@ -40,6 +40,11 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
     private volatile String mantaKeyPath;
 
     /**
+     * Whether metrics and MBeans should be tracked and exposed.
+     */
+    private volatile Boolean monitoringEnabled;
+
+    /**
      * General connection timeout for the Manta service.
      */
     private volatile Integer timeout;
@@ -205,6 +210,11 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
     @Override
     public String getMantaKeyPath() {
         return this.mantaKeyPath;
+    }
+
+    @Override
+    public Boolean getMonitoringEnabled() {
+        return this.monitoringEnabled;
     }
 
     @Override
@@ -611,6 +621,12 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
         }
 
         this.mantaKeyPath = mantaKeyPath;
+        return this;
+    }
+
+    @Override
+    public BaseChainedConfigContext setMonitoringEnabled(final Boolean monitoringEnabled) {
+        this.monitoringEnabled = monitoringEnabled;
         return this;
     }
 

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/BaseChainedConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/BaseChainedConfigContext.java
@@ -121,7 +121,7 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
     private volatile MetricReporterMode metricReporterMode;
 
     /**
-     * Whether metrics and MBeans should be tracked and exposed.
+     * Metrics output interval in seconds for modes that report metrics periodically.
      */
     private volatile Integer metricReporterOutputInterval;
 

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/BaseChainedConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/BaseChainedConfigContext.java
@@ -375,6 +375,10 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
             this.mantaKeyPath = context.getMantaKeyPath();
         }
 
+        if (context.getMonitoringEnabled() != null) {
+            this.monitoringEnabled = context.getMonitoringEnabled();
+        }
+
         if (context.getTimeout() != null) {
             this.timeout = context.getTimeout();
         }
@@ -494,6 +498,10 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
         if (!isPresent(this.getMantaKeyPath()) && !isPresent(this.getPrivateKeyContent())) {
             this.mantaKeyPathSetOnlyByDefaults = true;
             this.mantaKeyPath = context.getMantaKeyPath();
+        }
+
+        if (this.getMonitoringEnabled() == null) {
+            this.monitoringEnabled = context.getMonitoringEnabled();
         }
 
         if (this.getTimeout() == null) {

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/ConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/ConfigContext.java
@@ -146,7 +146,7 @@ public interface ConfigContext extends MantaMBeanable {
     MetricReporterMode getMetricReporterMode();
 
     /**
-     * @return number of milliseconds between metrics output for periodic reporters
+     * @return number of seconds between metrics output for periodic reporters
      */
     Integer getMetricReporterOutputInterval();
 

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/ConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/ConfigContext.java
@@ -141,6 +141,16 @@ public interface ConfigContext extends MantaMBeanable {
     Integer getSkipDirectoryDepth();
 
     /**
+     * @return the way metrics should be reported, {@code MetricReporterMode.DISABLED} or {@code null} to disable
+     */
+    MetricReporterMode getMetricReporterMode();
+
+    /**
+     * @return number of milliseconds between metrics output for periodic reporters
+     */
+    Integer getMetricReporterOutputInterval();
+
+    /**
      * @return true when client-side encryption is enabled.
      */
     Boolean isClientEncryptionEnabled();
@@ -180,10 +190,6 @@ public interface ConfigContext extends MantaMBeanable {
      * @return private encryption key data (can't be used if private key path is not null)
      */
     byte[] getEncryptionPrivateKeyBytes();
-
-    default Boolean getMonitoringEnabled() {
-        return true;
-    }
 
     /** {@inheritDoc} */
     @Override
@@ -233,6 +239,8 @@ public interface ConfigContext extends MantaMBeanable {
         sb.append(", verifyUploads=").append(context.verifyUploads());
         sb.append(", uploadBufferSize=").append(context.getUploadBufferSize());
         sb.append(", skipDirectoryDepth=").append(context.getSkipDirectoryDepth());
+        sb.append(", metricReporterMode=").append(context.getMetricReporterMode());
+        sb.append(", metricReporterOutputInterval=").append(context.getMetricReporterOutputInterval());
         sb.append(", clientEncryptionEnabled=").append(context.isClientEncryptionEnabled());
         sb.append(", permitUnencryptedDownloads=").append(context.permitUnencryptedDownloads());
         sb.append(", encryptionAuthenticationMode=").append(context.getEncryptionAuthenticationMode());
@@ -315,6 +323,16 @@ public interface ConfigContext extends MantaMBeanable {
 
         if (config.getSkipDirectoryDepth() != null && config.getSkipDirectoryDepth() < 0) {
             failureMessages.add("Manta skip directory depth must be 0 or greater");
+        }
+
+        if (config.getMetricReporterMode() != null) {
+            if (MetricReporterMode.SLF4J.equals(config.getMetricReporterMode())) {
+                if (config.getMetricReporterOutputInterval() == null) {
+                    failureMessages.add("SLF4J metric reporter selected but no output interval was provided");
+                } else if (config.getMetricReporterOutputInterval() < 1) {
+                    failureMessages.add("Metric reporter output interval (ms) must be 1 or greater");
+                }
+            }
         }
 
         if (BooleanUtils.isTrue(config.isClientEncryptionEnabled())) {

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/ConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/ConfigContext.java
@@ -181,6 +181,10 @@ public interface ConfigContext extends MantaMBeanable {
      */
     byte[] getEncryptionPrivateKeyBytes();
 
+    default Boolean getMonitoringEnabled() {
+        return true;
+    }
+
     /** {@inheritDoc} */
     @Override
     default DynamicMBean toMBean() {
@@ -542,4 +546,5 @@ public interface ConfigContext extends MantaMBeanable {
                 return null;
         }
     }
+
 }

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/DefaultsConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/DefaultsConfigContext.java
@@ -235,6 +235,16 @@ public class DefaultsConfigContext implements ConfigContext {
     }
 
     @Override
+    public MetricReporterMode getMetricReporterMode() {
+        return null;
+    }
+
+    @Override
+    public Integer getMetricReporterOutputInterval() {
+        return null;
+    }
+
+    @Override
     public Boolean isClientEncryptionEnabled() {
         return false;
     }

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/EnvVarConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/EnvVarConfigContext.java
@@ -120,6 +120,16 @@ public class EnvVarConfigContext implements ConfigContext {
     public static final String MANTA_SKIP_DIRECTORY_DEPTH_ENV_KEY = "MANTA_SKIP_DIRECTORY_DEPTH";
 
     /**
+     * Environment variable for setting the depth of directories to assume exists.
+     */
+    public static final String MANTA_METRIC_REPORTER_MODE_ENV_KEY = "MANTA_METRIC_REPORTER_MODE";
+
+    /**
+     * Environment variable for setting the depth of directories to assume exists.
+     */
+    public static final String MANTA_METRIC_REPORTER_OUTPUT_INTERVAL_ENV_KEY = "MANTA_METRIC_REPORTER_OUTPUT_INTERVAL";
+
+    /**
      * Environment variable for flag indicating when client-side encryption is enabled.
      */
     public static final String MANTA_CLIENT_ENCRYPTION_ENABLED_ENV_KEY = "MANTA_CLIENT_ENCRYPTION";
@@ -174,6 +184,8 @@ public class EnvVarConfigContext implements ConfigContext {
             MANTA_VERIFY_UPLOADS_ENV_KEY,
             MANTA_UPLOAD_BUFFER_SIZE_ENV_KEY,
             MANTA_SKIP_DIRECTORY_DEPTH_ENV_KEY,
+            MANTA_METRIC_REPORTER_MODE_ENV_KEY,
+            MANTA_METRIC_REPORTER_OUTPUT_INTERVAL_ENV_KEY,
             MANTA_CLIENT_ENCRYPTION_ENABLED_ENV_KEY,
             MANTA_ENCRYPTION_KEY_ID_ENV_KEY,
             MANTA_PERMIT_UNENCRYPTED_DOWNLOADS_ENV_KEY,
@@ -307,6 +319,20 @@ public class EnvVarConfigContext implements ConfigContext {
     @Override
     public Integer getSkipDirectoryDepth() {
         return MantaUtils.parseIntegerOrNull(getEnv(MANTA_SKIP_DIRECTORY_DEPTH_ENV_KEY));
+    }
+
+    @Override
+    public MetricReporterMode getMetricReporterMode() {
+        String enumValue = getEnv(MANTA_METRIC_REPORTER_MODE_ENV_KEY);
+
+        return MantaUtils.parseEnumOrNull(enumValue, MetricReporterMode.class);
+    }
+
+    @Override
+    public Integer getMetricReporterOutputInterval() {
+        final String strValue = getEnv(MANTA_METRIC_REPORTER_OUTPUT_INTERVAL_ENV_KEY);
+
+        return MantaUtils.parseIntegerOrNull(strValue);
     }
 
     @Override

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/MantaClientMetricConfiguration.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/MantaClientMetricConfiguration.java
@@ -23,8 +23,8 @@ import static org.apache.commons.lang3.Validate.notNull;
 public final class MantaClientMetricConfiguration {
 
     /**
-     * Unique identifier for each {@link com.joyent.manta.client.MantaClient} instance. Used to avoid collisions when
-     * registering objects in JMX.
+     * Unique identifier for each {@link com.joyent.manta.client.MantaClient} instance. Also used to avoid collisions
+     * when registering objects in JMX.
      */
     private final UUID clientId;
 

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/MantaClientMetricConfiguration.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/MantaClientMetricConfiguration.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2018, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.joyent.manta.config;
 
 import com.codahale.metrics.MetricRegistry;
@@ -7,15 +14,38 @@ import java.util.UUID;
 import static org.apache.commons.lang3.Validate.inclusiveBetween;
 import static org.apache.commons.lang3.Validate.notNull;
 
+/**
+ * Value object describing how metrics should be exposed for a {@link com.joyent.manta.client.MantaClient}.
+ *
+ * @author <a href="https://github.com/tjcelaya">Tomas Celaya</a>
+ * @since 3.1.9, 3.2.2
+ */
 public final class MantaClientMetricConfiguration {
 
+    /**
+     * Unique identifier for each {@link com.joyent.manta.client.MantaClient} instance. Used to avoid collisions when
+     * registering objects in JMX.
+     */
     private final UUID clientId;
+
+    /**
+     * Registry used to track metrics and to be used with a reporter (if one is set).
+     */
     private final MetricRegistry registry;
+
+    /**
+     * Method for reporting metrics.
+     */
     private final MetricReporterMode reporterMode;
+
+    /**
+     * Nullable duration used by periodic reporting modes.
+     */
     private final Integer periodicReporterOutputInterval;
 
     /**
-     * Empty configuration indicating no metrics should be collected.
+     * Empty configuration indicating no metrics should be collected. Ideally this constructor would be package-private
+     * but it is needed for testing by {@link com.joyent.manta.client.MantaClientAgent}.
      */
     public MantaClientMetricConfiguration() {
         this.clientId = null;
@@ -29,7 +59,7 @@ public final class MantaClientMetricConfiguration {
      * how reporting those metrics is handled.
      *
      * @param clientId client unique identifier
-     * @param registry supplied MetricRegistry to use for verification
+     * @param registry user-constructed metric registry
      */
     public MantaClientMetricConfiguration(final UUID clientId, final MetricRegistry registry) {
         this.clientId = notNull(clientId);
@@ -38,6 +68,18 @@ public final class MantaClientMetricConfiguration {
         this.periodicReporterOutputInterval = null;
     }
 
+    /**
+     * Construct a configuration for tracking metrics using the supplied registry, how those metrics should be reported,
+     * and the periodic output interval required by certain reporting modes.
+     *
+     * @param clientId                       client unique identifier
+     * @param registry                       user-constructed metric registry
+     * @param reporterMode                   method for reporting metrics
+     * @param periodicReporterOutputInterval potentially-null time for periodic metric reporters, validated for certain
+     *                                       reporting modes
+     * @throws NullPointerException     when the interval is required but none was given
+     * @throws IllegalArgumentException when the interval is provided but invalid
+     */
     public MantaClientMetricConfiguration(
             final UUID clientId,
             final MetricRegistry registry,
@@ -48,17 +90,6 @@ public final class MantaClientMetricConfiguration {
         this.registry = notNull(registry);
         this.reporterMode = notNull(reporterMode);
         this.periodicReporterOutputInterval = validateReporterOutputInterval(periodicReporterOutputInterval);
-    }
-
-    private Integer validateReporterOutputInterval(final Integer reporterOutputInterval) {
-        if (!this.reporterMode.equals(MetricReporterMode.SLF4J)) {
-            return reporterOutputInterval;
-        }
-        notNull(reporterOutputInterval,
-                "Reporter output interval must be set when SLF4J reporter is selected");
-        inclusiveBetween(1, Integer.MAX_VALUE, (Comparable<Integer>) reporterOutputInterval,
-                "Reporter output interval must be greater than 0 when SLF4J reporter is selected");
-        return reporterOutputInterval;
     }
 
     public UUID getClientId() {
@@ -77,4 +108,22 @@ public final class MantaClientMetricConfiguration {
         return this.periodicReporterOutputInterval;
     }
 
+    /**
+     * Check that the supplied reporter output interval is valid if the given reporting mode requires one and return it.
+     *
+     * @param reporterOutputInterval the interval to validate
+     * @return the valid interval
+     * @throws NullPointerException     when the interval is required but none was given
+     * @throws IllegalArgumentException when the interval is provided but invalid
+     */
+    private Integer validateReporterOutputInterval(final Integer reporterOutputInterval) {
+        if (!this.reporterMode.equals(MetricReporterMode.SLF4J)) {
+            return reporterOutputInterval;
+        }
+        notNull(reporterOutputInterval,
+                "Reporter output interval must be set when SLF4J reporter is selected");
+        inclusiveBetween(1, Integer.MAX_VALUE, (Comparable<Integer>) reporterOutputInterval,
+                "Reporter output interval must be greater than 0 when SLF4J reporter is selected");
+        return reporterOutputInterval;
+    }
 }

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/MantaClientMetricConfiguration.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/MantaClientMetricConfiguration.java
@@ -1,0 +1,80 @@
+package com.joyent.manta.config;
+
+import com.codahale.metrics.MetricRegistry;
+
+import java.util.UUID;
+
+import static org.apache.commons.lang3.Validate.inclusiveBetween;
+import static org.apache.commons.lang3.Validate.notNull;
+
+public final class MantaClientMetricConfiguration {
+
+    private final UUID clientId;
+    private final MetricRegistry registry;
+    private final MetricReporterMode reporterMode;
+    private final Integer periodicReporterOutputInterval;
+
+    /**
+     * Empty configuration indicating no metrics should be collected.
+     */
+    public MantaClientMetricConfiguration() {
+        this.clientId = null;
+        this.registry = null;
+        this.reporterMode = null;
+        this.periodicReporterOutputInterval = null;
+    }
+
+    /**
+     * Allow users to provide an existing MetricRegistry they might want to reuse. Caller is responsible for
+     * how reporting those metrics is handled.
+     *
+     * @param clientId client unique identifier
+     * @param registry supplied MetricRegistry to use for verification
+     */
+    public MantaClientMetricConfiguration(final UUID clientId, final MetricRegistry registry) {
+        this.clientId = notNull(clientId);
+        this.registry = notNull(registry);
+        this.reporterMode = null;
+        this.periodicReporterOutputInterval = null;
+    }
+
+    public MantaClientMetricConfiguration(
+            final UUID clientId,
+            final MetricRegistry registry,
+            final MetricReporterMode reporterMode,
+            final Integer periodicReporterOutputInterval
+    ) {
+        this.clientId = notNull(clientId);
+        this.registry = notNull(registry);
+        this.reporterMode = notNull(reporterMode);
+        this.periodicReporterOutputInterval = validateReporterOutputInterval(periodicReporterOutputInterval);
+    }
+
+    private Integer validateReporterOutputInterval(final Integer reporterOutputInterval) {
+        if (!this.reporterMode.equals(MetricReporterMode.SLF4J)) {
+            return reporterOutputInterval;
+        }
+        notNull(reporterOutputInterval,
+                "Reporter output interval must be set when SLF4J reporter is selected");
+        inclusiveBetween(1, Integer.MAX_VALUE, (Comparable<Integer>) reporterOutputInterval,
+                "Reporter output interval must be greater than 0 when SLF4J reporter is selected");
+        return reporterOutputInterval;
+    }
+
+    public UUID getClientId() {
+        return this.clientId;
+    }
+
+    public MetricRegistry getRegistry() {
+        return this.registry;
+    }
+
+    public MetricReporterMode getReporterMode() {
+        return this.reporterMode;
+    }
+
+    public Integer getPeriodicReporterOutputInterval() {
+        return this.periodicReporterOutputInterval;
+    }
+
+}

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/MapConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/MapConfigContext.java
@@ -123,6 +123,16 @@ public class MapConfigContext implements ConfigContext {
     public static final String MANTA_SKIP_DIRECTORY_DEPTH_KEY = "manta.skip_directory_depth";
 
     /**
+     * Property key for looking up a Manta agent reporting format.
+     */
+    public static final String MANTA_METRIC_REPORTER_MODE_KEY = "manta.metric_reporter.mode";
+
+    /**
+     * Property key for looking up a Manta agent reporting output interval.
+     */
+    public static final String MANTA_METRIC_REPORTER_OUTPUT_INTERVAL_KEY = "manta.metric_reporter.output_interval";
+
+    /**
      * Property key for flag indicating when client-side encryption is enabled.
      */
     public static final String MANTA_CLIENT_ENCRYPTION_ENABLED_KEY = "manta.client_encryption";
@@ -185,6 +195,8 @@ public class MapConfigContext implements ConfigContext {
             MANTA_UPLOAD_BUFFER_SIZE_KEY,
             MANTA_CONNECTION_REQUEST_TIMEOUT_KEY,
             MANTA_SKIP_DIRECTORY_DEPTH_KEY,
+            MANTA_METRIC_REPORTER_MODE_KEY,
+            MANTA_METRIC_REPORTER_OUTPUT_INTERVAL_KEY,
             MANTA_CLIENT_ENCRYPTION_ENABLED_KEY,
             MANTA_PERMIT_UNENCRYPTED_DOWNLOADS_KEY,
             MANTA_ENCRYPTION_KEY_ID_KEY,
@@ -393,6 +405,32 @@ public class MapConfigContext implements ConfigContext {
         }
 
         return MantaUtils.parseIntegerOrNull(backingMap.get(MANTA_SKIP_DIRECTORY_DEPTH_ENV_KEY));
+    }
+
+    @Override
+    public MetricReporterMode getMetricReporterMode() {
+        final MetricReporterMode metricReporterMode = MantaUtils.parseEnumOrNull(
+                backingMap.get(MANTA_ENCRYPTION_AUTHENTICATION_MODE_KEY),
+                MetricReporterMode.class);
+
+        if (metricReporterMode != null) {
+            return metricReporterMode;
+        }
+
+        return MantaUtils.parseEnumOrNull(
+                backingMap.get(MANTA_ENCRYPTION_AUTHENTICATION_MODE_ENV_KEY),
+                MetricReporterMode.class);
+    }
+
+    @Override
+    public Integer getMetricReporterOutputInterval() {
+        final Integer mapValue = MantaUtils.parseIntegerOrNull(backingMap.get(MANTA_METRIC_REPORTER_OUTPUT_INTERVAL_KEY));
+
+        if (mapValue != null) {
+            return mapValue;
+        }
+
+        return MantaUtils.parseIntegerOrNull(backingMap.get(MANTA_METRIC_REPORTER_OUTPUT_INTERVAL_ENV_KEY));
     }
 
     @Override

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/MapConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/MapConfigContext.java
@@ -410,7 +410,7 @@ public class MapConfigContext implements ConfigContext {
     @Override
     public MetricReporterMode getMetricReporterMode() {
         final MetricReporterMode metricReporterMode = MantaUtils.parseEnumOrNull(
-                backingMap.get(MANTA_ENCRYPTION_AUTHENTICATION_MODE_KEY),
+                backingMap.get(MANTA_METRIC_REPORTER_MODE_KEY),
                 MetricReporterMode.class);
 
         if (metricReporterMode != null) {
@@ -418,7 +418,7 @@ public class MapConfigContext implements ConfigContext {
         }
 
         return MantaUtils.parseEnumOrNull(
-                backingMap.get(MANTA_ENCRYPTION_AUTHENTICATION_MODE_ENV_KEY),
+                backingMap.get(MANTA_METRIC_REPORTER_MODE_ENV_KEY),
                 MetricReporterMode.class);
     }
 

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/MapConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/MapConfigContext.java
@@ -424,7 +424,8 @@ public class MapConfigContext implements ConfigContext {
 
     @Override
     public Integer getMetricReporterOutputInterval() {
-        final Integer mapValue = MantaUtils.parseIntegerOrNull(backingMap.get(MANTA_METRIC_REPORTER_OUTPUT_INTERVAL_KEY));
+        final Integer mapValue = MantaUtils.parseIntegerOrNull(
+                backingMap.get(MANTA_METRIC_REPORTER_OUTPUT_INTERVAL_KEY));
 
         if (mapValue != null) {
             return mapValue;

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/MetricReporterMode.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/MetricReporterMode.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016-2017, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.manta.config;
+
+/**
+ * Enum specifying the available metric reporting modes.
+ *
+ * @author <a href="https://github.com/tjcelaya">Tomas Celaya</a>
+ * @since 3.1.9, 3.2.2
+ */
+public enum MetricReporterMode {
+    /**
+     * No metrics will be collected or reported.
+     */
+    DISABLED,
+
+    /**
+     * Report metrics through JMX (as MBeans).
+     */
+    JMX,
+
+    /**
+     * Report metrics through SLF4J (as logs).
+     */
+    SLF4J;
+
+    /**
+     * The default metric reporting mode is to disable metric reporting.
+     */
+    public static final MetricReporterMode DEFAULT = DISABLED;
+}

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/SettableConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/SettableConfigContext.java
@@ -50,13 +50,6 @@ public interface SettableConfigContext<T> extends ConfigContext {
     T setMantaKeyPath(String mantaKeyPath);
 
     /**
-     * Whether or not MBeans and metrics should be activated.
-     * @param monitoring build a monitoring agent or not
-     * @return the current instance of {@link T}
-     */
-    T setMonitoringEnabled(Boolean monitoring);
-
-    /**
      * Sets the general connection timeout for the Manta service.
      * @param timeout timeout in milliseconds
      * @return the current instance of {@link T}
@@ -186,6 +179,22 @@ public interface SettableConfigContext<T> extends ConfigContext {
      * @return the current instance of {@link T}
      */
     T setSkipDirectoryDepth(Integer depth);
+
+    /**
+     * Sets the method used to report metrics (or disable them entirely).
+     *
+     * @param metricReporterMode metric reporting mode
+     * @return the current instance of {@link T}
+     */
+    T setMetricReporterMode(MetricReporterMode metricReporterMode);
+
+    /**
+     * Sets the method used to report metrics (or disables them entirely).
+     *
+     * @param metricReporterOutputInterval metrics output interval in milliseconds for modes that report periodically
+     * @return the current instance of {@link T}
+     */
+    T setMetricReporterOutputInterval(Integer metricReporterOutputInterval);
 
     /**
      * Sets flag indicating when client-side encryption is enabled.
@@ -331,6 +340,25 @@ public interface SettableConfigContext<T> extends ConfigContext {
             case MapConfigContext.MANTA_SKIP_DIRECTORY_DEPTH_KEY:
             case EnvVarConfigContext.MANTA_SKIP_DIRECTORY_DEPTH_ENV_KEY:
                 config.setSkipDirectoryDepth(MantaUtils.parseIntegerOrNull(value));
+                break;
+            case MapConfigContext.MANTA_METRIC_REPORTER_MODE_KEY:
+            case EnvVarConfigContext.MANTA_METRIC_REPORTER_MODE_ENV_KEY:
+                final String metricReporterModeStr = Objects.toString(value);
+                if (StringUtils.isBlank(metricReporterModeStr)) {
+                    return;
+                }
+
+                try {
+                    config.setEncryptionAuthenticationMode(EncryptionAuthenticationMode.valueOf(metricReporterModeStr));
+                } catch (IllegalArgumentException e) {
+                    // error parsing enum value, so we just exit the function
+                    return;
+                }
+
+                break;
+            case MapConfigContext.MANTA_METRIC_REPORTER_OUTPUT_INTERVAL_KEY:
+            case EnvVarConfigContext.MANTA_METRIC_REPORTER_OUTPUT_INTERVAL_ENV_KEY:
+                config.setMetricReporterOutputInterval(MantaUtils.parseIntegerOrNull(value));
                 break;
             case MapConfigContext.MANTA_CLIENT_ENCRYPTION_ENABLED_KEY:
             case EnvVarConfigContext.MANTA_CLIENT_ENCRYPTION_ENABLED_ENV_KEY:

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/SettableConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/SettableConfigContext.java
@@ -191,7 +191,7 @@ public interface SettableConfigContext<T> extends ConfigContext {
     /**
      * Sets the method used to report metrics (or disables them entirely).
      *
-     * @param metricReporterOutputInterval metrics output interval in milliseconds for modes that report periodically
+     * @param metricReporterOutputInterval metrics output interval in seconds for modes that report metrics periodically
      * @return the current instance of {@link T}
      */
     T setMetricReporterOutputInterval(Integer metricReporterOutputInterval);

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/SettableConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/SettableConfigContext.java
@@ -51,10 +51,10 @@ public interface SettableConfigContext<T> extends ConfigContext {
 
     /**
      * Whether or not MBeans and metrics should be activated.
-     * @param agent build an agent or not
+     * @param monitoring build a monitoring agent or not
      * @return the current instance of {@link T}
      */
-    T setMonitoringEnabled(Boolean agent);
+    T setMonitoringEnabled(Boolean monitoring);
 
     /**
      * Sets the general connection timeout for the Manta service.

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/SettableConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/SettableConfigContext.java
@@ -50,6 +50,13 @@ public interface SettableConfigContext<T> extends ConfigContext {
     T setMantaKeyPath(String mantaKeyPath);
 
     /**
+     * Whether or not MBeans and metrics should be activated.
+     * @param agent build an agent or not
+     * @return the current instance of {@link T}
+     */
+    T setMonitoringEnabled(Boolean agent);
+
+    /**
      * Sets the general connection timeout for the Manta service.
      * @param timeout timeout in milliseconds
      * @return the current instance of {@link T}

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaConnectionFactory.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaConnectionFactory.java
@@ -7,11 +7,11 @@
  */
 package com.joyent.manta.http;
 
-import com.codahale.metrics.MetricRegistry;
 import com.joyent.http.signature.ThreadLocalSigner;
 import com.joyent.manta.client.MantaMBeanable;
 import com.joyent.manta.config.ConfigContext;
 import com.joyent.manta.config.DefaultsConfigContext;
+import com.joyent.manta.config.MantaClientMetricConfiguration;
 import com.joyent.manta.exception.ConfigurationException;
 import com.joyent.manta.util.MantaVersion;
 import org.apache.commons.lang3.ObjectUtils;
@@ -154,11 +154,11 @@ public class MantaConnectionFactory implements Closeable, MantaMBeanable {
      *
      * @param config                        configuration of the connection parameters
      * @param connectionFactoryConfigurator existing HttpClient objects to reuse
-     * @param metricRegistry                potentially-null registry for tracking client metrics
+     * @param metricConfig                  potentially-null configuration for tracking client metrics
      */
     public MantaConnectionFactory(final ConfigContext config,
                                   final MantaConnectionFactoryConfigurator connectionFactoryConfigurator,
-                                  final MetricRegistry metricRegistry) {
+                                  final MantaClientMetricConfiguration metricConfig) {
         this.config = Validate.notNull(config, "Configuration context must not be null");
 
         if (connectionFactoryConfigurator != null) {
@@ -169,7 +169,7 @@ public class MantaConnectionFactory implements Closeable, MantaMBeanable {
             this.httpClientBuilder = createStandardBuilder();
         }
 
-        configureHttpClientBuilderDefaults(metricRegistry);
+        configureHttpClientBuilderDefaults(metricConfig);
     }
 
     /**
@@ -318,11 +318,11 @@ public class MantaConnectionFactory implements Closeable, MantaMBeanable {
     /**
      * Apply required configuration to an HttpClientBuilder that may have been created by us or provided externally.
      *
-     * @param metricRegistry potentially-null registry for tracking client metrics
+     * @param metricConfig potentially-null configuration for tracking client metrics
      */
-    private void configureHttpClientBuilderDefaults(final MetricRegistry metricRegistry) {
+    private void configureHttpClientBuilderDefaults(final MantaClientMetricConfiguration metricConfig) {
         if (config.getRetries() > 0) {
-            httpClientBuilder.setRetryHandler(new MantaHttpRequestRetryHandler(config.getRetries(), metricRegistry));
+            httpClientBuilder.setRetryHandler(new MantaHttpRequestRetryHandler(config.getRetries(), metricConfig));
             httpClientBuilder.setServiceUnavailableRetryStrategy(new MantaServiceUnavailableRetryStrategy(config));
         } else {
             LOGGER.info("Retry of failed requests is disabled");

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaConnectionFactory.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaConnectionFactory.java
@@ -367,7 +367,7 @@ public class MantaConnectionFactory implements Closeable, MantaMBeanable {
             } else {
                 String msg = String.format(
                         "Expecting proxy to be instance of InetSocketAddress. "
-                                + " Actually: %s", proxy.address());
+                        + " Actually: %s", proxy.address());
                 throw new ConfigurationException(msg);
             }
         } else {

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaHttpRequestRetryHandler.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaHttpRequestRetryHandler.java
@@ -8,8 +8,8 @@
 package com.joyent.manta.http;
 
 import com.codahale.metrics.Meter;
-import com.codahale.metrics.MetricRegistry;
 import com.joyent.manta.config.ConfigContext;
+import com.joyent.manta.config.MantaClientMetricConfiguration;
 import org.apache.http.client.HttpRequestRetryHandler;
 import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.protocol.HttpContext;
@@ -81,14 +81,14 @@ public class MantaHttpRequestRetryHandler extends DefaultHttpRequestRetryHandler
     /**
      * Creates a new instance with the passed configuration.
      *
-     * @param retryCount     how many times to retry; 0 means no retries
-     * @param metricRegistry potentially-null registry for tracking client metrics
+     * @param retryCount   how many times to retry; 0 means no retries
+     * @param metricConfig potentially-null configuration for tracking client metrics
      */
-    public MantaHttpRequestRetryHandler(final int retryCount, final MetricRegistry metricRegistry) {
+    public MantaHttpRequestRetryHandler(final int retryCount, final MantaClientMetricConfiguration metricConfig) {
         super(retryCount, true, NON_RETRIABLE);
 
-        if (metricRegistry != null) {
-            this.retries = metricRegistry.meter("retries");
+        if (metricConfig != null && metricConfig.getRegistry() != null) {
+            this.retries = metricConfig.getRegistry().meter("retries");
         } else {
             this.retries = null;
         }

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaHttpRequestRetryHandler.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaHttpRequestRetryHandler.java
@@ -38,7 +38,7 @@ public class MantaHttpRequestRetryHandler extends DefaultHttpRequestRetryHandler
     /**
      * Logger instance.
      */
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(MantaHttpRequestRetryHandler.class);
 
     /**
      * List of all exception types that can't be retried.
@@ -53,6 +53,11 @@ public class MantaHttpRequestRetryHandler extends DefaultHttpRequestRetryHandler
      * Key for HttpContext setting indicating the request should NOT be retried under any circumstances.
      */
     public static final String CONTEXT_ATTRIBUTE_MANTA_RETRY_DISABLE = "manta.retry.disable";
+
+    /**
+     * The name used to publish the retry metrics.
+     */
+    public static final String METRIC_NAME_RETRIES = "retries";
 
     /**
      * Nullable meter for keeping track of the count and rate of retries.
@@ -88,7 +93,7 @@ public class MantaHttpRequestRetryHandler extends DefaultHttpRequestRetryHandler
         super(retryCount, true, NON_RETRIABLE);
 
         if (metricConfig != null && metricConfig.getRegistry() != null) {
-            this.retries = metricConfig.getRegistry().meter("retries");
+            this.retries = metricConfig.getRegistry().meter(METRIC_NAME_RETRIES);
         } else {
             this.retries = null;
         }

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaHttpRequestRetryHandler.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaHttpRequestRetryHandler.java
@@ -38,7 +38,7 @@ public class MantaHttpRequestRetryHandler extends DefaultHttpRequestRetryHandler
     /**
      * Logger instance.
      */
-    private static final Logger logger = LoggerFactory.getLogger(MantaHttpRequestRetryHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(MantaHttpRequestRetryHandler.class);
 
     /**
      * List of all exception types that can't be retried.

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaHttpRequestRetryHandler.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaHttpRequestRetryHandler.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.List;
 import javax.net.ssl.SSLException;
 
-import static com.codahale.metrics.MetricRegistry.name;
 import static org.apache.commons.lang3.Validate.notNull;
 
 /**
@@ -89,7 +88,7 @@ public class MantaHttpRequestRetryHandler extends DefaultHttpRequestRetryHandler
         super(retryCount, true, NON_RETRIABLE);
 
         if (metricRegistry != null) {
-            this.retries = metricRegistry.meter(name(MantaHttpRequestRetryHandler.class, "retries"));
+            this.retries = metricRegistry.meter("retries");
         } else {
             this.retries = null;
         }

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/MantaClientAgentTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/MantaClientAgentTest.java
@@ -14,16 +14,16 @@ import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
-public class MantaMBeanSupervisorTest {
+public class MantaClientAgentTest {
 
     @Test
     public void canExposeConfig() throws Exception {
-        final MantaMBeanSupervisor supervisor = new MantaMBeanSupervisor();
+        final MantaClientAgent agent = new MantaClientAgent();
         final MBeanServer beanServer = ManagementFactory.getPlatformMBeanServer();
 
-        supervisor.expose(new StandardConfigContext());
+        agent.register(new StandardConfigContext());
 
-        final Map<ObjectName, DynamicMBean> beans = supervisor.getBeans();
+        final Map<ObjectName, DynamicMBean> beans = agent.getBeans();
         Assert.assertEquals(beans.size(), 1);
 
         final List<String> propList = Arrays.asList(MapConfigContext.ALL_PROPERTIES);
@@ -35,36 +35,36 @@ public class MantaMBeanSupervisorTest {
             propList.contains(attrInfo.getName());
         }
 
-        supervisor.close();
+        agent.close();
         Assert.assertFalse(beanServer.isRegistered(configName));
     }
 
     @Test
     public void canReuseObjectNamesAfterReset() throws Exception {
-        final MantaMBeanSupervisor supervisor = new MantaMBeanSupervisor();
+        final MantaClientAgent agent = new MantaClientAgent();
         final MBeanServer beanServer = ManagementFactory.getPlatformMBeanServer();
 
-        supervisor.expose(new StandardConfigContext());
+        agent.register(new StandardConfigContext());
 
-        final Map<ObjectName, DynamicMBean> beans = supervisor.getBeans();
+        final Map<ObjectName, DynamicMBean> beans = agent.getBeans();
         Assert.assertEquals(beans.size(), 1);
 
         final ObjectName configName = extractSingleBeanName(beans);
 
         Assert.assertTrue(beanServer.isRegistered(configName));
-        supervisor.reset();
+        agent.reset();
         Assert.assertFalse(beanServer.isRegistered(configName));
 
-        supervisor.expose(new StandardConfigContext());
+        agent.register(new StandardConfigContext());
 
-        final Map<ObjectName, DynamicMBean> beansAfterReset = supervisor.getBeans();
+        final Map<ObjectName, DynamicMBean> beansAfterReset = agent.getBeans();
         Assert.assertEquals(beansAfterReset.size(), 1);
 
         final ObjectName newConfigName = extractSingleBeanName(beansAfterReset);
 
         Assert.assertEquals(configName, newConfigName);
 
-        supervisor.close();
+        agent.close();
         Assert.assertFalse(beanServer.isRegistered(configName));
     }
 

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/MetricReporterSupplierTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/MetricReporterSupplierTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2018, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.manta.client;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Slf4jReporter;
+import com.codahale.metrics.jmx.JmxReporter;
+import com.joyent.manta.config.MantaClientMetricConfiguration;
+import com.joyent.manta.config.MetricReporterMode;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.Closeable;
+import java.lang.management.ManagementFactory;
+import java.util.UUID;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import static com.joyent.manta.http.MantaHttpRequestRetryHandler.METRIC_NAME_RETRIES;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+@Test
+public class MetricReporterSupplierTest {
+    public void throwsOnNullInput() {
+        Assert.assertThrows(NullPointerException.class, () -> new MetricReporterSupplier(null));
+    }
+
+    public void createsAndStartsJmxReporter() throws MalformedObjectNameException, InterruptedException {
+        final UUID clientId = UUID.randomUUID();
+        final MetricRegistry registry = new MetricRegistry();
+        registry.meter(METRIC_NAME_RETRIES);
+
+        final MantaClientMetricConfiguration metricConfig = new MantaClientMetricConfiguration(clientId, registry, MetricReporterMode.JMX, null);
+        final Closeable jmxReporter = new MetricReporterSupplier(metricConfig).get();
+        assertTrue(jmxReporter instanceof JmxReporter);
+
+        final MBeanServer platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
+
+        assertTrue(platformMBeanServer.isRegistered(buildObjectName(clientId, METRIC_NAME_RETRIES)));
+
+        final JmxReporter reporter = (JmxReporter) jmxReporter;
+        reporter.close();
+
+        assertFalse(platformMBeanServer.isRegistered(buildObjectName(clientId, METRIC_NAME_RETRIES)));
+    }
+    public void createsAndStartsSlf4jReporter() {
+        final MantaClientMetricConfiguration metricConfig = new MantaClientMetricConfiguration(UUID.randomUUID(), new MetricRegistry(), MetricReporterMode.SLF4J, 1000);
+        final Closeable jmxReporter = new MetricReporterSupplier(metricConfig).get();
+        assertTrue(jmxReporter instanceof Slf4jReporter);
+
+        final Slf4jReporter reporter = (Slf4jReporter) jmxReporter;
+        reporter.close();
+    }
+
+    private ObjectName buildObjectName(final UUID clientId, final String beanName) throws MalformedObjectNameException {
+        return new ObjectName(String.format(MantaClientAgent.FMT_MBEAN_OBJECT_NAME, beanName, clientId));
+    }
+
+}

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/config/MantaClientMetricConfigurationTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/config/MantaClientMetricConfigurationTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.manta.config;
+
+import com.codahale.metrics.MetricRegistry;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.UUID;
+
+@Test
+public class MantaClientMetricConfigurationTest {
+    public void rejectsInvalidInputs() throws Exception {
+        Assert.assertThrows(NullPointerException.class, () ->
+            new MantaClientMetricConfiguration(null, null));
+        Assert.assertThrows(NullPointerException.class, () ->
+            new MantaClientMetricConfiguration(null, null, null, null));
+
+        Assert.assertThrows(NullPointerException.class, () ->
+            new MantaClientMetricConfiguration(UUID.randomUUID(), new MetricRegistry(), MetricReporterMode.SLF4J, null));
+
+        Assert.assertThrows(IllegalArgumentException.class, () ->
+            new MantaClientMetricConfiguration(UUID.randomUUID(), new MetricRegistry(), MetricReporterMode.SLF4J, -1));
+
+        Assert.assertThrows(IllegalArgumentException.class, () ->
+            new MantaClientMetricConfiguration(UUID.randomUUID(), new MetricRegistry(), MetricReporterMode.SLF4J, 0));
+    }
+}

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/config/TestConfigContext.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/config/TestConfigContext.java
@@ -41,8 +41,6 @@ public class TestConfigContext extends BaseChainedConfigContext {
                 .setMantaUser("username")
                 .setMantaKeyId(UnitTestConstants.FINGERPRINT)
                 .setPrivateKeyContent(UnitTestConstants.PRIVATE_KEY)
-                // most test configs don't need mbeans and metrics enabled
-                .setMonitoringEnabled(false)
         );
     }
 
@@ -57,8 +55,6 @@ public class TestConfigContext extends BaseChainedConfigContext {
     public TestConfigContext(ConfigContext context, Properties properties,
                              boolean includeEnvironmentVars) {
         super();
-        // most test configs don't need mbeans and metrics enabled
-        setMonitoringEnabled(false);
 
         // load defaults
         overwriteWithContext(DEFAULT_CONFIG);
@@ -117,9 +113,7 @@ public class TestConfigContext extends BaseChainedConfigContext {
                 .setMantaUser(mantaUser)
                 .setMantaKeyId(mantaKeyId)
                 .setTimeout(mantaTimeout)
-                .setRetries(retries)
-                // most test configs don't need mbeans and metrics enabled
-                .setMonitoringEnabled(false);
+                .setRetries(retries);
 
         if (privateKeyUrl != null) {
             testConfig.setMantaKeyPath(privateKeyUrl.getFile());

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/config/TestConfigContext.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/config/TestConfigContext.java
@@ -40,7 +40,10 @@ public class TestConfigContext extends BaseChainedConfigContext {
                 .setMantaURL("http://localhost")
                 .setMantaUser("username")
                 .setMantaKeyId(UnitTestConstants.FINGERPRINT)
-                .setPrivateKeyContent(UnitTestConstants.PRIVATE_KEY));
+                .setPrivateKeyContent(UnitTestConstants.PRIVATE_KEY)
+                // most test configs don't need mbeans and metrics enabled
+                .setMonitoringEnabled(false)
+        );
     }
 
     /**
@@ -54,6 +57,8 @@ public class TestConfigContext extends BaseChainedConfigContext {
     public TestConfigContext(ConfigContext context, Properties properties,
                              boolean includeEnvironmentVars) {
         super();
+        // most test configs don't need mbeans and metrics enabled
+        setMonitoringEnabled(false);
 
         // load defaults
         overwriteWithContext(DEFAULT_CONFIG);
@@ -112,7 +117,9 @@ public class TestConfigContext extends BaseChainedConfigContext {
                 .setMantaUser(mantaUser)
                 .setMantaKeyId(mantaKeyId)
                 .setTimeout(mantaTimeout)
-                .setRetries(retries);
+                .setRetries(retries)
+                // most test configs don't need mbeans and metrics enabled
+                .setMonitoringEnabled(false);
 
         if (privateKeyUrl != null) {
             testConfig.setMantaKeyPath(privateKeyUrl.getFile());

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/http/MantaHttpRequestRetryHandlerTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/http/MantaHttpRequestRetryHandlerTest.java
@@ -16,9 +16,7 @@ import static org.testng.Assert.assertTrue;
 @Test
 public class MantaHttpRequestRetryHandlerTest {
 
-    private final MetricFilter retryMetricFilter = (name, metric) ->
-            name.matches("^com\\.joyent\\.manta\\.http\\.MantaHttpRequestRetryHandler.*retries");
-
+    private static final MetricFilter FILTER_RETRY_METRIC = (name, metric) -> name.equals("retries");
 
     public void indicatesShouldRetryOnGenericIOException() {
         final MantaHttpRequestRetryHandler retryHandler = new MantaHttpRequestRetryHandler(1);
@@ -30,7 +28,7 @@ public class MantaHttpRequestRetryHandlerTest {
         final MetricRegistry registry = new MetricRegistry();
         final MantaHttpRequestRetryHandler retryHandler = new MantaHttpRequestRetryHandler(0, registry);
 
-        final Collection<Meter> meters = registry.getMeters(retryMetricFilter).values();
+        final Collection<Meter> meters = registry.getMeters(FILTER_RETRY_METRIC).values();
         assertEquals(meters.size(), 1);
     }
 
@@ -39,7 +37,7 @@ public class MantaHttpRequestRetryHandlerTest {
         final MetricRegistry registry = new MetricRegistry();
         final MantaHttpRequestRetryHandler retryHandler = new MantaHttpRequestRetryHandler(1, registry);
 
-        final Optional<Meter> maybeMeter = registry.getMeters(retryMetricFilter).values().stream().findFirst();
+        final Optional<Meter> maybeMeter = registry.getMeters(FILTER_RETRY_METRIC).values().stream().findFirst();
         assertTrue(maybeMeter.isPresent());
 
         assertEquals(maybeMeter.get().getCount(), 0, "meter should have zero samples");

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/http/MantaHttpRequestRetryHandlerTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/http/MantaHttpRequestRetryHandlerTest.java
@@ -3,12 +3,14 @@ package com.joyent.manta.http;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
+import com.joyent.manta.config.MantaClientMetricConfiguration;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -26,7 +28,7 @@ public class MantaHttpRequestRetryHandlerTest {
 
     public void createsRetriesMetricInRegistry() {
         final MetricRegistry registry = new MetricRegistry();
-        final MantaHttpRequestRetryHandler retryHandler = new MantaHttpRequestRetryHandler(0, registry);
+        final MantaHttpRequestRetryHandler retryHandler = new MantaHttpRequestRetryHandler(0, new MantaClientMetricConfiguration(UUID.randomUUID(), registry));
 
         final Collection<Meter> meters = registry.getMeters(FILTER_RETRY_METRIC).values();
         assertEquals(meters.size(), 1);
@@ -35,7 +37,7 @@ public class MantaHttpRequestRetryHandlerTest {
     @Test(dependsOnMethods = {"indicatesShouldRetryOnGenericIOException", "createsRetriesMetricInRegistry"})
     public void recordsRetryMetric() {
         final MetricRegistry registry = new MetricRegistry();
-        final MantaHttpRequestRetryHandler retryHandler = new MantaHttpRequestRetryHandler(1, registry);
+        final MantaHttpRequestRetryHandler retryHandler = new MantaHttpRequestRetryHandler(1, new MantaClientMetricConfiguration(UUID.randomUUID(), registry));
 
         final Optional<Meter> maybeMeter = registry.getMeters(FILTER_RETRY_METRIC).values().stream().findFirst();
         assertTrue(maybeMeter.isPresent());

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/http/MantaHttpRequestRetryHandlerTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/http/MantaHttpRequestRetryHandlerTest.java
@@ -1,0 +1,53 @@
+package com.joyent.manta.http;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+@Test
+public class MantaHttpRequestRetryHandlerTest {
+
+    private final MetricFilter retryMetricFilter = (name, metric) ->
+            name.matches("^com\\.joyent\\.manta\\.http\\.MantaHttpRequestRetryHandler.*retries");
+
+
+    public void indicatesShouldRetryOnGenericIOException() {
+        final MantaHttpRequestRetryHandler retryHandler = new MantaHttpRequestRetryHandler(1);
+
+        assertTrue(retryHandler.retryRequest(new IOException("something went wrong"), 1, new HttpClientContext()));
+    }
+
+    public void createsRetriesMetricInRegistry() {
+        final MetricRegistry registry = new MetricRegistry();
+        final MantaHttpRequestRetryHandler retryHandler = new MantaHttpRequestRetryHandler(0, registry);
+
+        final Collection<Meter> meters = registry.getMeters(retryMetricFilter).values();
+        assertEquals(meters.size(), 1);
+    }
+
+    @Test(dependsOnMethods = {"indicatesShouldRetryOnGenericIOException", "createsRetriesMetricInRegistry"})
+    public void recordsRetryMetric() {
+        final MetricRegistry registry = new MetricRegistry();
+        final MantaHttpRequestRetryHandler retryHandler = new MantaHttpRequestRetryHandler(1, registry);
+
+        final Optional<Meter> maybeMeter = registry.getMeters(retryMetricFilter).values().stream().findFirst();
+        assertTrue(maybeMeter.isPresent());
+
+        assertEquals(maybeMeter.get().getCount(), 0, "meter should have zero samples");
+
+        retryHandler.retryRequest(new IOException("something went wrong"), 1, new HttpClientContext());
+        assertEquals(maybeMeter.get().getCount(), 1, "meter should have one sample");
+
+        retryHandler.retryRequest(new IOException("something else went wrong"), 1, new HttpClientContext());
+        assertEquals(maybeMeter.get().getCount(), 2, "meter should have two samples");
+    }
+}

--- a/java-manta-it/src/test/java/com/joyent/manta/config/IntegrationTestConfigContext.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/config/IntegrationTestConfigContext.java
@@ -31,14 +31,12 @@ public class IntegrationTestConfigContext extends SystemSettingsConfigContext {
 
     private static String suiteRunId = UUID.randomUUID().toString();
 
-    private static final BaseChainedConfigContext BASE = new StandardConfigContext();
-
     /**
      * Populate configuration from defaults, environment variables, system
      * properties and an addition context passed in.
      */
     public IntegrationTestConfigContext() {
-        super(enableTestEncryption(BASE, encryptionEnabled(), encryptionCipher()));
+        super(enableTestEncryption(new StandardConfigContext(), encryptionEnabled(), encryptionCipher()));
     }
 
     /**
@@ -47,7 +45,7 @@ public class IntegrationTestConfigContext extends SystemSettingsConfigContext {
      * client-side encryption configuration settings.
      */
     public IntegrationTestConfigContext(Boolean usingEncryption) {
-        super(enableTestEncryption(BASE,
+        super(enableTestEncryption(new StandardConfigContext(),
                 (encryptionEnabled() && usingEncryption == null) ||
                         BooleanUtils.isTrue(usingEncryption), encryptionCipher()));
     }
@@ -58,7 +56,7 @@ public class IntegrationTestConfigContext extends SystemSettingsConfigContext {
      * client-side encryption configuration settings.
      */
     public IntegrationTestConfigContext(Boolean usingEncryption, String encryptionCipher) {
-        super(enableTestEncryption(BASE,
+        super(enableTestEncryption(new StandardConfigContext(),
                 (encryptionEnabled() && usingEncryption == null) ||
                         BooleanUtils.isTrue(usingEncryption), encryptionCipher));
     }

--- a/java-manta-it/src/test/java/com/joyent/manta/config/IntegrationTestConfigContext.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/config/IntegrationTestConfigContext.java
@@ -31,12 +31,14 @@ public class IntegrationTestConfigContext extends SystemSettingsConfigContext {
 
     private static String suiteRunId = UUID.randomUUID().toString();
 
+    private static final BaseChainedConfigContext BASE = new StandardConfigContext().setMonitoringEnabled(false);
+
     /**
      * Populate configuration from defaults, environment variables, system
      * properties and an addition context passed in.
      */
     public IntegrationTestConfigContext() {
-        super(enableTestEncryption(new StandardConfigContext(), encryptionEnabled(), encryptionCipher()));
+        super(enableTestEncryption(BASE, encryptionEnabled(), encryptionCipher()));
     }
 
     /**
@@ -45,7 +47,7 @@ public class IntegrationTestConfigContext extends SystemSettingsConfigContext {
      * client-side encryption configuration settings.
      */
     public IntegrationTestConfigContext(Boolean usingEncryption) {
-        super(enableTestEncryption(new StandardConfigContext(),
+        super(enableTestEncryption(BASE,
                 (encryptionEnabled() && usingEncryption == null) ||
                         BooleanUtils.isTrue(usingEncryption), encryptionCipher()));
     }
@@ -56,7 +58,7 @@ public class IntegrationTestConfigContext extends SystemSettingsConfigContext {
      * client-side encryption configuration settings.
      */
     public IntegrationTestConfigContext(Boolean usingEncryption, String encryptionCipher) {
-        super(enableTestEncryption(new StandardConfigContext(),
+        super(enableTestEncryption(BASE,
                 (encryptionEnabled() && usingEncryption == null) ||
                         BooleanUtils.isTrue(usingEncryption), encryptionCipher));
     }

--- a/java-manta-it/src/test/java/com/joyent/manta/config/IntegrationTestConfigContext.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/config/IntegrationTestConfigContext.java
@@ -31,7 +31,7 @@ public class IntegrationTestConfigContext extends SystemSettingsConfigContext {
 
     private static String suiteRunId = UUID.randomUUID().toString();
 
-    private static final BaseChainedConfigContext BASE = new StandardConfigContext().setMonitoringEnabled(false);
+    private static final BaseChainedConfigContext BASE = new StandardConfigContext();
 
     /**
      * Populate configuration from defaults, environment variables, system

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,7 @@
         <dependency.fast-md5.version>2.7.1</dependency.fast-md5.version>
         <dependency.cloning.version>1.9.6</dependency.cloning.version>
         <dependency.picocli.version>1.0.1</dependency.picocli.version>
+        <dependency.dropwizard-metrics.version>3.1.0</dependency.dropwizard-metrics.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
         <dependency.fast-md5.version>2.7.1</dependency.fast-md5.version>
         <dependency.cloning.version>1.9.6</dependency.cloning.version>
         <dependency.picocli.version>1.0.1</dependency.picocli.version>
-        <dependency.dropwizard-metrics.version>3.1.0</dependency.dropwizard-metrics.version>
+        <dependency.dropwizard-metrics.version>4.0.2</dependency.dropwizard-metrics.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Notable changes:
- the package-private `MantaMBeanSupervisor` has been renamed to `MantaClientAgent` since it's now responsible for both MBeans and the metrics reporter. Relevant tests have been updated and expanded.
- Some private or package-private constructors now accept a `MetricRegistry` for either tracking their own metrics or passing it on to child objects. Constructor overrides have been added to supply `null` for previous usages of these constructors.
  - Current examples include:
    - `MantaHttpRequestRetryHandler` for tracking retries
    - `MantaClientAgent` for publishing the registry to JMX
- `IntegrationTestConfigContext` will have monitoring disabled by default (i.e. no MBeans and no metrics). It doesn't seem useful to care about JMX or metrics for integration tests right now. **This may be wholly or partially reverted**

This satisfies the first option in #410 and provides the necessary data for the second option. (note that neither of these exclude option 3) 

Other things to keep in mind:
 - Currently, a client generates its ID and passes that on to the agent. We may want to use this ID elsewhere (perhaps as part of the User-Agent?) and keep it in `MantaClient` or make this a local variable in the constructor. Either way, we need to address the `QUESTION` comment [near its initialization](https://github.com/joyent/java-manta/compare/master...tjcelaya:fix-410?expand=1#diff-a29b3a00d80d81587eee0c833d058a61R239).
 - We may want to mention the change in JMX structure in the changelog to reference client instance ID instead of "supervisor count." A screenshot of the new structure is included below. I believe the UUID for identifying clients disambiguates the relationship between `MantaMBeanSupervisor` and `MantaClient` for maintainers.

<img width="963" alt="screen shot 2018-04-14 at 6 14 53 pm" src="https://user-images.githubusercontent.com/1973223/38774088-6a08861e-4014-11e8-8951-287ecd70032f.png">