### PR TITLE
Add New Integration-Test, To Verify Issue#123 is Resolved

### DIFF
--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientAuthenticationIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientAuthenticationIT.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2019, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.manta.client;
+
+import com.joyent.manta.config.*;
+import com.joyent.manta.exception.ConfigurationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.*;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Tests client authentication, sub-user functionality and other issues
+ * associated with it for the {@link MantaClient} class.
+ *
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>-
+ */
+public class MantaClientAuthenticationIT {
+    private static final String TEST_DATA = "Arise,Awake And Do Not Stop Until Your Goal Is Reached.";
+
+    private MantaClient mantaClient;
+
+    private String testPathPrefix;
+
+    @BeforeClass
+    @Parameters({"usingEncryption"})
+    public void beforeClass(@Optional Boolean usingEncryption) throws IOException {
+
+        // Let TestNG configuration take precedence over environment variables
+        ConfigContext config = new IntegrationTestConfigContext(usingEncryption);
+
+        mantaClient = new MantaClient(config);
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
+        mantaClient.putDirectory(testPathPrefix, true);
+    }
+
+    @AfterClass
+    public void afterClass() throws IOException {
+        IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
+    }
+
+    @Test(expectedExceptions = { ConfigurationException.class })
+    public final void testInvalidMantaUser() throws IOException {
+        System.setProperty("manta.dumpConfig", "true");
+        final ConfigContext config = new ChainedConfigContext(
+                new StandardConfigContext()
+                        .setMantaKeyId("some placeholder string")
+                        .setMantaUser("MY USERNAME"),
+                new DefaultsConfigContext()
+
+        );
+
+        try (final MantaClient client = new MantaClient(config)) {
+            Assert.assertNotNull(client);
+
+            final String name = UUID.randomUUID().toString();
+            final String path = config.getMantaUser() + "/stor/" + name;
+            client.put(path, TEST_DATA);
+        }
+    }
+}
+


### PR DESCRIPTION
- The conversation in [Issue#123](https://github.com/joyent/java-manta/issues/123) is the motivation behind creating this pull-request.

- Since we know an Invalid MantaUser no longer results in ```500 Internal Server Error```. We can safely close the aforementioned issue. 

- Instead a ConfigurationException is raised which has been incorporated since ```3.0.0``` within this context [here](https://github.com/joyent/java-manta/blob/master/java-manta-client-unshaded/src/main/java/com/joyent/manta/exception/ConfigurationException.java).

- Future ```sub-user-configuration testing```, etc will be incorporated in this integration-test.
