### PR TITLE
Resolve regression introduced by #357

### DIFF
--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaHttpRequestFactory.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaHttpRequestFactory.java
@@ -220,8 +220,8 @@ public class MantaHttpRequestFactory {
     }
 
     /**
-     * Add headers to an {@link org.apache.http.client.methods.HttpUriRequest} without clobbering defaults
-     * and authentication.
+     * Add headers to an {@link org.apache.http.client.methods.HttpUriRequest}. Never copies the request ID header.
+     * If reusing a request ID is desired (which it should never be) it will need to be done manually.
      *
      * @param httpMessage request to attach headers to
      * @param headers headers to attach
@@ -229,7 +229,7 @@ public class MantaHttpRequestFactory {
     public static void addHeaders(final HttpMessage httpMessage, final Header... headers) {
         Validate.notNull(httpMessage, "HttpMessage must not be null");
         for (final Header header : headers) {
-            if (header.getName().equals(MantaHttpHeaders.REQUEST_ID)) {
+            if (MantaHttpHeaders.REQUEST_ID.equals(header.getName())) {
                 continue;
             }
 

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaHttpRequestFactory.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaHttpRequestFactory.java
@@ -229,6 +229,10 @@ public class MantaHttpRequestFactory {
     public static void addHeaders(final HttpMessage httpMessage, final Header... headers) {
         Validate.notNull(httpMessage, "HttpMessage must not be null");
         for (final Header header : headers) {
+            if (header.getName().equals(MantaHttpHeaders.REQUEST_ID)) {
+                continue;
+            }
+
             httpMessage.addHeader(header);
         }
     }

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/RequestIdInterceptor.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/RequestIdInterceptor.java
@@ -61,6 +61,12 @@ public class RequestIdInterceptor implements HttpRequestInterceptor {
 
     @Override
     public void process(final HttpRequest request, final HttpContext context) throws HttpException, IOException {
+        if (request.containsHeader(MantaHttpHeaders.REQUEST_ID)) {
+            // See: MANTA-3673, manta barfs on malformed x-request-id
+            // TODO: what do? throw exception, log warning/error and skip?
+            return;
+        }
+
         final UUID id = TIME_BASED_GENERATOR.generate();
         final String requestId = id.toString();
         final Header idHeader = new BasicHeader(MantaHttpHeaders.REQUEST_ID, requestId);

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/RequestIdInterceptor.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/RequestIdInterceptor.java
@@ -61,12 +61,6 @@ public class RequestIdInterceptor implements HttpRequestInterceptor {
 
     @Override
     public void process(final HttpRequest request, final HttpContext context) throws HttpException, IOException {
-        if (request.containsHeader(MantaHttpHeaders.REQUEST_ID)) {
-            // See: MANTA-3673, manta barfs on malformed x-request-id
-            // TODO: what do? throw exception, log warning/error and skip?
-            return;
-        }
-
         final UUID id = TIME_BASED_GENERATOR.generate();
         final String requestId = id.toString();
         final Header idHeader = new BasicHeader(MantaHttpHeaders.REQUEST_ID, requestId);


### PR DESCRIPTION
Fixes `MantaClientRangeIT#canGetWithUnboundedStartRange` which was failing because of MANTA-3673 (inability to cope with anything but a single well-formed UUID in the `x-request-id` header).

~# Open Questions:~
I didn't think this through enough, fixing the test failure by updating `MantaHttpRequestFactory#addHeaders` seems like a quick fix for now and avoids the unexpected WARN log that users can't do anything about.