### PR TITLE
Allow users to pass in MantaHttpHeaders with MantaClient#delete

### DIFF
--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -220,7 +220,7 @@ public class MantaClient implements AutoCloseable {
      *
      * @param config The configuration context that provides all of the configuration values
      * @param connectionFactoryConfigurator pre-configured objects for use with a MantaConnectionFactory (or null)
-     * @param httpHelper helper object for executing http requests (or null to build one ourselvers)
+     * @param httpHelper helper object for executing http requests (or null to build one ourselves)
      */
     MantaClient(final ConfigContext config,
                 final MantaConnectionFactoryConfigurator connectionFactoryConfigurator,

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -342,6 +342,7 @@ public class MantaClient implements AutoCloseable {
      * Deletes an object from Manta.
      *
      * @param rawPath The fully qualified path of the Manta object.
+     * @param requestHeaders HTTP headers to attach to request
      * @throws IOException If an IO exception has occurred.
      * @throws MantaClientHttpResponseException If a HTTP status code other than {@code 200 | 202 | 204} is encountered
      */

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -339,10 +339,10 @@ public class MantaClient implements AutoCloseable {
     }
 
     /**
-     * Deletes an object from Manta.
+     * Deletes an object from Manta, with optional headers.
      *
      * @param rawPath The fully qualified path of the Manta object.
-     * @param requestHeaders HTTP headers to attach to request
+     * @param requestHeaders HTTP headers to attach to request (may be null)
      * @throws IOException If an IO exception has occurred.
      * @throws MantaClientHttpResponseException If a HTTP status code other than {@code 200 | 202 | 204} is encountered
      */

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -196,7 +196,7 @@ public class MantaClient implements AutoCloseable {
      *
      * Users opting into advanced configuration (i.e. not passing {@code null} as the second parameter)
      * should be comfortable with the internals of {@link CloseableHttpClient} and accept that we can only make a
-     * best effort to support all possible use-cases. For example, uses may pass in a builder which is wired to a
+     * best effort to support all possible use-cases. For example, users may pass in a builder which is wired to a
      * {@link org.apache.http.impl.conn.BasicHttpClientConnectionManager} and effectively make the client
      * single-threaded by eliminating the connection pool. Bug or feature? You decide!
      *
@@ -214,7 +214,7 @@ public class MantaClient implements AutoCloseable {
      *
      * Users opting into advanced configuration (i.e. not passing {@code null} as the second parameter)
      * should be comfortable with the internals of {@link CloseableHttpClient} and accept that we can only make a
-     * best effort to support all possible use-cases. For example, uses may pass in a builder which is wired to a
+     * best effort to support all possible use-cases. For example, users may pass in a builder which is wired to a
      * {@link org.apache.http.impl.conn.BasicHttpClientConnectionManager} and effectively make the client
      * single-threaded by eliminating the connection pool. Bug or feature? You decide!
      *

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/exception/MantaClientHttpResponseException.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/exception/MantaClientHttpResponseException.java
@@ -204,7 +204,7 @@ public class MantaClientHttpResponseException extends MantaIOException {
                                                                 final String path,
                                                                 final Integer... expectedResponseCodes) {
         if (expectedResponseCodes != null) {
-            return String.format("HTTP request returned unexpected response code: expected one of [%s], got[%d] ",
+            return String.format("HTTP request returned unexpected response code: expected one of %s, got [%d] ",
                                  Arrays.toString(expectedResponseCodes),
                                  response.getStatusLine().getStatusCode());
         }

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/exception/MantaClientHttpResponseException.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/exception/MantaClientHttpResponseException.java
@@ -127,7 +127,7 @@ public class MantaClientHttpResponseException extends MantaIOException {
     public MantaClientHttpResponseException(final HttpRequest request,
                                             final HttpResponse response,
                                             final String path) {
-        this(request, response, path, (Integer[]) null);
+        this(request, response, path, (int[]) null);
     }
 
     /**
@@ -137,11 +137,12 @@ public class MantaClientHttpResponseException extends MantaIOException {
      * @param request HTTP request object
      * @param response HTTP response object
      * @param path The fully qualified path of the object. i.e. /user/stor/foo/bar/baz
+     * @param expectedResponseCodes list of allowed response codes when the exception is response-code-related
      */
     public MantaClientHttpResponseException(final HttpRequest request,
                                             final HttpResponse response,
                                             final String path,
-                                            final Integer... expectedResponseCodes) {
+                                            final int... expectedResponseCodes) {
         super(buildExceptionMessageFromHttpExchange(request, response, path, expectedResponseCodes));
         final HttpEntity entity = response.getEntity();
         final ContentType jsonContentType = ContentType.APPLICATION_JSON;
@@ -199,10 +200,19 @@ public class MantaClientHttpResponseException extends MantaIOException {
         }
     }
 
+    /**
+     * Build an exception message tailored to the arguments passed to the most complex constructor.
+     *
+     * @param request HTTP request object
+     * @param response HTTP response object
+     * @param path The fully qualified path of the object. i.e. /user/stor/foo/bar/baz
+     * @param expectedResponseCodes list of allowed response codes
+     * @return a relevant error message
+     */
     private static String buildExceptionMessageFromHttpExchange(final HttpRequest request,
                                                                 final HttpResponse response,
                                                                 final String path,
-                                                                final Integer... expectedResponseCodes) {
+                                                                final int... expectedResponseCodes) {
         if (expectedResponseCodes != null) {
             return String.format("HTTP request returned unexpected response code: expected one of %s, got [%d] ",
                                  Arrays.toString(expectedResponseCodes),

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/HttpHelper.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/HttpHelper.java
@@ -71,6 +71,7 @@ public interface HttpHelper extends AutoCloseable, HttpConnectionAware {
      * Executes a HTTP DELETE against the remote Manta API with provided headers.
      *
      * @param path The fully qualified path of the object. i.e. /user/stor/foo/bar/baz
+     * @param headers HTTP headers to attach to request
      * @return Apache HTTP Client response object
      * @throws IOException when there is a problem getting the object over the network
      */

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/HttpHelper.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/HttpHelper.java
@@ -68,6 +68,16 @@ public interface HttpHelper extends AutoCloseable, HttpConnectionAware {
     HttpResponse httpDelete(String path) throws IOException;
 
     /**
+     * Executes a HTTP DELETE against the remote Manta API with provided headers.
+     *
+     * @param path The fully qualified path of the object. i.e. /user/stor/foo/bar/baz
+     * @return Apache HTTP Client response object
+     * @throws IOException when there is a problem getting the object over the network
+     */
+    HttpResponse httpDelete(String path,
+                            MantaHttpHeaders headers) throws IOException;
+
+    /**
      * Utility method for handling HTTP POST to the Apache HTTP Client.
      *
      * @param path path to post to (without hostname)

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/StandardHttpHelper.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/StandardHttpHelper.java
@@ -52,6 +52,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
+import static org.apache.http.HttpStatus.SC_ACCEPTED;
+import static org.apache.http.HttpStatus.SC_NO_CONTENT;
+import static org.apache.http.HttpStatus.SC_OK;
+
 /**
  * Helper class used for common HTTP operations against the Manta server.
  *
@@ -162,13 +166,39 @@ public class StandardHttpHelper implements HttpHelper {
 
     @Override
     public HttpResponse httpDelete(final String path) throws IOException {
+        return this.httpDelete(path, null);
+    }
+
+    @Override
+    public HttpResponse httpDelete(final String path,
+                                   final MantaHttpHeaders headers) throws IOException {
         Validate.notNull(path, "Path must not be null");
 
         LOGGER.debug("DELETE {}", path);
 
         final HttpDelete delete = requestFactory.delete(path);
-        return executeAndCloseRequest(delete, "DELETE {} response [{}] {} ");
+        if (headers != null) {
+            MantaHttpRequestFactory.addHeaders(delete, headers.asApacheHttpHeaders());
+        }
+
+        final CloseableHttpResponse response = executeAndCloseRequest(delete, "DELETE {} response [{}] {} ");
+        final int code = response.getStatusLine().getStatusCode();
+
+        // any of the following are valid response codes for DELETE
+        // though manta currently only returns SC_NO_CONTENT (204)
+        // general error response codes (>=400) like SC_PRECONDITION_FAILED are validated by executeAndCloseRequest
+        if (code != SC_OK
+                && code != SC_ACCEPTED
+                && code != SC_NO_CONTENT) {
+            throw new MantaClientHttpResponseException(delete,
+                                                       response,
+                                                       path,
+                                                       SC_OK, SC_ACCEPTED, SC_NO_CONTENT);
+        }
+
+        return response;
     }
+
 
     @Override
     public HttpResponse httpPost(final String path) throws IOException {

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/MantaClientTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/MantaClientTest.java
@@ -1,6 +1,8 @@
 package com.joyent.manta.client;
 
 import com.joyent.manta.config.TestConfigContext;
+import com.joyent.manta.http.HttpHelper;
+import com.joyent.manta.http.MantaHttpHeaders;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.Test;
@@ -9,12 +11,14 @@ import java.io.IOException;
 import java.util.stream.Stream;
 
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@Test
 public class MantaClientTest {
 
     @AfterTest
@@ -22,7 +26,6 @@ public class MantaClientTest {
         Mockito.validateMockitoUsage();
     }
 
-    @Test
     public void listObjectsDoesNotLeakConnectionsWhenThereAreResults() throws IOException {
         // BasicHttpClientConnectionManager maintains a single connection
 
@@ -39,7 +42,6 @@ public class MantaClientTest {
         verify(iteratorMock).close();
     }
 
-    @Test
     public void listObjectsDoesNotLeakConnectionsWhenNoResults() throws IOException {
         // BasicHttpClientConnectionManager maintains a single connection
 
@@ -54,5 +56,17 @@ public class MantaClientTest {
         listing.close();
 
         verify(iteratorMock).close();
+    }
+
+    public void deleteWithHeadersPassesAlongHeaders() throws IOException {
+        final HttpHelper helper = mock(HttpHelper.class);
+        final MantaClient client = new MantaClient(new TestConfigContext(), null, helper);
+        final MantaHttpHeaders hdrs = new MantaHttpHeaders();
+        final String etag = "magic";
+        hdrs.setIfMatch(etag);
+
+        client.delete("/test/stor/foo", hdrs);
+
+        verify(helper).httpDelete(anyString(), argThat(h -> etag.equals(h.getIfMatch())));
     }
 }

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/http/StandardHttpHelperTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/http/StandardHttpHelperTest.java
@@ -258,7 +258,6 @@ public class StandardHttpHelperTest {
         when(statusLine.getStatusCode())
                 .thenReturn(SC_NO_CONTENT);
 
-
         final StandardHttpHelper helper = new StandardHttpHelper(connCtx, config);
         final MantaHttpHeaders ifMatchHeader = new MantaHttpHeaders();
         final String etag = "foo";

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/http/StandardHttpHelperTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/http/StandardHttpHelperTest.java
@@ -8,12 +8,14 @@ import com.joyent.manta.exception.MantaClientHttpResponseException;
 import com.joyent.manta.exception.MantaUnexpectedObjectTypeException;
 import com.joyent.manta.http.entity.NoContentEntity;
 import com.twmacinta.util.FastMD5Digest;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.NullInputStream;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.*;
+import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPut;
@@ -24,21 +26,26 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicHeader;
 import org.bouncycastle.crypto.Digest;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 import static com.joyent.manta.client.MantaObjectResponse.DIRECTORY_RESPONSE_CONTENT_TYPE;
+import static org.apache.http.HttpHeaders.IF_MATCH;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@Test
 public class StandardHttpHelperTest {
 
     @Mock
@@ -70,7 +77,11 @@ public class StandardHttpHelperTest {
                 .thenReturn(new Header[]{});
     }
 
-    @Test
+    @AfterMethod
+    public void teardown() throws Exception {
+        Mockito.validateMockitoUsage();
+    }
+
     public void testHttpPutValidatesResponseCodeSuccessfully() throws Exception {
         when(statusLine.getStatusCode())
                 .thenReturn(HttpStatus.SC_NO_CONTENT);
@@ -87,7 +98,6 @@ public class StandardHttpHelperTest {
         Assert.assertNotNull(put);
     }
 
-    @Test
     public void testHttpPutValidatesResponseCodeAndThrowsWhenInvalid() throws Exception {
         when(statusLine.getStatusCode())
                 .thenReturn(HttpStatus.SC_OK);
@@ -101,7 +111,6 @@ public class StandardHttpHelperTest {
                 helper.httpPut("/path", null, NoContentEntity.INSTANCE, null));
     }
 
-    @Test
     public void testHttpPutChecksumsSuccessfully() throws Exception {
         when(statusLine.getStatusCode())
                 .thenReturn(HttpStatus.SC_NO_CONTENT);
@@ -142,7 +151,6 @@ public class StandardHttpHelperTest {
         Assert.assertNotNull(put);
     }
 
-    @Test
     public void testHttpPutChecksumsCompareDifferentlyFails() throws Exception {
         when(statusLine.getStatusCode())
                 .thenReturn(HttpStatus.SC_NO_CONTENT);
@@ -177,7 +185,6 @@ public class StandardHttpHelperTest {
                 helper.httpPut("/path", null, new ByteArrayEntity(contentBytes), null));
     }
 
-    @Test
     public void testHttpPutThrowsWhenChecksumRequestedButNotReturned() throws Exception {
         when(statusLine.getStatusCode())
                 .thenReturn(HttpStatus.SC_NO_CONTENT);
@@ -194,7 +201,6 @@ public class StandardHttpHelperTest {
                 helper.httpPut("/path", null, NoContentEntity.INSTANCE, null));
     }
 
-    @Test
     public void throwsAppropriateExceptionWhenStreamingObjectThatIsDir() {
         final String path = "/user/stor/a-dir";
         final StandardHttpHelper helper = new StandardHttpHelper(connCtx, config);
@@ -220,5 +226,16 @@ public class StandardHttpHelperTest {
 
         Assert.assertThrows(MantaUnexpectedObjectTypeException.class, () ->
                 helper.httpRequestAsInputStream(get, headers));
+    }
+
+    public void deleteWithHeadersPassesAlongHeaders() throws Exception {
+        final StandardHttpHelper helper = new StandardHttpHelper(connCtx, config);
+        final MantaHttpHeaders ifMatchHeader = new MantaHttpHeaders();
+        final String etag = "foo";
+        ifMatchHeader.setIfMatch(etag);
+
+        helper.httpDelete("/path", ifMatchHeader);
+
+        verify(client).execute(argThat(r -> etag.equals(r.getFirstHeader(IF_MATCH).getValue())));
     }
 }


### PR DESCRIPTION
API changes:
 - package-private constructor for `MantaClient` to allow passing an `HttpHelper` directly
 - method `MantaClient#delete(String, MantaHttpHeaders)` added
 - method `HttpHelper#httpDelete(String, MantaHttpHeaders)` added
 - public constructor for `MantaClientHttpResponseException(HttpRequest, HttpResponse, String, Integer...)` added (in case the response is <400 and not one of the valid DELETE response codes: 200/202/204)

Unit tests were added for:
- `MantaClient#delete` → `HttpHelper#httpDelete`, verifying the `If-Match` header passed in is seen by the helper
- `HttpHelper` → `HttpClient`, verifying the request seen by the `HttpClient` contains the expected header value

Integration test added:
 - create an empty file
 - grab its ETag
 - attempt to delete with an invalid ETag (string reverse of ETag, the behavior of `If-Match: ""` seems to be undefined)
   - make sure we get the expected exception (412 Precondition Failed response code)
   - make sure the object still exists
- delete with correct ETag in `If-Match` header
   - make sure the object no longer exists

Bystanders:
 - minor `@Test` annotation cleanup
 - extracted common path generation code in one of the unit tests into the `generatePath` helper. might belong in a more general class but left in its own test class for now