### PR TITLE
Improve testing and documentation for delete prune operations

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -171,7 +171,7 @@ Note: Dynamic Updates marked with an asterisk (*) are enabled by the `AuthAwareC
     operation (i.e. `/$MANTA_USER` and `/$MANTA_USER/stor` would not be counted). A detailed explanation and example are provided [later in this document](/USAGE.md#skipping-directories)
 * `manta.prune_empty_parent_depth` (**MANTA_PRUNE_EMPTY_PARENT_DEPTH**)
     Integer indicating the maximum number of empty parent directories to prune. If the client is given the value of -1 then the client will try and delete
-    all empty parent directories. see [the section on parent directory pruning later in this document](/USAGE.md#Pruning empty parent directories) 
+    all empty parent directories. see [the section on parent directory pruning later in this document](/USAGE.md#pruning-empty-parent-directories) 
 * `manta.download_continuations` (**MANTA_DOWNLOAD_CONTINUATIONS**)
     Nullable Integer property for enabling the [download continuation](#download-continuation) "optimization."
     A value of 0 explicitly disabled this feature, a value of `-1` enables unlimited continuations, a positive value

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -104,6 +104,7 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static com.joyent.manta.config.DefaultsConfigContext.DEFAULT_PRUNE_DEPTH;
 import static com.joyent.manta.util.MantaUtils.formatPath;
 
 /**
@@ -395,7 +396,7 @@ public class MantaClient implements AutoCloseable {
             throws IOException {
         Validate.notBlank(rawPath, "rawPath must not be blank");
         String path = formatPath(rawPath);
-        if (pruneDepth == null || pruneDepth == 0) {
+        if (pruneDepth == null || pruneDepth == DEFAULT_PRUNE_DEPTH) {
             LOG.debug("DELETE {}", path);
             httpHelper.httpDelete(path, requestHeaders);
         } else {

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -399,7 +399,7 @@ public class MantaClient implements AutoCloseable {
             LOG.debug("DELETE {}", path);
             httpHelper.httpDelete(path, requestHeaders);
         } else {
-            PruneEmpytParentDirectoryStrategy.pruneParentDirectories(this, requestHeaders, path, pruneDepth);
+            PruneEmptyParentDirectoryStrategy.pruneParentDirectories(this, requestHeaders, path, pruneDepth);
         }
    }
 

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/PruneEmptyParentDirectoryStrategy.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/PruneEmptyParentDirectoryStrategy.java
@@ -49,6 +49,10 @@ final class PruneEmptyParentDirectoryStrategy {
             final String path,
             final int limit) throws IOException {
         // First thing first, delete the child directory.
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Pruning first directory: {}", path);
+        }
         client.delete(path, headers, null);
 
         // Generating all parent paths.
@@ -63,7 +67,10 @@ final class PruneEmptyParentDirectoryStrategy {
         }
         for (int i = 0; i < actualLimit; i++) {
             try {
-                LOG.debug("************ Deleting Index : " + i + " name " + directories[i]);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Pruning directory[{}] at path: {}", i, directories[i]);
+                }
+
                 client.delete(directories[i], headers, null);
             } catch (MantaClientHttpResponseException responseException) {
                 if (responseException.getServerCode().equals(MantaErrorCode.RESOURCE_NOT_FOUND_ERROR)) {

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/PruneEmptyParentDirectoryStrategy.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/PruneEmptyParentDirectoryStrategy.java
@@ -19,21 +19,21 @@ import com.joyent.manta.http.MantaHttpHeaders;
 import com.joyent.manta.util.MantaUtils;
 
 /**
- * Utility class for recursive directory creation strategies.
+ * Utility class for recursive directory removal strategies.
  *
  * @author <a href="https://github.com/douglasAtJoyent">Douglas Anderson</a>
  * @since 3.2.4
  */
-final class PruneEmpytParentDirectoryStrategy {
+final class PruneEmptyParentDirectoryStrategy {
 
-    private static final Logger LOG = LoggerFactory.getLogger(PruneEmpytParentDirectoryStrategy.class);
+    private static final Logger LOG = LoggerFactory.getLogger(PruneEmptyParentDirectoryStrategy.class);
 
     /**
      * Pass this if you want to prune all parent directories.
      */
     public static final Integer PRUNE_ALL_PARENTS = -1;
 
-    private PruneEmpytParentDirectoryStrategy() {
+    private PruneEmptyParentDirectoryStrategy() {
     }
 
     /**

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/DefaultsConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/DefaultsConfigContext.java
@@ -92,6 +92,12 @@ public class DefaultsConfigContext implements ConfigContext {
     public static final boolean DEFAULT_DISABLE_NATIVE_SIGNATURES = false;
 
     /**
+     * The default depth of directories to prune to when prune depth
+     * is set to null.
+     */
+    public static final int DEFAULT_PRUNE_DEPTH = 0;
+
+    /**
      * Default number of milliseconds to wait for a TCP socket's connection to
      * timeout.
      */

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/PruneEmptyParentDirectoryStrategyTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/PruneEmptyParentDirectoryStrategyTest.java
@@ -1,0 +1,146 @@
+package com.joyent.manta.client;
+
+import com.joyent.manta.config.DefaultsConfigContext;
+import com.joyent.manta.config.TestConfigContext;
+import com.joyent.manta.http.MantaHttpHeaders;
+import org.apache.commons.lang3.ObjectUtils;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static com.joyent.manta.client.PruneEmptyParentDirectoryStrategy.PRUNE_ALL_PARENTS;
+import static com.joyent.manta.client.PruneEmptyParentDirectoryStrategy.pruneParentDirectories;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+@Test
+public class PruneEmptyParentDirectoryStrategyTest {
+    public void canPruneEmptyDirectoriesWithDefaultSetting() throws IOException {
+        final MantaClient client = new MantaClient(new TestConfigContext());
+        final MantaClient clientSpy = spy(client);
+        final MantaHttpHeaders headers = new MantaHttpHeaders();
+        final String path = "/user/stor/dir1/dir2/object.txt";
+        final DefaultsConfigContext config = new DefaultsConfigContext();
+
+        /* We look for the value of the defaults as returned by the default
+         * method in the default configuration settings class first because
+         * it could be changed to be something other than null. If it is null,
+         * then we get the value that the null value is interpreted as. We pull
+         * the limit value in this way in order to validate that our test logic
+         * matches our app logic.
+         */
+        final int limit = ObjectUtils.firstNonNull(config.getPruneEmptyParentDepth(),
+                DefaultsConfigContext.DEFAULT_PRUNE_DEPTH);
+
+        // Prevent the client from actually calling out to a real Manta
+        Mockito.doNothing().when(clientSpy).delete(path, headers, null);
+
+        pruneParentDirectories(clientSpy, headers, path, limit);
+
+        // Verify that we only issued a single delete call because our limit is 0
+        Mockito.verify(clientSpy, times(1))
+                .delete(path, headers, null);
+
+        // Verify that is the only call that we made
+        Mockito.verifyNoMoreInteractions(clientSpy);
+    }
+
+    public void canPruneEmptyDirectoriesWithLimitOne() throws IOException {
+        final MantaClient client = new MantaClient(new TestConfigContext());
+        final MantaClient clientSpy = spy(client);
+        final MantaHttpHeaders headers = new MantaHttpHeaders();
+        final String path = "/user/stor/dir1/dir2/object.txt";
+        final int limit = 1;
+
+        // Prevent the client from actually calling out to a real Manta
+        Mockito.doNothing().when(clientSpy).delete(path, headers, null);
+        Mockito.doNothing().when(clientSpy).delete("/user/stor/dir1/dir2", headers, null);
+
+        pruneParentDirectories(clientSpy, headers, path, limit);
+
+        Mockito.verify(clientSpy, times(1))
+                .delete(path, headers, null);
+        Mockito.verify(clientSpy, times(1))
+                .delete("/user/stor/dir1/dir2", headers, null);
+
+        // Verify that is the only call that we made
+        Mockito.verifyNoMoreInteractions(clientSpy);
+    }
+
+    public void canPruneEmptyDirectoriesWithLimitTwo() throws IOException {
+        final MantaClient client = new MantaClient(new TestConfigContext());
+        final MantaClient clientSpy = spy(client);
+        final MantaHttpHeaders headers = new MantaHttpHeaders();
+        final String path = "/user/stor/dir1/dir2/object.txt";
+        final int limit = 2;
+
+        // Prevent the client from actually calling out to a real Manta
+        Mockito.doNothing().when(clientSpy).delete(path, headers, null);
+        Mockito.doNothing().when(clientSpy).delete("/user/stor/dir1/dir2", headers, null);
+        Mockito.doNothing().when(clientSpy).delete("/user/stor/dir1", headers, null);
+
+        pruneParentDirectories(clientSpy, headers, path, limit);
+
+        Mockito.verify(clientSpy, times(1))
+                .delete(path, headers, null);
+        Mockito.verify(clientSpy, times(1))
+                .delete("/user/stor/dir1/dir2", headers, null);
+        Mockito.verify(clientSpy, times(1))
+                .delete("/user/stor/dir1", headers, null);
+
+        // Verify that is the only call that we made
+        Mockito.verifyNoMoreInteractions(clientSpy);
+    }
+
+    public void verifyThatPruneEmptyDirectoriesWontPruneBelowStorRoot() throws IOException {
+        final MantaClient client = new MantaClient(new TestConfigContext());
+        final MantaClient clientSpy = spy(client);
+        final MantaHttpHeaders headers = new MantaHttpHeaders();
+        final String path = "/user/stor/dir1/dir2/object.txt";
+        final int limit = 3;
+
+        // Prevent the client from actually calling out to a real Manta
+        Mockito.doNothing().when(clientSpy).delete(path, headers, null);
+        Mockito.doNothing().when(clientSpy).delete("/user/stor/dir1/dir2", headers, null);
+        Mockito.doNothing().when(clientSpy).delete("/user/stor/dir1", headers, null);
+
+        pruneParentDirectories(clientSpy, headers, path, limit);
+
+        Mockito.verify(clientSpy, times(1))
+                .delete(path, headers, null);
+        Mockito.verify(clientSpy, times(1))
+                .delete("/user/stor/dir1/dir2", headers, null);
+        Mockito.verify(clientSpy, times(1))
+                .delete("/user/stor/dir1", headers, null);
+
+        // Verify that is the only call that we made
+        Mockito.verifyNoMoreInteractions(clientSpy);
+    }
+
+    public void canPruneAllDirectories() throws IOException {
+        final MantaClient client = new MantaClient(new TestConfigContext());
+        final MantaClient clientSpy = spy(client);
+        final MantaHttpHeaders headers = new MantaHttpHeaders();
+        final String path = "/user/stor/dir1/dir2/object.txt";
+        final int limit = PRUNE_ALL_PARENTS;
+
+        // Prevent the client from actually calling out to a real Manta
+        Mockito.doNothing().when(clientSpy).delete(path, headers, null);
+        Mockito.doNothing().when(clientSpy).delete("/user/stor/dir1/dir2", headers, null);
+        Mockito.doNothing().when(clientSpy).delete("/user/stor/dir1", headers, null);
+
+        pruneParentDirectories(clientSpy, headers, path, limit);
+
+        Mockito.verify(clientSpy, times(1))
+                .delete(path, headers, null);
+        Mockito.verify(clientSpy, times(1))
+                .delete("/user/stor/dir1/dir2", headers, null);
+        Mockito.verify(clientSpy, times(1))
+                .delete("/user/stor/dir1", headers, null);
+
+        // Verify that is the only call that we made
+        Mockito.verifyNoMoreInteractions(clientSpy);
+    }
+}

--- a/java-manta-client-unshaded/src/test/resources/testng.xml
+++ b/java-manta-client-unshaded/src/test/resources/testng.xml
@@ -17,6 +17,7 @@
             <class name="com.joyent.manta.client.MantaClientValidationTest" />
             <class name="com.joyent.manta.client.MantaDirectoryListingIteratorTest" />
             <class name="com.joyent.manta.client.MetricReporterSupplierTest" />
+            <class name="com.joyent.manta.client.PruneEmptyParentDirectoryStrategyTest" />
         </classes>
     </test>
     <test name="Configuration Context Tests">

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientDirectoriesIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientDirectoriesIT.java
@@ -24,7 +24,6 @@ import java.util.UUID;
 
 import static com.joyent.manta.client.MantaClient.SEPARATOR;
 import static com.joyent.manta.exception.MantaErrorCode.RESOURCE_NOT_FOUND_ERROR;
-import static com.joyent.manta.exception.MantaErrorCode.BAD_REQUEST_ERROR;
 import static com.joyent.manta.util.MantaUtils.writeablePrefixPaths;
 
 /**
@@ -260,7 +259,7 @@ public class MantaClientDirectoriesIT {
         final String childDir = createRandomDirectory(parentDir, 5);
         LOG.info("CHILD DIR  : " + childDir);
         LOG.info("Parent DIR : " + parentDir);
-        mantaClient.delete(childDir, null, PruneEmpytParentDirectoryStrategy.PRUNE_ALL_PARENTS);
+        mantaClient.delete(childDir, null, PruneEmptyParentDirectoryStrategy.PRUNE_ALL_PARENTS);
         Assert.assertFalse(mantaClient.existsAndIsAccessible(childDir));
         Assert.assertFalse(mantaClient.existsAndIsAccessible(parentDir));
         // Getting the path of the parent's parent.


### PR DESCRIPTION
This PR incorporates the following changes:
- Fixed typo in class name for prune directory strategy
- Cleans up the log messages for prune operations
- Adds unit tests to test prune algorithm
- Fixes link in `USAGE.md` for prune depth setting