### PR TITLE
Fixing Issue#363

### DIFF
--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/EncryptionType.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/EncryptionType.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
+import static com.joyent.manta.client.MantaClient.SEPARATOR;
 import static com.joyent.manta.util.MantaVersion.CLIENT_SIDE_ENCRYPTION_MAX_VERSION;
 import static com.joyent.manta.util.MantaVersion.CLIENT_SIDE_ENCRYPTION_MIN_VERSION;
 
@@ -38,11 +39,6 @@ public final class EncryptionType {
      */
     private static final Map<String, EncryptionType> SUPPORTED_ENCRYPTION_TYPES =
             Collections.singletonMap(CLIENT.name, CLIENT);
-
-    /**
-     * Separator string between type name and version.
-     */
-    private static final String SEPARATOR = "/";
 
     /**
      * Encryption type name.

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/SupportedCipherDetails.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/SupportedCipherDetails.java
@@ -7,6 +7,7 @@
  */
 package com.joyent.manta.client.crypto;
 
+import com.joyent.manta.client.MantaClient;
 import com.joyent.manta.exception.MantaClientEncryptionException;
 import org.bouncycastle.crypto.macs.HMac;
 
@@ -195,7 +196,7 @@ public interface SupportedCipherDetails {
                     + "[%s] provider", cipherName, provider.getName());
             throw new MantaClientEncryptionException(msg, e);
         } catch (NoSuchPaddingException e) {
-            String[] split = cipherName.split("/");
+            String[] split = cipherName.split(MantaClient.SEPARATOR);
             if (split.length >= 3) {
                 String padding = split[2];
                 String msg = String.format("Invalid padding mode specified: %s",

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaHttpRequestFactory.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/MantaHttpRequestFactory.java
@@ -7,6 +7,7 @@
  */
 package com.joyent.manta.http;
 
+import com.joyent.manta.client.MantaClient;
 import com.joyent.manta.config.AuthAwareConfigContext;
 import com.joyent.manta.exception.ConfigurationException;
 import com.joyent.manta.exception.MantaClientException;
@@ -247,7 +248,7 @@ public class MantaHttpRequestFactory {
         Validate.notNull(path, "Path must not be null");
 
         final String format;
-        if (path.startsWith("/")) {
+        if (path.startsWith(MantaClient.SEPARATOR)) {
             format = "%s%s";
         } else {
             format = "%s/%s";

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/util/MantaUtils.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/util/MantaUtils.java
@@ -249,7 +249,7 @@ public final class MantaUtils {
     public static String[] parseAccount(final String account) {
         Validate.notNull(account, "Account must not be null");
 
-        final int slashPos = account.indexOf("/");
+        final int slashPos = account.indexOf(SEPARATOR);
 
         if (account.isEmpty()) {
             throw new IllegalArgumentException("Username can't be empty");

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/MantaClientTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/MantaClientTest.java
@@ -10,6 +10,7 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.util.stream.Stream;
 
+import static com.joyent.manta.client.MantaClient.SEPARATOR;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doReturn;
@@ -36,7 +37,7 @@ public class MantaClientTest {
         final MantaClient clientSpy = spy(client);
         doReturn(iteratorMock).when(clientSpy).streamingIterator(anyString());
 
-        final Stream<MantaObject> listing = clientSpy.listObjects("/");
+        final Stream<MantaObject> listing = clientSpy.listObjects(SEPARATOR);
         listing.close();
 
         verify(iteratorMock).close();
@@ -52,7 +53,7 @@ public class MantaClientTest {
         final MantaClient clientSpy = spy(client);
         doReturn(iteratorMock).when(clientSpy).streamingIterator(anyString());
 
-        final Stream<MantaObject> listing = clientSpy.listObjects("/");
+        final Stream<MantaObject> listing = clientSpy.listObjects(SEPARATOR);
         listing.close();
 
         verify(iteratorMock).close();

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/http/EncryptedHttpHelperTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/http/EncryptedHttpHelperTest.java
@@ -7,6 +7,7 @@
  */
 package com.joyent.manta.http;
 
+import com.joyent.manta.client.MantaClient;
 import com.joyent.manta.client.crypto.AesCbcCipherDetails;
 import com.joyent.manta.client.crypto.AesGcmCipherDetails;
 import com.joyent.manta.client.crypto.SecretKeyUtils;
@@ -33,6 +34,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
 import static com.joyent.manta.config.DefaultsConfigContext.DEFAULT_MANTA_URL;
+import static com.joyent.manta.client.MantaClient.SEPARATOR;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -73,7 +75,7 @@ public class EncryptedHttpHelperTest {
 
         boolean caught = false;
         try {
-            URI uri = URI.create(DEFAULT_MANTA_URL + "/" + path);
+            URI uri = URI.create(DEFAULT_MANTA_URL + SEPARATOR + path);
             HttpGet get = new HttpGet(uri);
             MantaHttpHeaders headers = new MantaHttpHeaders();
             httpHelper.httpRequestAsInputStream(get, headers);
@@ -108,7 +110,7 @@ public class EncryptedHttpHelperTest {
                 new MantaHttpRequestFactory(UnitTestConstants.UNIT_TEST_URL),
                 config);
 
-        URI uri = URI.create(DEFAULT_MANTA_URL + "/" + path);
+        URI uri = URI.create(DEFAULT_MANTA_URL + SEPARATOR + path);
 
         CloseableHttpResponse fakeResponse = mock(CloseableHttpResponse.class);
         StatusLine statusLine = new BasicStatusLine(HttpVersion.HTTP_1_1,

--- a/java-manta-examples/src/main/java/ClientEncryptionDownloadException.java
+++ b/java-manta-examples/src/main/java/ClientEncryptionDownloadException.java
@@ -26,7 +26,7 @@ public class ClientEncryptionDownloadException {
         String mantaUserName = "USERNAME";
         String privateKeyPath = "PATH/.ssh/id_rsa";
         String publicKeyId = "04:92:7b:23:bc:08:4f:d7:3b:5a:38:9e:4a:17:2e:df";
-        String mantaPath = "/" + mantaUserName + "/stor/foo";
+        String mantaPath = MantaClient.SEPARATOR + mantaUserName + "/stor/foo";
 
         ConfigContext uploadConfig = new ChainedConfigContext(
                 new DefaultsConfigContext(),

--- a/java-manta-examples/src/main/java/ClientEncryptionMetadata.java
+++ b/java-manta-examples/src/main/java/ClientEncryptionMetadata.java
@@ -40,7 +40,7 @@ public class ClientEncryptionMetadata {
                 .setEncryptionPrivateKeyBytes(Base64.getDecoder().decode("RkZGRkZGRkJEOTY3ODNDNkM5MUUyMjIyMTExMTIyMjI="));
 
         try (MantaClient client = new MantaClient(config)) {
-            String mantaPath = "/" + mantaUserName + "/stor/meta";
+            String mantaPath = MantaClient.SEPARATOR + mantaUserName + "/stor/meta";
 
             MantaMetadata metadata = new MantaMetadata();
             metadata.put("e-secretkey", "My Secret Value");

--- a/java-manta-examples/src/main/java/ClientEncryptionRangeDownload.java
+++ b/java-manta-examples/src/main/java/ClientEncryptionRangeDownload.java
@@ -49,7 +49,7 @@ public class ClientEncryptionRangeDownload {
                 .setEncryptionPrivateKeyBytes(Base64.getDecoder().decode("RkZGRkZGRkJEOTY3ODNDNkM5MUUyMjIyMTExMTIyMjI="));
 
         try (MantaClient client = new MantaClient(config)) {
-            String mantaPath = "/" + mantaUserName + "/stor/foo";
+            String mantaPath = MantaClient.SEPARATOR + mantaUserName + "/stor/foo";
 
             // Divided into 16 byte block chunks for testing
             final String plaintext = "This is my secre" +

--- a/java-manta-examples/src/main/java/ClientEncryptionServerMultipart.java
+++ b/java-manta-examples/src/main/java/ClientEncryptionServerMultipart.java
@@ -13,6 +13,8 @@ import com.joyent.manta.config.*;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.lang3.exception.ContextedRuntimeException;
 
+import static com.joyent.manta.client.MantaClient.SEPARATOR;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Base64;
@@ -52,7 +54,8 @@ public class ClientEncryptionServerMultipart {
     }
 
     private static void multipartUpload(EncryptedServerSideMultipartManager multipart) {
-        String uploadObject = "/" + mantaUsername + "/stor/multipart";
+        String uploadObject = SEPARATOR + mantaUsername + SEPARATOR
+                + "stor" + SEPARATOR + "multipart";
 
 
         // We catch network errors and handle them here

--- a/java-manta-examples/src/main/java/ServerMultipart.java
+++ b/java-manta-examples/src/main/java/ServerMultipart.java
@@ -12,6 +12,8 @@ import com.joyent.manta.config.*;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.lang3.exception.ContextedRuntimeException;
 
+import static com.joyent.manta.client.MantaClient.SEPARATOR;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.stream.Stream;
@@ -45,7 +47,8 @@ public class ServerMultipart {
     }
 
     private static void multipartUpload(ServerSideMultipartManager multipart) {
-        String uploadObject = "/" + mantaUsername + "/stor/multipart";
+        String uploadObject = SEPARATOR + mantaUsername + SEPARATOR
+                + "stor" + SEPARATOR + "multipart";
 
 
         // We catch network errors and handle them here

--- a/java-manta-examples/src/main/java/SimpleClientEncryption.java
+++ b/java-manta-examples/src/main/java/SimpleClientEncryption.java
@@ -10,6 +10,8 @@ import com.joyent.manta.client.MantaClient;
 import com.joyent.manta.client.MantaObjectResponse;
 import com.joyent.manta.config.*;
 
+import static com.joyent.manta.client.MantaClient.SEPARATOR;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.io.IOException;
@@ -43,7 +45,8 @@ public class SimpleClientEncryption {
                 .setEncryptionPrivateKeyBytes(Base64.getDecoder().decode("RkZGRkZGRkJEOTY3ODNDNkM5MUUyMjIyMTExMTIyMjI="));
 
         try (MantaClient client = new MantaClient(config)) {
-            String mantaPath = "/" + mantaUserName + "/stor/foo";
+            String mantaPath = SEPARATOR + mantaUserName + SEPARATOR
+                    + "stor" + SEPARATOR + "foo";
 
             MantaObjectResponse response = client.put(mantaPath, "This is my secret\nthat I want encrypted.");
 

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
@@ -42,6 +42,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
+import static com.joyent.manta.client.MantaClient.SEPARATOR;
 import static com.joyent.manta.exception.MantaErrorCode.RESOURCE_NOT_FOUND_ERROR;
 
 /**
@@ -389,7 +390,7 @@ public class MantaClientIT {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
         mantaClient.put(path, TEST_DATA);
-        final String newDir = testPathPrefix + "subdir-" + UUID.randomUUID() + "/";
+        final String newDir = testPathPrefix + "subdir-" + UUID.randomUUID() + SEPARATOR;
         mantaClient.putDirectory(newDir);
         final String newPath = newDir + "this-is-a-new-name.txt";
 
@@ -403,7 +404,7 @@ public class MantaClientIT {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
         mantaClient.put(path, TEST_DATA);
-        final String newDir = testPathPrefix + "subdir-" + UUID.randomUUID() + "/";
+        final String newDir = testPathPrefix + "subdir-" + UUID.randomUUID() + SEPARATOR;
 
         final String newPath = newDir + "this-is-a-new-name.txt";
 
@@ -417,7 +418,7 @@ public class MantaClientIT {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
         mantaClient.put(path, TEST_DATA);
-        final String newDir = testPathPrefix + "subdir-" + UUID.randomUUID() + "/";
+        final String newDir = testPathPrefix + "subdir-" + UUID.randomUUID() + SEPARATOR;
 
         final String newPath = newDir + "this-is-a-new-name.txt";
 
@@ -441,7 +442,7 @@ public class MantaClientIT {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
         mantaClient.putDirectory(path);
-        final String newDir = testPathPrefix + "subdir-" + UUID.randomUUID() + "/";
+        final String newDir = testPathPrefix + "subdir-" + UUID.randomUUID() + SEPARATOR;
 
         mantaClient.move(path, newDir);
         boolean newLocationExists = mantaClient.existsAndIsAccessible(newDir);
@@ -507,7 +508,7 @@ public class MantaClientIT {
     public final void canMoveDirectoryWithContents() throws IOException {
         final String name = "source-" + UUID.randomUUID().toString();
         final String source = testPathPrefix + name + MantaClient.SEPARATOR;
-        final String destination = testPathPrefix + "dest-" + UUID.randomUUID() + "/";
+        final String destination = testPathPrefix + "dest-" + UUID.randomUUID() + SEPARATOR;
         moveDirectoryWithContents(source, destination);
     }
 
@@ -515,7 +516,7 @@ public class MantaClientIT {
     public final void canMoveDirectoryWithContentsAndErrorProneCharacters() throws IOException {
         final String name = "source-" + UUID.randomUUID().toString() + "- -!@#$%^&*()";
         final String source = testPathPrefix + name + MantaClient.SEPARATOR;
-        final String destination = testPathPrefix + "dest-" + UUID.randomUUID() + "- -!@#$%^&*" + "/";
+        final String destination = testPathPrefix + "dest-" + UUID.randomUUID() + "- -!@#$%^&*" + SEPARATOR;
         moveDirectoryWithContents(source, destination);
     }
 
@@ -527,7 +528,7 @@ public class MantaClientIT {
 
         mantaClient.put(String.format("%s/%s", pathPrefix, UUID.randomUUID()), "");
         mantaClient.put(String.format("%s/%s", pathPrefix, UUID.randomUUID()), "");
-        final String subDir = pathPrefix + "/" + UUID.randomUUID().toString();
+        final String subDir = pathPrefix + SEPARATOR + UUID.randomUUID().toString();
         mantaClient.putDirectory(subDir, null);
         mantaClient.put(String.format("%s/%s", subDir, UUID.randomUUID()), "");
         final Stream<MantaObject> objs = mantaClient.listObjects(pathPrefix);

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSigningIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSigningIT.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static com.joyent.manta.client.MantaClient.SEPARATOR;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -205,7 +206,7 @@ public class MantaClientSigningIT {
             if (connection.getResponseCode() != 200) {
                 String errorText = IOUtils.toString(connection.getErrorStream(), Charset.defaultCharset());
 
-                if (config.getMantaUser().contains("/")) {
+                if (config.getMantaUser().contains(SEPARATOR)) {
                     String msg = String.format("This fails due to an outstanding bug: MANTA-2839.\n%s",
                             errorText);
                     throw new SkipException(msg);

--- a/java-manta-it/src/test/java/com/joyent/manta/config/IntegrationTestConfigContext.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/config/IntegrationTestConfigContext.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.util.Base64;
 import java.util.UUID;
 
+import static com.joyent.manta.client.MantaClient.SEPARATOR;
+
 
 /**
  * {@link ConfigContext} implementation that loads
@@ -123,7 +125,7 @@ public class IntegrationTestConfigContext extends SystemSettingsConfigContext {
 
 
     public static String generateBasePath(final ConfigContext config, final String testBaseName) {
-        return generateSuiteBasePath(config) + testBaseName + "/";
+        return generateSuiteBasePath(config) + testBaseName + SEPARATOR;
     }
 
     public static void cleanupTestDirectory(final MantaClient mantaClient, final String testPathPrefix) throws IOException {


### PR DESCRIPTION
Consistency for our usage of the constant ```MantaClient.SEPARATOR```. Refer [Issue#363](https://github.com/joyent/java-manta/issues/363)