### PR TITLE
Modifying testng-it.xml file to exclude New Run-Config

### DIFF
--- a/java-manta-it/src/test/resources/testng-it.xml
+++ b/java-manta-it/src/test/resources/testng-it.xml
@@ -16,6 +16,7 @@
         <groups>
             <run>
                 <exclude name="encrypted"/>
+                <exclude name="encryption-provider" />
             </run>
         </groups>
         <packages>
@@ -30,6 +31,11 @@
     <test name="Manta Client Integration Tests [AES128/CTR Encrypted]">
         <parameter name="usingEncryption" value="true"/>
         <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
+        <groups>
+            <run>
+                <exclude name="encryption-provider" />
+            </run>
+        </groups>
         <packages>
             <package name="com.joyent.manta.client.*">
                 <exclude name="com.joyent.manta.client.jobs"/>
@@ -40,6 +46,11 @@
     <test name="Manta Client Integration Tests [AES128/GCM Encrypted]">
         <parameter name="usingEncryption" value="true"/>
         <parameter name="encryptionCipher" value="AES128/GCM/NoPadding"/>
+        <groups>
+            <run>
+                <exclude name="encryption-provider" />
+            </run>
+        </groups>
         <packages>
             <package name="com.joyent.manta.client.*">
                 <exclude name="com.joyent.manta.client.jobs"/>
@@ -49,6 +60,11 @@
     <test name="Manta Client Integration Tests [AES128/CBC Encrypted]">
         <parameter name="usingEncryption" value="true"/>
         <parameter name="encryptionCipher" value="AES128/CBC/PKCS5Padding"/>
+        <groups>
+            <run>
+                <exclude name="encryption-provider" />
+            </run>
+        </groups>
         <packages>
             <package name="com.joyent.manta.client.*">
                 <exclude name="com.joyent.manta.client.jobs"/>


### PR DESCRIPTION
These changes were introduced to exclude the newly made ```MultiCryptoProviderDecryption``` unit test from certain tests specified in the ```testng-it.xml``` file. It will help avoid failures if we source this xml file to run a test-suite.