### PR TITLE
Prune-Depth Config Documentation, Added Unit Tests for Different Limits

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -575,9 +575,12 @@ When `manta.prune_empty_parent_depth`/`MANTA_PRUNE_EMPTY_PARENT_DEPTH` is set to
    /Dir1
    /Dir1/Dir2
    /Dir1/Dir2/Dir3
-   /Dir1/Dir2/Dir3/test.txt
-   If you have prune_empty_parent_depth set to 1 then delete test.txt, the client should delete Dir3 as well.
- 
+   /Dir1/Dir2/Dir3/Dir4
+   /Dir1/Dir2/Dir3/Dir4/test.txt
+   If you have prune_empty_parent_depth set to 1 then delete test.txt, the client should delete Dir4 as well.
+   If you have prune_empty_parent_depth set to 2 the client should delete Dir3, with the directories and file in the previous case.
+   If you have prune_empty_parent_depth set to 3 the client should delete Dir2, with the directories and file cumulatively included from the previous cases.
+   If you have prune_empty_parent_depth set to 4 the client should delete Dir1, with the directories and file cumulatively included from the previous cases. 
 #### Scenario 2 : Prune Empty Parent Depth -1
 - Given the directory structure : 
    /Dir1

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/PruneEmptyParentDirectoryStrategyTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/PruneEmptyParentDirectoryStrategyTest.java
@@ -162,6 +162,31 @@ public class PruneEmptyParentDirectoryStrategyTest {
         Mockito.verifyNoMoreInteractions(clientSpy);
     }
 
+    public void canPruneEmptyDirectoriesWithLimitThree() throws IOException {
+        final MantaClient clientSpy = spy(client);
+        final MantaHttpHeaders headers = new MantaHttpHeaders();
+        final String path = "/user/stor/dir1/dir2/dir3/object.txt";
+        final int limit = 3;
+
+        // Prevent the client from actually calling out to a real Manta
+        Mockito.doNothing().when(clientSpy)
+                .delete(startsWith("/user/stor"), any(MantaHttpHeaders.class), isNull());
+
+        pruneParentDirectories(clientSpy, headers, path, limit);
+
+        Mockito.verify(clientSpy, times(1))
+                .delete(path, headers, null);
+        Mockito.verify(clientSpy, times(1))
+                .delete("/user/stor/dir1/dir2/dir3", headers, null);
+        Mockito.verify(clientSpy, times(1))
+                .delete("/user/stor/dir1/dir2", headers, null);
+        Mockito.verify(clientSpy, times(1))
+                .delete("/user/stor/dir1", headers, null);
+
+        // Verify that is the only call that we made
+        Mockito.verifyNoMoreInteractions(clientSpy);
+    }
+
     public void canPruneEmptyDirectoriesWithLimitFour() throws IOException {
         final MantaClient clientSpy = spy(client);
         final MantaHttpHeaders headers = new MantaHttpHeaders();

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/PruneEmptyParentDirectoryStrategyTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/PruneEmptyParentDirectoryStrategyTest.java
@@ -146,7 +146,6 @@ public class PruneEmptyParentDirectoryStrategyTest {
         final int limit = 2;
 
         // Prevent the client from actually calling out to a real Manta
-        // Prevent the client from actually calling out to a real Manta
         Mockito.doNothing().when(clientSpy)
                 .delete(startsWith("/user/stor"), any(MantaHttpHeaders.class), isNull());
 
@@ -163,13 +162,39 @@ public class PruneEmptyParentDirectoryStrategyTest {
         Mockito.verifyNoMoreInteractions(clientSpy);
     }
 
+    public void canPruneEmptyDirectoriesWithLimitFour() throws IOException {
+        final MantaClient clientSpy = spy(client);
+        final MantaHttpHeaders headers = new MantaHttpHeaders();
+        final String path = "/user/stor/dir1/dir2/dir3/dir4/object.txt";
+        final int limit = 4;
+
+        // Prevent the client from actually calling out to a real Manta
+        Mockito.doNothing().when(clientSpy)
+                .delete(startsWith("/user/stor"), any(MantaHttpHeaders.class), isNull());
+
+        pruneParentDirectories(clientSpy, headers, path, limit);
+
+        Mockito.verify(clientSpy, times(1))
+                .delete(path, headers, null);
+        Mockito.verify(clientSpy, times(1))
+                .delete("/user/stor/dir1/dir2/dir3/dir4", headers, null);
+        Mockito.verify(clientSpy, times(1))
+                .delete("/user/stor/dir1/dir2/dir3", headers, null);
+        Mockito.verify(clientSpy, times(1))
+                .delete("/user/stor/dir1/dir2", headers, null);
+        Mockito.verify(clientSpy, times(1))
+                .delete("/user/stor/dir1", headers, null);
+
+        // Verify that is the only call that we made
+        Mockito.verifyNoMoreInteractions(clientSpy);
+    }
+
     public void verifyThatPruneEmptyDirectoriesWontPruneBelowStorRoot() throws IOException {
         final MantaClient clientSpy = spy(client);
         final MantaHttpHeaders headers = new MantaHttpHeaders();
         final String path = "/user/stor/dir1/dir2/object.txt";
         final int limit = 3;
 
-        // Prevent the client from actually calling out to a real Manta
         // Prevent the client from actually calling out to a real Manta
         Mockito.doNothing().when(clientSpy)
                 .delete(startsWith("/user/stor"), any(MantaHttpHeaders.class), isNull());


### PR DESCRIPTION
Configuration Parameters for ```prune_empty_parent_depth```, which are functionally simple to describe, seem to be really difficult to communicate about when specific cases are concerned. This just emphasizes the need to make certain documentation changes and adding a few unit tests for better interpretation of the setting.