### PR TITLE
Disabled Zulu JDK in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,14 @@ cache:
   - $HOME/.downloads
 sudo: true
 
-addons:
-  apt:
-    sources:
-      - sourceline: 'deb http://repos.azulsystems.com/ubuntu stable main'
-        key_url: 'http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems'
-    packages:
-      - zulu-8
-      - zulu-9
+#addons:
+#  apt:
+#    sources:
+#      - sourceline: 'deb http://repos.azulsystems.com/ubuntu stable main'
+#        key_url: 'http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems'
+#    packages:
+#      - zulu-8
+#      - zulu-9
 
 # Oracle JDK 8 and the OpenJDK 8 are both installed by default by TravisCI
 # Additionally, they both have the unlimited JCE policy installed as well.
@@ -25,13 +25,13 @@ addons:
 before_install:
   - echo 'MAVEN_OPTS="-Dorg.slf4j.simpleLogger.defaultLogLevel=warn"' >~/.mavenrc
   - mkdir -p $HOME/.downloads
-  - wget -N -q -O $HOME/.downloads/ZuluJCEPolicies.zip 'https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip'
-  # The SHA256 checksum for JCE for Azul will break if Azul updates their archive.
-  # If so, you will need to update the fingerprint below after verifying the
-  # authenticity of the archive.
-  - echo "8021a28b8cac41b44f1421fd210a0a0822fcaf88d62d2e70a35b2ff628a8675a  $HOME/.downloads/ZuluJCEPolicies.zip" | sha256sum -c
-  - sudo unzip -o -j $HOME/.downloads/ZuluJCEPolicies.zip ZuluJCEPolicies/local_policy.jar ZuluJCEPolicies/US_export_policy.jar -d /usr/lib/jvm/zulu-8-amd64/jre/lib/security
-  - sudo unzip -o -j $HOME/.downloads/ZuluJCEPolicies.zip ZuluJCEPolicies/local_policy.jar ZuluJCEPolicies/US_export_policy.jar -d /usr/lib/jvm/zulu-9-amd64/lib/security
+#  - wget -N -q -O $HOME/.downloads/ZuluJCEPolicies.zip 'https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip'
+#  # The SHA256 checksum for JCE for Azul will break if Azul updates their archive.
+#  # If so, you will need to update the fingerprint below after verifying the
+#  # authenticity of the archive.
+#  - echo "8021a28b8cac41b44f1421fd210a0a0822fcaf88d62d2e70a35b2ff628a8675a  $HOME/.downloads/ZuluJCEPolicies.zip" | sha256sum -c
+#  - sudo unzip -o -j $HOME/.downloads/ZuluJCEPolicies.zip ZuluJCEPolicies/local_policy.jar ZuluJCEPolicies/US_export_policy.jar -d /usr/lib/jvm/zulu-8-amd64/jre/lib/security
+#  - sudo unzip -o -j $HOME/.downloads/ZuluJCEPolicies.zip ZuluJCEPolicies/local_policy.jar ZuluJCEPolicies/US_export_policy.jar -d /usr/lib/jvm/zulu-9-amd64/lib/security
 
 matrix:
   fast_finish: true
@@ -55,21 +55,21 @@ matrix:
         - CMD="mvn clean test -Dcheckstyle.skip=true"
         - LANG=en_US.utf8
     # unit tests (zulu-8)
-    - env:
-        - JAVA_HOME=/usr/lib/jvm/zulu-8-amd64
-        - DESC="zulu-8 unit tests"
-        - CMD="mvn clean test -Dcheckstyle.skip=true"
-        - LANG=en_US.utf8
+#    - env:
+#        - JAVA_HOME=/usr/lib/jvm/zulu-8-amd64
+#        - DESC="zulu-8 unit tests"
+#        - CMD="mvn clean test -Dcheckstyle.skip=true"
+#        - LANG=en_US.utf8
     - jdk: oraclejdk9
       env:
         - DESC="oraclejdk9 unit tests"
         - CMD="mvn clean test -Dcheckstyle.skip=true"
         - LANG=en_US.utf8
     # unit tests (zulu-9)
-    - env:
-        - JAVA_HOME=/usr/lib/jvm/zulu-9-amd64
-        - DESC="zulu-9 unit tests"
-        - CMD="mvn clean test -Dcheckstyle.skip=true"
-        - LANG=en_US.utf8
+#    - env:
+#        - JAVA_HOME=/usr/lib/jvm/zulu-9-amd64
+#        - DESC="zulu-9 unit tests"
+#        - CMD="mvn clean test -Dcheckstyle.skip=true"
+#        - LANG=en_US.utf8
 
 script: echo ${CMD}; ${CMD}


### PR DESCRIPTION
Currently, the Azul Zulu JDK download via apt is not working properly and causing builds to fail in TravisCI. This PR disableds the Azul Zulu JDK within the TravisCI configuration.