### PR TITLE
More helpful error messages for invalid keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project aims to adhere to [Semantic Versioning](http://semver.org/).
  - [Underlying stream is not closed when we throw a `MantaClientEncryptionException`](https://github.com/joyent/java-manta/issues/391)
  - [Underlying stream is not closed by `MantaEncryptedObjectInputStream` for range requests with certain ciphers](https://github.com/joyent/java-manta/issues/398)
  - [Exceptions relating to object type expectations are too generic](https://github.com/joyent/java-manta/issues/403)
+ - Upgraded HTTP Signatures dependency from 4.0.6 to 4.0.8, jna-gmp from 2.0.0 to 2.1.0, and BouncyCastle from 1.58 to 1.59.
+ - Improved error messages for missing or invalid private keys.
 
 ## [3.2.1] - 2017-12-01
 ### Added

--- a/java-manta-it/src/test/java/com/joyent/manta/http/MantaHttpHeadersIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/http/MantaHttpHeadersIT.java
@@ -12,7 +12,6 @@ import com.joyent.manta.client.MantaObject;
 import com.joyent.manta.config.ConfigContext;
 import com.joyent.manta.config.IntegrationTestConfigContext;
 import com.joyent.manta.exception.MantaClientHttpResponseException;
-import com.joyent.manta.http.MantaHttpHeaders;
 import com.joyent.test.util.MantaAssert;
 import com.joyent.test.util.MantaFunction;
 import org.apache.commons.collections4.CollectionUtils;

--- a/java-manta-it/src/test/java/com/joyent/manta/http/MantaHttpHeadersIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/http/MantaHttpHeadersIT.java
@@ -5,8 +5,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.joyent.manta.client;
+package com.joyent.manta.http;
 
+import com.joyent.manta.client.MantaClient;
+import com.joyent.manta.client.MantaObject;
 import com.joyent.manta.config.ConfigContext;
 import com.joyent.manta.config.IntegrationTestConfigContext;
 import com.joyent.manta.exception.MantaClientHttpResponseException;
@@ -98,9 +100,11 @@ public class MantaHttpHeadersIT {
             mantaClient.put(path, TEST_DATA, headers);
         } catch (MantaClientHttpResponseException e) {
             if (e.getServerCode().equals(INVALID_ROLE_TAG_ERROR)) {
-                String msg = "You will need to add roles [manta] in "
-                        + "order for this test to work";
-                throw new SkipException(msg, e);
+                throw new SkipException(
+                        String.format(
+                                "You will need to add roles [%s] in  order for this test to work",
+                                primaryRoleName),
+                        e);
             }
 
             throw e;
@@ -133,9 +137,12 @@ public class MantaHttpHeadersIT {
             mantaClient.put(path, TEST_DATA, headers);
         } catch (MantaClientHttpResponseException e) {
             if (e.getServerCode().equals(INVALID_ROLE_TAG_ERROR)) {
-                String msg = "You will need to add roles [manta, role2] in "
-                             + "order for this test to work";
-                throw new SkipException(msg, e);
+                throw new SkipException(
+                        String.format(
+                                "You will need to add roles [%s, %s] in  order for this test to work",
+                                primaryRoleName,
+                                secondaryRoleName),
+                        e);
             }
 
             throw e;
@@ -168,9 +175,12 @@ public class MantaHttpHeadersIT {
             mantaClient.put(path, TEST_DATA, headers);
         } catch (MantaClientHttpResponseException e) {
             if (e.getServerCode().equals(INVALID_ROLE_TAG_ERROR)) {
-                String msg = "You will need to add roles [manta, role2] in "
-                        + "order for this test to work";
-                throw new SkipException(msg, e);
+                throw new SkipException(
+                        String.format(
+                                "You will need to add roles [%s, %s] in  order for this test to work",
+                                primaryRoleName,
+                                secondaryRoleName),
+                        e);
             }
         }
 
@@ -219,11 +229,12 @@ public class MantaHttpHeadersIT {
         try {
             mantaClient.put(path, TEST_DATA, headers);
         } catch (MantaClientHttpResponseException e) {
-            if (e.getServerCode().equals(INVALID_ROLE_TAG_ERROR)) {
-                String msg = "You will need to add roles [manta, role2] in "
-                        + "order for this test to work";
-                throw new SkipException(msg, e);
-            }
+                throw new SkipException(
+                        String.format(
+                                "You will need to add roles [%s, %s] in  order for this test to work",
+                                primaryRoleName,
+                                secondaryRoleName),
+                        e);
         }
 
         final Set<String> updatedRoles = new HashSet<>();

--- a/java-manta-it/src/test/resources/testng-it.xml
+++ b/java-manta-it/src/test/resources/testng-it.xml
@@ -2,13 +2,13 @@
 <suite name="Java Manta SDK Integration Test Suite" verbose="1">
 
     <listeners>
-        <listener class-name="com.joyent.test.util.MantaPathSuiteListener" />
+        <listener class-name="com.joyent.test.util.MantaPathSuiteListener"/>
     </listeners>
 
     <test name="Manta Client Integration Test Helper Class Tests">
         <classes>
-            <class name="com.joyent.test.util.FailingInputStreamTest" />
-            <class name="com.joyent.test.util.RandomInputStreamTest" />
+            <class name="com.joyent.test.util.FailingInputStreamTest"/>
+            <class name="com.joyent.test.util.RandomInputStreamTest"/>
         </classes>
     </test>
 
@@ -22,7 +22,8 @@
             <package name="com.joyent.manta.client.*">
                 <exclude name="com.joyent.manta.client.jobs"/>
             </package>
-            <package name="com.joyent.manta.client.multipart.*" />
+            <package name="com.joyent.manta.client.multipart.*"/>
+            <package name="com.joyent.manta.http.*"/>
         </packages>
     </test>
     <!-- We run many of the integration tests over again using client-side encryption -->
@@ -33,7 +34,7 @@
             <package name="com.joyent.manta.client.*">
                 <exclude name="com.joyent.manta.client.jobs"/>
             </package>
-            <package name="com.joyent.manta.client.multipart.*" />
+            <package name="com.joyent.manta.client.multipart.*"/>
         </packages>
     </test>
     <test name="Manta Client Integration Tests [AES128/GCM Encrypted]">
@@ -57,7 +58,7 @@
 
     <test name="Manta Job Tests">
         <packages>
-            <package name="com.joyent.manta.client.jobs.*" />
+            <package name="com.joyent.manta.client.jobs.*"/>
         </packages>
     </test>
 </suite>

--- a/pom.xml
+++ b/pom.xml
@@ -149,12 +149,12 @@
         <maven-error-prone-core.version>2.1.1</maven-error-prone-core.version>
 
         <!-- Dependency versions -->
-        <dependency.http-client-signature.version>4.0.6</dependency.http-client-signature.version>
+        <dependency.http-client-signature.version>4.0.8-SNAPSHOT</dependency.http-client-signature.version>
         <dependency.apache-http-client.version>4.5.3</dependency.apache-http-client.version>
-        <dependency.bouncycastle.version>1.58</dependency.bouncycastle.version>
+        <dependency.bouncycastle.version>1.59</dependency.bouncycastle.version>
         <dependency.fasterxml-uuid>3.1.4</dependency.fasterxml-uuid>
         <dependency.jackson.version>2.9.1</dependency.jackson.version>
-        <dependency.jnagmp.version>2.0.0</dependency.jnagmp.version>
+        <dependency.jnagmp.version>2.1.0</dependency.jnagmp.version>
         <dependency.urlbuilder.version>2.0.9</dependency.urlbuilder.version>
 
         <dependency.checkstyle.version>8.2</dependency.checkstyle.version>


### PR DESCRIPTION
Bump dependency versions and provide error messages tailored to the way the key was provided. We need java-http-signature 4.0.8 because of [this issue](https://github.com/joyent/java-http-signature/issues/50) which causes an unhandled `NullPointerException`. The other dependency version changes are to satisfy dependency convergence. Release notes imply there are no breaking changes between versions.

Additionally, if the key was provided directly as key content the error message would say:

```
Unable to read key files from path: null
```

Now there are different error messages, one for a failure to load the key from a path:

```
Unable to read private key files from path: ${MANTA_KEY_PATH}
```

and a separate message for those providing the content:

```
Unable to read supplied private key content
```
