### PR TITLE
Connection timeout error message removed for test class TCPSocketConnectionTimeoutIT

### DIFF
--- a/java-manta-it/src/test/java/com/joyent/manta/http/TCPSocketConnectionTimeoutIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/http/TCPSocketConnectionTimeoutIT.java
@@ -62,12 +62,10 @@ public class TCPSocketConnectionTimeoutIT {
             start = Instant.now();
             client.head(testPathPrefix);
 
-        } catch(InterruptedIOException e){
+        } catch (InterruptedIOException e) {
             Assert.assertEquals(e.getClass().getSimpleName(),
-                    "ConnectTimeoutException");
-            Assert.assertTrue(e.getMessage().endsWith("connect timed out"),
-                    "ConnectTimeoutException didn't end with expected "
-                            + "connection timeout message. Actual exception:\n"
+                    "ConnectTimeoutException",
+                    "Expected exception ConnectTimeoutException was not thrown. Actual Exception:\n"
                             + ExceptionUtils.getStackTrace(e));
         } finally {
             stop = Instant.now();


### PR DESCRIPTION
Java uses different underlying network libraries between Linux, MacOS, SmartOS and Windows, so the message returned in exceptions like the following are not consistent. Hence this ```assertTrue()``` statement had to be removed to make the test consistent for all systems.