### PR TITLE
Failing Integration-Test, EncryptedServerSideMultipartManagerIT 

### DIFF
--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
@@ -94,8 +94,8 @@ public class EncryptedServerSideMultipartManagerIT {
     }
 
     public void nonExistentFileHasNotStarted() throws IOException {
-        String path = testPathPrefix + UUID.randomUUID().toString();
-        UUID unknownId = new UUID(0L, 3);
+        final String path = testPathPrefix + UUID.randomUUID().toString();
+        final UUID unknownId = new UUID(0L, 3);
 
         ServerSideMultipartUpload wrapped = new ServerSideMultipartUpload(
                 unknownId, path, null);

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
@@ -95,7 +95,7 @@ public class EncryptedServerSideMultipartManagerIT {
 
     public void nonExistentFileHasNotStarted() throws IOException {
         String path = testPathPrefix + UUID.randomUUID().toString();
-        UUID unknownId = new UUID(0L, -1L);
+        UUID unknownId = new UUID(0L, 3);
 
         ServerSideMultipartUpload wrapped = new ServerSideMultipartUpload(
                 unknownId, path, null);

--- a/java-manta-it/src/test/java/com/joyent/manta/http/TCPSocketConnectionTimeoutIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/http/TCPSocketConnectionTimeoutIT.java
@@ -27,7 +27,7 @@ import java.time.Instant;
  * Integration tests for verifying the connection timeout behaviour for an invalid connection.
  * This Integration test is written for the sole purpose of verifying Issue #441.
  *
- * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
+ * @author <a href="https://github.com/dekobon">Ashwin A Nair</a>
  */
 @Test
 public class TCPSocketConnectionTimeoutIT {

--- a/java-manta-it/src/test/java/com/joyent/manta/http/TCPSocketConnectionTimeoutIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/http/TCPSocketConnectionTimeoutIT.java
@@ -29,6 +29,7 @@ import java.time.Instant;
  *
  * @author <a href="https://github.com/dekobon">Ashwin A Nair</a>
  */
+
 @Test
 public class TCPSocketConnectionTimeoutIT {
     private static final Logger LOG = LoggerFactory.getLogger(TCPSocketConnectionTimeoutIT.class);

--- a/java-manta-it/src/test/java/com/joyent/manta/http/TCPSocketConnectionTimeoutIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/http/TCPSocketConnectionTimeoutIT.java
@@ -27,9 +27,8 @@ import java.time.Instant;
  * Integration tests for verifying the connection timeout behaviour for an invalid connection.
  * This Integration test is written for the sole purpose of verifying Issue #441.
  *
- * @author <a href="https://github.com/dekobon">Ashwin A Nair</a>
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
-
 @Test
 public class TCPSocketConnectionTimeoutIT {
     private static final Logger LOG = LoggerFactory.getLogger(TCPSocketConnectionTimeoutIT.class);


### PR DESCRIPTION
Since the UUID value for any given upload shouldn't have a character, 0 or 9 as the last char, these changes was made to rectify the failure.

```Line-98 params for LSB of a new UUID object updated from '-1L' to '3'```