### PR TITLE
Improve AutoContinuingInputStream failure case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project aims to adhere to [Semantic Versioning](http://semver.org/).
 ## [3.2.3-SNAPSHOT] - Coming soon!
 ### Fixed
  - [UnsupportedOperationException when getting a 0 byte file using `MantaClient.getAsInputStream`](https://github.com/joyent/java-manta/issues/408)
+ - [AutoContinuingInputStream fails to handle fatal exceptions correctly and triggers a self-suppression error.](https://github.com/joyent/java-manta/pull/429)
 
 ### Added
  - Client metrics can now be enabled by selecting a reporting mode with the
@@ -16,6 +17,9 @@ This project aims to adhere to [Semantic Versioning](http://semver.org/).
     - [Timers](http://metrics.dropwizard.io/4.0.0/manual/core.html#timer) per HTTP request method.
     - [Meters](http://metrics.dropwizard.io/4.0.0/manual/core.html#meter) per exception that occurs during requests.
  - [`MantaClient#delete(String, MantaHttpHeaders)`](https://github.com/joyent/java-manta/issues/427)
+ - [Download auto-resume](https://github.com/joyent/java-manta/issues/411) has been added in the form of
+    [`manta.download_continuations`/`MANTA_DOWNLOAD_CONTINUATIONS` configuration
+    setting](https://github.com/joyent/java-manta/blob/master/USAGE.md#download-continuation).
 
 ### Changed
  - MBeans registered in JMX no longer use an incrementing integer and instead are created under

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -221,7 +221,28 @@ public class MantaClient implements AutoCloseable {
      *
      * @param config The configuration context that provides all of the configuration values
      * @param connectionFactoryConfigurator pre-configured objects for use with a MantaConnectionFactory (or null)
+     * @param metricConfiguration the metrics registry and configuration, or null to prepare one from the general config
+     */
+    public MantaClient(final ConfigContext config,
+                       final MantaConnectionFactoryConfigurator connectionFactoryConfigurator,
+                       final MantaClientMetricConfiguration metricConfiguration) {
+        this(config, connectionFactoryConfigurator, null, metricConfiguration);
+    }
+
+    /**
+     * Creates a new instance of the Manta client based on user-provided connection objects. This allows for a higher
+     * degree of customization at the cost of more involvement from the consumer.
+     *
+     * Users opting into advanced configuration (i.e. not passing {@code null} as the second parameter)
+     * should be comfortable with the internals of {@link CloseableHttpClient} and accept that we can only make a
+     * best effort to support all possible use-cases. For example, users may pass in a builder which is wired to a
+     * {@link org.apache.http.impl.conn.BasicHttpClientConnectionManager} and effectively make the client
+     * single-threaded by eliminating the connection pool. Bug or feature? You decide!
+     *
+     * @param config The configuration context that provides all of the configuration values
+     * @param connectionFactoryConfigurator pre-configured objects for use with a MantaConnectionFactory (or null)
      * @param httpHelper helper object for executing http requests (or null to build one ourselves)
+     * @param metricConfiguration the metrics registry and configuration, or null to prepare one from the general config
      */
     MantaClient(final ConfigContext config,
                 final MantaConnectionFactoryConfigurator connectionFactoryConfigurator,

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/ApacheHttpGetResponseEntityContentContinuator.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/ApacheHttpGetResponseEntityContentContinuator.java
@@ -238,7 +238,7 @@ public class ApacheHttpGetResponseEntityContentContinuator implements InputStrea
                           + "to recover at byte offset {} "
                           + "from exception {}",
                   this.request.getMethod(),
-                  this.request.getRequestLine(),
+                  this.request.getRequestLine().getUri(),
                   bytesRead,
                   ex.getMessage());
 

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/ApacheHttpGetResponseEntityContentContinuator.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/ApacheHttpGetResponseEntityContentContinuator.java
@@ -232,10 +232,15 @@ public class ApacheHttpGetResponseEntityContentContinuator implements InputStrea
                     ex);
         }
 
-        LOG.debug("Attempting to build a continuation for request {} to recover at byte offset {} from exception {}",
+        LOG.debug("Attempting to build a continuation for "
+                          + "[{}] request "
+                          + "to path [{}] "
+                          + "to recover at byte offset {} "
+                          + "from exception {}",
+                  this.request.getMethod(),
                   this.request.getRequestLine(),
                   bytesRead,
-                  ex);
+                  ex.getMessage());
 
         // if an IOException occurs while reading EOF the user may ask us for a continuation
         // starting after the last valid byte.

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/ApacheHttpGetResponseEntityContentContinuator.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/ApacheHttpGetResponseEntityContentContinuator.java
@@ -218,6 +218,8 @@ public class ApacheHttpGetResponseEntityContentContinuator implements InputStrea
      */
     @Override
     public InputStream buildContinuation(final IOException ex, final long bytesRead) throws IOException {
+        requireNonNull(ex);
+
         if (!isRecoverable(ex)) {
             throw ex;
         }

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/util/AutoContinuingInputStream.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/util/AutoContinuingInputStream.java
@@ -57,12 +57,17 @@ public class AutoContinuingInputStream extends ContinuingInputStream {
      * continuing
      */
     private void attemptRecovery(final IOException originalIOException) throws IOException {
-        final InputStream continuation;
         try {
-            continuation = this.continuator.buildContinuation(originalIOException, this.getBytesRead());
-            super.continueWith(continuation);
+            super.continueWith(this.continuator.buildContinuation(originalIOException, this.getBytesRead()));
         } catch (final IOException ioe) {
             LOG.debug("Failed to automatically recover: {}", ioe.getMessage());
+
+            // if a different exception was thrown while recovering, add it as a suppressed exception
+            if (originalIOException != ioe) {
+                originalIOException.addSuppressed(ioe);
+            }
+
+            // rethrow the original exception
             throw originalIOException;
         }
     }

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/util/AutoContinuingInputStream.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/util/AutoContinuingInputStream.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 
 import static java.util.Objects.requireNonNull;
 
@@ -59,7 +60,7 @@ public class AutoContinuingInputStream extends ContinuingInputStream {
     private void attemptRecovery(final IOException originalIOException) throws IOException {
         try {
             super.continueWith(this.continuator.buildContinuation(originalIOException, this.getBytesRead()));
-        } catch (final IOException ioe) {
+        } catch (final UncheckedIOException | IOException ioe) {
             LOG.debug("Failed to automatically recover: {}", ioe.getMessage());
 
             // if a different exception was thrown while recovering, add it as a suppressed exception

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/util/AutoContinuingInputStream.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/util/AutoContinuingInputStream.java
@@ -143,8 +143,10 @@ public class AutoContinuingInputStream extends ContinuingInputStream {
 
         final InputStream wrapped = this.getWrapped();
 
-        if (wrapped != null) {
-            wrapped.close();
+        if (wrapped == null) {
+            return;
         }
+
+        wrapped.close();
     }
 }

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/util/AutoContinuingInputStreamTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/util/AutoContinuingInputStreamTest.java
@@ -1,0 +1,66 @@
+package com.joyent.manta.util;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.ClosedInputStream;
+import org.apache.commons.io.input.ProxyInputStream;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.expectThrows;
+
+@Test
+public class AutoContinuingInputStreamTest {
+
+    /**
+     * We can't use {@link org.apache.commons.io.input.BrokenInputStream} for this test because it will return the same
+     * exception during close and trigger the
+     * <a href="https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html#suppressed-exceptions">self-suppression
+     * issue</a>.
+     * <p>
+     * On the other hand, we can't use {@link FailingInputStream} because that generates its own exceptions, so we
+     * wouldn't be able to use {@link org.testng.Assert#assertSame} and check that no suppressed exceptions were added.
+     */
+    private static final class ReadExceptionInputStream extends ProxyInputStream {
+
+        private final IOException exception;
+
+        public ReadExceptionInputStream(final IOException exception) {
+            super(ClosedInputStream.CLOSED_INPUT_STREAM);
+            this.exception = exception;
+        }
+
+        @Override
+        protected void beforeRead(final int n) throws IOException {
+            throw this.exception;
+        }
+    }
+
+    public void rethrowsUnrecoverableExceptionsDirectly() throws Exception {
+        // the exception to consider fatal
+        final IOException ex = new IOException("oops");
+
+        // source stream always throws that exception
+        final InputStream original = new ReadExceptionInputStream(ex);
+
+        // pretend that it was a fatal exception and should be rethrown
+        final InputStreamContinuator continuator = mock(InputStreamContinuator.class);
+        when(continuator.buildContinuation(same(ex), anyLong())).thenThrow(ex);
+
+        final IOException caught = expectThrows(IOException.class, () -> {
+            try (final AutoContinuingInputStream in = new AutoContinuingInputStream(original, continuator)) {
+                IOUtils.toByteArray(in);
+            }
+        });
+
+        assertSame(caught, ex);
+        assertEquals(caught.getSuppressed().length, 0);
+    }
+}

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/util/ContinuingInputStreamTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/util/ContinuingInputStreamTest.java
@@ -368,8 +368,6 @@ public class ContinuingInputStreamTest {
         final ContinuingInputStream cis = new ContinuingInputStream(new BrokenInputStream());
 
         assertThrows(IOException.class, () -> cis.available());
-
-        assertThrows(IllegalStateException.class,  () -> cis.read());
     }
 
     public void testSkipCompletelySingleOperation() throws IOException {
@@ -432,8 +430,6 @@ public class ContinuingInputStreamTest {
 
         assertThrows(IOException.class, () -> cis.skip(1));
         assertEquals(cis.getBytesRead(), 0);
-
-        assertThrows(IllegalStateException.class, () -> cis.skip(1));
 
         cis.continueWith(new ByteArrayInputStream(STUB_OBJECT_BYTES));
 

--- a/java-manta-it/src/test/java/com/joyent/manta/http/ApacheHttpGetResponseEntityContentContinuatorIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/http/ApacheHttpGetResponseEntityContentContinuatorIT.java
@@ -1,8 +1,9 @@
-package com.joyent.manta.client;
+package com.joyent.manta.http;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
+import com.joyent.manta.client.MantaClient;
 import com.joyent.manta.client.crypto.AesCtrCipherDetails;
 import com.joyent.manta.client.crypto.SecretKeyUtils;
 import com.joyent.manta.client.crypto.SupportedCipherDetails;
@@ -13,8 +14,6 @@ import com.joyent.manta.config.EncryptionAuthenticationMode;
 import com.joyent.manta.config.IntegrationTestConfigContext;
 import com.joyent.manta.config.MantaClientMetricConfiguration;
 import com.joyent.manta.config.MetricReporterMode;
-import com.joyent.manta.http.HttpRange;
-import com.joyent.manta.http.MantaHttpHeaders;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -392,7 +391,6 @@ public class ApacheHttpGetResponseEntityContentContinuatorIT {
         }
 
         final MantaClient mantaClient = new MantaClient(config,
-                                                        null,
                                                         null,
                                                         metricConfig);
 


### PR DESCRIPTION
Currently if an unrecoverable exception happens while using try-with-resources in combination with auto-resume the following will occur:

- `AutoContinuingInputStream` will catch it and invoke `attemptRecovery` to ask its continuator for a continuation
- the continuator will rethrow the exception because it is considered fatal
- immediately `ContinuingInputStream` will call `this.discardWrapped()` which closes the wrapped stream and sets `this.wrapped` to `null`
- the catch in `attemptRecovery` will attempt to add the newly caught exception as a suppressed exception of the original (thinking it was related to recovery)
- try-with-resources sees the original exception and calls close on the outer stream which triggers an NPE when `AutoContinuingInputStream` calls `this.getWrapped().close()` (because the superclass already discarded the wrapped stream so there is nothing to close) so that NPE is attached to the original exception as a suppressed exception

This is all much more complicated than it needs to be and is the result of over-eager behavior on the part of `ContinuingInputStream` and a missing null check in `AutoContinuingInputStream#close`. The resulting exception looks like this:

```
java.lang.IllegalArgumentException: Self-suppression not permitted
	at java.lang.Throwable.addSuppressed(Throwable.java:1043)
	at com.joyent.manta.util.AutoContinuingInputStream.attemptRecovery(AutoContinuingInputStream.java:59)
	at com.joyent.manta.util.AutoContinuingInputStream.read(AutoContinuingInputStream.java:81)
	at com.joyent.manta.client.MantaObjectInputStream.read(MantaObjectInputStream.java:175)
	...
	at org.apache.commons.io.IOUtils.toByteArray(IOUtils.java:721)
	at com.joyent.manta.client.ApacheHttpGetResponseEntityContentContinuatorIT.regularObjectDownloadUnencrypted(ApacheHttpGetResponseEntityContentContinuatorIT.java:244)
	Suppressed: java.lang.NullPointerException
		at com.joyent.manta.util.AutoContinuingInputStream.close(AutoContinuingInputStream.java:138)
		at com.joyent.manta.org.apache.commons.io.IOUtils.closeQuietly(IOUtils.java:339)
		at com.joyent.manta.org.apache.commons.io.IOUtils.closeQuietly(IOUtils.java:270)
		at com.joyent.manta.client.MantaObjectInputStream.close(MantaObjectInputStream.java:190)
		at com.joyent.manta.client.ApacheHttpGetResponseEntityContentContinuatorIT.$closeResource(ApacheHttpGetResponseEntityContentContinuatorIT.java:231)
		at com.joyent.manta.client.ApacheHttpGetResponseEntityContentContinuatorIT.regularObjectDownloadUnencrypted(ApacheHttpGetResponseEntityContentContinuatorIT.java:245)
		... 30 more
Caused by: javax.net.ssl.SSLException: SSL peer shut down incorrectly
	at sun.security.ssl.InputRecord.readV3Record(InputRecord.java:596)
	...
	at com.joyent.manta.org.apache.http.conn.EofSensorInputStream.read(EofSensorInputStream.java:148)
	at com.joyent.manta.util.ContinuingInputStream.read(ContinuingInputStream.java:146)
	at com.joyent.manta.util.AutoContinuingInputStream.read(AutoContinuingInputStream.java:79)
	... 37 more
```

Instead, we'd rather just throw `javax.net.ssl.SSLException: SSL peer shut down incorrectly` and call it a day. This PR fixes that situation and adds a test for verifying that an exception rethrown by `InputStreamContinuator#buildContinuation` is rethrown as-is.

This PR also makes `ContinuingInputStream` easier to use by removing the automatic calls to             `discardWrapped()` on any exception so some redundant `try` statements have also been removed.