### PR TITLE
Changed Disabled mode to VerificationDisabled Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project aims to adhere to [Semantic Versioning](http://semver.org/).
 ### Added
  - [Allow for authentication to be disabled in CSE](https://github.com/joyent/java-manta/issues/465)
    Client side encryption HMAC authentication of ciphertext for CTR/CBC ciphers
-   can now be disabled. The default authentication mode continues to be
+   can now be in VerificationDisabled mode. The default authentication mode continues to be
    Mandatory.
 ### Changed
  - [Deprecate Jobs Multipart implementation and disable integration tests](https://github.com/joyent/java-manta/issues/459)

--- a/USAGE.md
+++ b/USAGE.md
@@ -199,7 +199,7 @@ Note: Dynamic Updates marked with an asterisk (*) are enabled by the `AuthAwareC
     encryption is enabled.
 * `manta.encryption_auth_mode` (**MANTA_ENCRYPTION_AUTH_MODE**)
     [EncryptionAuthenticationMode](/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/EncryptionAuthenticationMode.java)
-    enum type indicating that authenticating encryption verification is either `Mandatory`, `Optional` or `Disabled`.
+    enum type indicating that authenticating encryption verification is either `Mandatory`, `Optional` or `VerificationDisabled`.
 * `manta.encryption_key_path` (**MANTA_ENCRYPTION_KEY_PATH**)
     The path on the local filesystem or a URI understandable by the JVM indicating the
     location of the private key used to perform client-side encryption. If this value is

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/EncryptionAuthenticationMode.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/EncryptionAuthenticationMode.java
@@ -29,10 +29,10 @@ public enum EncryptionAuthenticationMode {
     Mandatory,
 
     /**
-     * Disabled mode will disable ciphertext verification upon decryption.
+     * VerificationDisabled mode will disable ciphertext verification upon decryption.
      * HMACs will still be created when encrypting.
      */
-    Disabled;
+    VerificationDisabled;
 
     /**
      * The default encryption object authentication mode (Mandatory).

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/EncryptionHttpHelper.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/EncryptionHttpHelper.java
@@ -283,7 +283,7 @@ public class EncryptionHttpHelper extends StandardHttpHelper {
 
         /* Errors when we attempt to do an HTTP range request when authentication
          * mode is set to Mandatory because HTTP range requests will only work
-         * with authentication disabled. When you do a range request, it gets
+         * with authentication in verification disabled mode. When you do a range request, it gets
          * arbitrary bytes from the ciphertext of the source object which means
          * that you will not be able to verify the ciphertext using the HMAC
          * because you don't have all of the bytes available. */
@@ -380,9 +380,9 @@ public class EncryptionHttpHelper extends StandardHttpHelper {
                     secretKey, false, initialSkipBytes, plaintextRangeLength, unboundedEnd);
         } else {
             /* We skip authentication on the ciphertext only when it is explicitly
-             * disabled. For the Mandatory and Optional modes, it is enabled. */
+             * in verification disabled mode. For the Mandatory and Optional modes, it is enabled. */
             final boolean authenticateCiphertext =
-                    !encryptionAuthenticationMode.equals(EncryptionAuthenticationMode.Disabled);
+                    !encryptionAuthenticationMode.equals(EncryptionAuthenticationMode.VerificationDisabled);
             return new MantaEncryptedObjectInputStream(rawStream, this.cipherDetails,
                     secretKey, authenticateCiphertext);
         }

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/config/SystemSettingsConfigContextTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/config/SystemSettingsConfigContextTest.java
@@ -141,9 +141,9 @@ public class SystemSettingsConfigContextTest {
                 input, MANTA_ENCRYPTION_AUTHENTICATION_MODE_KEY));
     }
 
-    public void authenticationModeCanBeSetToDisabled() {
-        final String input = "Disabled";
-        final EncryptionAuthenticationMode expected = EncryptionAuthenticationMode.Disabled;
+    public void authenticationModeCanBeSetToVerificationDisabled() {
+        final String input = "VerificationDisabled";
+        final EncryptionAuthenticationMode expected = EncryptionAuthenticationMode.VerificationDisabled;
 
         final Properties properties = new Properties();
         properties.setProperty(MANTA_ENCRYPTION_AUTHENTICATION_MODE_KEY, input);


### PR DESCRIPTION
Since we want to disable both the verification and creation of HMAC signatures for authenticating ciphertext. The enum value that was created (to disable ciphertext verification upon decryption where HMACs will still be created while encrypting. ) in [PR#466](https://github.com/joyent/java-manta/pull/466/files) defined ```Disabled``` has been modified to be called ```VerificationDisabled```.