### PR TITLE
Fixes #439

### DIFF
--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaClient.java
@@ -1237,12 +1237,17 @@ public class MantaClient implements AutoCloseable {
     }
 
     /**
-     * Creates an OutputStream that wraps a PUT request to Manta. Try to avoid using this
+     * <p>Creates an OutputStream that wraps a PUT request to Manta. Try to avoid using this
      * to add data to Manta because it requires an additional thread to be started in order
      * to upload using an {@link java.io.OutputStream}. Additionally, if you do not close()
-     * the stream, the data will not be uploaded.
+     * the stream, the data will not be uploaded.</p>
      *
-     * @param path     The fully qualified path of the object. i.e. /user/stor/foo/bar/baz
+     * <p>NOTE: Use of this method should be discouraged because it uses another thread
+     * and it uses reflection in order to provide an {@link java.io.OutputStream} implementation.
+     * It is provided for users who have no choice but to use an {@link java.io.OutputStream} to
+     * write data to Manta due to constraints in their object model.</p>
+     *
+     * @param path The fully qualified path of the object. i.e. /user/stor/foo/bar/baz
      * @return A OutputStream that allows for directly uploading to Manta
      */
     public MantaObjectOutputStream putAsOutputStream(final String path) {
@@ -1250,13 +1255,18 @@ public class MantaClient implements AutoCloseable {
     }
 
     /**
-     * Creates an OutputStream that wraps a PUT request to Manta. Try to avoid using this
+     * <p>Creates an OutputStream that wraps a PUT request to Manta. Try to avoid using this
      * to add data to Manta because it requires an additional thread to be started in order
      * to upload using an {@link java.io.OutputStream}. Additionally, if you do not close()
-     * the stream, the data will not be uploaded.
+     * the stream, the data will not be uploaded.</p>
      *
-     * @param path     The fully qualified path of the object. i.e. /user/stor/foo/bar/baz
-     * @param headers  optional HTTP headers to include when copying the object
+     * <p>NOTE: Use of this method should be discouraged because it uses another thread
+     * and it uses reflection in order to provide an {@link java.io.OutputStream} implementation.
+     * It is provided for users who have no choice but to use an {@link java.io.OutputStream} to
+     * write data to Manta due to constraints in their object model.</p>
+     *
+     * @param path The fully qualified path of the object. i.e. /user/stor/foo/bar/baz
+     * @param headers optional HTTP headers to include when copying the object
      * @return A OutputStream that allows for directly uploading to Manta
      */
     public MantaObjectOutputStream putAsOutputStream(final String path,
@@ -1265,12 +1275,17 @@ public class MantaClient implements AutoCloseable {
     }
 
     /**
-     * Creates an OutputStream that wraps a PUT request to Manta. Try to avoid using this
+     * <p>Creates an OutputStream that wraps a PUT request to Manta. Try to avoid using this
      * to add data to Manta because it requires an additional thread to be started in order
      * to upload using an {@link java.io.OutputStream}. Additionally, if you do not close()
-     * the stream, the data will not be uploaded.
+     * the stream, the data will not be uploaded.</p>
      *
-     * @param path     The fully qualified path of the object. i.e. /user/stor/foo/bar/baz
+     * <p>NOTE: Use of this method should be discouraged because it uses another thread
+     * and it uses reflection in order to provide an {@link java.io.OutputStream} implementation.
+     * It is provided for users who have no choice but to use an {@link java.io.OutputStream} to
+     * write data to Manta due to constraints in their object model.</p>
+     *
+     * @param path The fully qualified path of the object. i.e. /user/stor/foo/bar/baz
      * @param metadata optional user-supplied metadata for object
      * @return A OutputStream that allows for directly uploading to Manta
      */
@@ -1280,14 +1295,19 @@ public class MantaClient implements AutoCloseable {
     }
 
     /**
-     * Creates an OutputStream that wraps a PUT request to Manta. Try to avoid using this
+     * <p>Creates an OutputStream that wraps a PUT request to Manta. Try to avoid using this
      * to add data to Manta because it requires an additional thread to be started in order
      * to upload using an {@link java.io.OutputStream}. Additionally, if you do not close()
-     * the stream, the data will not be uploaded.
+     * the stream, the data will not be uploaded.</p>
      *
-     * @param rawPath     The fully qualified path of the object. i.e. /user/stor/foo/bar/baz
+     * <p>NOTE: Use of this method should be discouraged because it uses another thread
+     * and it uses reflection in order to provide an {@link java.io.OutputStream} implementation.
+     * It is provided for users who have no choice but to use an {@link java.io.OutputStream} to
+     * write data to Manta due to constraints in their object model.</p>
+     *
+     * @param rawPath The fully qualified path of the object. i.e. /user/stor/foo/bar/baz
      * @param metadata optional user-supplied metadata for object
-     * @param headers  optional HTTP headers to include when copying the object
+     * @param headers optional HTTP headers to include when copying the object
      * @return A OutputStream that allows for directly uploading to Manta
      */
     public MantaObjectOutputStream putAsOutputStream(final String rawPath,

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaObjectOutputStream.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaObjectOutputStream.java
@@ -13,6 +13,7 @@ import com.joyent.manta.http.MantaHttpHeaders;
 import com.joyent.manta.http.entity.EmbeddedHttpContent;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.ClosedOutputStream;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.http.entity.ContentType;
 import org.slf4j.Logger;
@@ -29,14 +30,19 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 
 /**
- * {@link OutputStream} that wraps the PUT operations using an {@link java.io.InputStream}
+ * <p>{@link OutputStream} that wraps the PUT operations using an {@link java.io.InputStream}
  * as a data source. This implementation uses another thread to keep the Apache HTTP
  * Client's {@link OutputStream} open in order to proxy all calls to it. This is far
  * from an ideal implementation. Please only use this class as a last resort when needing
- * to provide compatibility with inflexible APIs that require an {@link OutputStream}.
+ * to provide compatibility with inflexible APIs that require an {@link OutputStream}.</p>
+ *
+ * <p>NOTE: Use of this class should be discouraged because it uses another thread
+ * and it uses reflection in order to provide an {@link OutputStream} implementation.
+ * It is provided for users who have no choice but to use an {@link OutputStream} to
+ * write data to Manta due to constraints in their object model.</p>
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  * @since 2.4.0
@@ -119,7 +125,7 @@ public class MantaObjectOutputStream extends OutputStream {
     /**
      * A running count of the total number of bytes written.
      */
-    private AtomicLong bytesWritten = new AtomicLong(0L);
+    private LongAdder bytesWritten = new LongAdder();
 
     /**
      * Flag indicating that this stream has been closed.
@@ -172,7 +178,7 @@ public class MantaObjectOutputStream extends OutputStream {
          * becomes available.
          */
         synchronized (this.httpContent) {
-            while (!httpContent.isClosed() && httpContent.getWriter() == null) {
+            while (!isClosed() && !httpContent.isClosed() && httpContent.getWriter() == null) {
                 try {
                     /* We poll because the httpContent.notify() call within the
                      * httpContent.writeTo() method may have been called before
@@ -187,43 +193,47 @@ public class MantaObjectOutputStream extends OutputStream {
 
     @Override
     public void write(final int b) throws IOException {
-        if (this.closed.get()) {
+        // Note: isClosed() is an expensive check, see note inside method
+        if (isClosed()) {
             MantaIOException e = new MantaIOException("Can't write to a closed stream");
             e.setContextValue("path", path);
             throw e;
         }
 
         httpContent.getWriter().write(b);
-        bytesWritten.incrementAndGet();
+        bytesWritten.increment();
     }
 
     @Override
     public void write(final byte[] b) throws IOException {
-        if (this.closed.get()) {
+        // Note: isClosed() is an expensive check, see note inside method
+        if (isClosed()) {
             MantaIOException e = new MantaIOException("Can't write to a closed stream");
             e.setContextValue("path", path);
             throw e;
         }
 
         httpContent.getWriter().write(b);
-        bytesWritten.addAndGet(b.length);
+        bytesWritten.add(b.length);
     }
 
     @Override
     public void write(final byte[] b, final int off, final int len) throws IOException {
-        if (this.closed.get()) {
+        // Note: isClosed() is an expensive check, see note inside method
+        if (isClosed()) {
             MantaIOException e = new MantaIOException("Can't write to a closed stream");
             e.setContextValue("path", path);
             throw e;
         }
 
         httpContent.getWriter().write(b, off, len);
-        bytesWritten.addAndGet(b.length);
+        bytesWritten.add(b.length);
     }
 
     @Override
     public void flush() throws IOException {
-        if (this.closed.get()) {
+        // Note: isClosed() is an expensive check, see note inside method
+        if (isClosed()) {
             return;
         }
 
@@ -269,9 +279,11 @@ public class MantaObjectOutputStream extends OutputStream {
     }
 
     /**
-     * Finds the most inner stream if the embedded stream is stored on the passed
+     * <p>Finds the most inner stream if the embedded stream is stored on the passed
      * stream as a field named <code>out</code>. This hold true for all classes
-     * that extend {@link java.io.FilterOutputStream}.
+     * that extend {@link java.io.FilterOutputStream}.</p>
+     *
+     * <p>NOTE: This is a dirty hack.</p>
      *
      * @param stream stream to search for inner stream
      * @return reference to inner stream class
@@ -297,6 +309,14 @@ public class MantaObjectOutputStream extends OutputStream {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>NOTE: This close method calls flush() on the inner {@link OutputStream}
+     * and then closes it if possible.</p>
+     *
+     * @throws IOException
+     */
     @Override
     public synchronized void close() throws IOException {
         this.closed.compareAndSet(false, true);
@@ -312,12 +332,15 @@ public class MantaObjectOutputStream extends OutputStream {
          * we wake up the the sleeping thread in order for it properly exit the
          * writeTo() method in which it was waiting. */
         synchronized (this.httpContent) {
+            /* We notify the streaming thread which is waiting within
+             * EmbeddedHttpContent.writeTo() in order for it to wake up
+             * and exit the thread. */
             this.httpContent.notify();
         }
 
         try {
             this.objectResponse = this.completed.get();
-            this.objectResponse.setContentLength(bytesWritten.get());
+            this.objectResponse.setContentLength(bytesWritten.longValue());
         } catch (InterruptedException e) {
             // continue execution if interrupted
         } catch (ExecutionException e) {
@@ -349,6 +372,26 @@ public class MantaObjectOutputStream extends OutputStream {
      * @return true if closed, otherwise false
      */
     public boolean isClosed() {
+        if (!closed.get()) {
+            return closed.get();
+        }
+
+        final Boolean innerClosed;
+
+        /* Note: There is a performance cost here that we are paying in exchange
+         * for correctness. Every execution of isInnerStreamClosed() uses
+         * reflection to find out if the innermost OutputStream is in fact
+         * closed. */
+        if (httpContent != null && httpContent.getWriter() != null) {
+             innerClosed = isInnerStreamClosed(httpContent.getWriter());
+        } else {
+            innerClosed = false;
+        }
+
+        if (BooleanUtils.toBoolean(innerClosed)) {
+            return closed.compareAndSet(false, innerClosed);
+        }
+
         return closed.get();
     }
 

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaObjectOutputStreamIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaObjectOutputStreamIT.java
@@ -9,9 +9,11 @@ package com.joyent.manta.client;
 
 import com.joyent.manta.config.ConfigContext;
 import com.joyent.manta.config.IntegrationTestConfigContext;
+import com.joyent.manta.exception.MantaIOException;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomUtils;
+import org.apache.commons.lang3.exception.ExceptionContext;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
 import org.testng.annotations.AfterClass;
@@ -127,18 +129,21 @@ public class MantaObjectOutputStreamIT {
         }
     }
 
-    public void canUploadMuchLargerFileWithPeriodicWaits() throws IOException, InterruptedException {
+    public void canUploadMuchLargerFileWithPeriodicWaits() throws Exception {
         String path = testPathPrefix + "uploaded-" + UUID.randomUUID() + ".txt";
         MantaObjectOutputStream out = mantaClient.putAsOutputStream(path);
         ByteArrayOutputStream bout = new ByteArrayOutputStream(6553600);
 
         MessageDigest md5Digest = DigestUtils.getMd5Digest();
         long totalBytes = 0;
+        int chunkSize = -1;
+
+        Exception failureException = null;
 
         try {
             for (int i = 0; i < 100; i++) {
-                int chunkSize = RandomUtils.nextInt(1, 131072);
-                byte[] randomBytes = RandomUtils.nextBytes(chunkSize);
+                chunkSize = RandomUtils.nextInt(1, 10);
+                final byte[] randomBytes = RandomUtils.nextBytes(chunkSize);
                 md5Digest.update(randomBytes);
                 totalBytes += randomBytes.length;
                 out.write(randomBytes);
@@ -149,16 +154,35 @@ public class MantaObjectOutputStreamIT {
                     Thread.sleep(RandomUtils.nextLong(1L, 1000L));
                 }
             }
+        } catch (MantaIOException e) {
+            failureException = e;
         } finally {
-            out.close();
             bout.close();
+
+            try {
+                out.close();
+                // Test to see if the file was successfully created
+                mantaClient.head(path);
+            } catch (MantaIOException e) {
+                failureException = e;
+            }
+        }
+
+        if (failureException != null) {
+            if (failureException instanceof ExceptionContext) {
+                ExceptionContext e = (ExceptionContext)failureException;
+                e.setContextValue("lastChunkSize", chunkSize);
+                e.setContextValue("totalBytes", totalBytes);
+            }
+            throw failureException;
         }
 
         try (InputStream in = mantaClient.getAsInputStream(path)) {
             byte[] expected = bout.toByteArray();
             byte[] actual = IOUtils.readFully(in, (int)totalBytes);
 
-            AssertJUnit.assertArrayEquals("Bytes written via OutputStream don't match read bytes",
+            AssertJUnit.assertArrayEquals("Bytes written via "
+                            + "OutputStream doesn't match read bytes",
                     expected, actual);
         }
     }

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaObjectOutputStreamIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaObjectOutputStreamIT.java
@@ -104,6 +104,8 @@ public class MantaObjectOutputStreamIT {
         try {
             for (int i = 0; i < 100; i++) {
                 int chunkSize = RandomUtils.nextInt(1, 131072);
+                System.out.printf("[%03d] Writing to OutputStream with [%06d] sized chunk\n",
+                        i+1, chunkSize);
                 byte[] randomBytes = RandomUtils.nextBytes(chunkSize);
                 md5Digest.update(randomBytes);
                 totalBytes += randomBytes.length;
@@ -112,6 +114,7 @@ public class MantaObjectOutputStreamIT {
 
                 // periodically flush
                 if (i % 25 == 0) {
+                    System.out.println("  Flushing OutputStream");
                     out.flush();
                 }
             }
@@ -142,8 +145,10 @@ public class MantaObjectOutputStreamIT {
 
         try {
             for (int i = 0; i < 100; i++) {
-                chunkSize = RandomUtils.nextInt(1, 10);
+                chunkSize = RandomUtils.nextInt(1, 131072);
                 final byte[] randomBytes = RandomUtils.nextBytes(chunkSize);
+                System.out.printf("[%03d] Writing to OutputStream with [%06d] sized chunk\n",
+                        i+1, chunkSize);
                 md5Digest.update(randomBytes);
                 totalBytes += randomBytes.length;
                 out.write(randomBytes);
@@ -151,7 +156,9 @@ public class MantaObjectOutputStreamIT {
 
                 // periodically wait
                 if (i % 3 == 0) {
-                    Thread.sleep(RandomUtils.nextLong(1L, 1000L));
+                    final long waitTime = RandomUtils.nextLong(1L, 1000L);
+                    System.out.printf("  Waiting for [%04d] ms\n", waitTime);
+                    Thread.sleep(waitTime);
                 }
             }
         } catch (MantaIOException e) {


### PR DESCRIPTION
This change does the following:

- Adds comments regarding how cross thread coordination works between `MantaObjectOutputStream` and `EmbeddedHttpContent`.
- Adds javadoc warning to avoid using `MantaObjectOutputStream` because it uses reflection and additional threads.
- Changes the byte counting data structure from `AtomicInteger` to `LongAdder`.
- Adds improved closed stream checking logic.
- Changes from a `Thread.sleep()` polling model to a `wait()` / `notify()` model for checking to see if the initial `OutputStream` has been allocated within a separate thread.
- Adds `isClosed()` method to `MantaObjectOutputStream`.
- Improves error reporting for failures and runtime information in `MantaObjectOutputStreamIT`.
- Fixes bug #439 by closing the `EmbeddedHttpContent` instance within `MantaObjectOutputStream.clost()`.
- Removed unused `throws` parameters from method signatures.