### PR TITLE
Defining HeavyWeight and Other Test Groups

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,44 @@
+# Configuration Parameter Contributions
+
+This is a brief guide for developers interested in making open-source contributions to the configuration parameters for 
+java-manta. [Java-Manta]((http://joyent.github.com/java-manta)) is a community-maintained Java SDK for interacting with 
+Joyent's Manta object storage system.
+
+### Recommended Prerequisite References
+ - [Using The SDK](https://github.com/joyent/java-manta#usage)
+ - [Contributing to Java-Manta](https://github.com/joyent/java-manta/blob/master/CONTRIBUTING.md)
+ - [Configuration Documentation](https://github.com/joyent/java-manta/blob/master/USAGE.md#configuration)
+ - [General Examples](https://github.com/joyent/java-manta#general-examples)
+ 
+### Adding a Configuration Parameter to the SDK
+
+Configuration parameters allow users to flexibly leverage SDK features to match their performance, authentication, 
+and encryption requirements.
+
+To submit a new configuration parameter to the Java-Manta SDK:
+ - Determine the nature of the new parameter. Consider basic design decisions such as conditions that govern its use, 
+  its datatype, etc.
+   - For example, if the new configuration parameter is a ```Boolean```, find the line ```Boolean isClientEncryptionEnabled();```
+     in [ConfigContext](https://github.com/joyent/java-manta/blob/master/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/ConfigContext.java). 
+     Use that section of code as a template to implement the new configuration variable.
+
+ - Add a method in [SettableConfigContext](https://github.com/joyent/java-manta/blob/master/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/SettableConfigContext.java) 
+  and imitate the pre-existing implementations in the class. Include additions to detailed information in the JavaDocs.
+
+ - Add keys for constants in [MapConfigContext](https://github.com/joyent/java-manta/blob/master/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/MapConfigContext.java) and [EnvVarConfigContext](https://github.com/joyent/java-manta/blob/master/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/EnvVarConfigContext.java). 
+  Include an implementation for the required interface methods.
+
+ - Add a default setting in [DefaultsConfigContext](https://github.com/joyent/java-manta/blob/master/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/DefaultsConfigContext.java). This determines a default value for the parameter when none is provided 
+  via command line or environment variable.
+
+ - Add code to the methods `overwriteWithContext()` and `overwriteWithDefaultContext()` in [BaseChainedConfigContext](https://github.com/joyent/java-manta/blob/master/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/SettableConfigContext.java) 
+  to ensure the overwrite behavior works correctly.
+  
+ - Update the test file [ChainedConfigContextTest](https://github.com/joyent/java-manta/blob/master/java-manta-client-unshaded/src/test/java/com/joyent/manta/config/ChainedConfigContextTest.java) to verify the behavior for the added parameter.
+  
+ - Update [USAGE.md](https://github.com/joyent/java-manta/blob/master/USAGE.md#configuration) to include the new configuration parameter and to add clear instructions on how to use it.
+
+ - Add information about the new parameter in the [CHANGELOG.md](https://github.com/joyent/java-manta/blob/master/CHANGELOG.md).
+
+
+ Note: [Adding a new configuration parameter manta.content_type_detection](https://github.com/joyent/java-manta/pull/494) can help developers find and edit the appropriate classes.

--- a/README.md
+++ b/README.md
@@ -98,9 +98,15 @@ Known edge cases and other topics are covered in [the FAQ](/FAQ.md).
 Contributions are welcome! Please read the [CONTRIBUTING.md](/CONTRIBUTING.md) document for details
 on getting started.
 
+## Developing
+
+There are portions of the SDK that are somewhat complex or fiddly. Please read the [DEVELOPING.md](/DEVELOPING.md) 
+document for details, before developing the Java SDK.
+
 ### Testing
 
-Please refer to the [testing documentation](/TESTING.md).
+Contributing developers are strongly encouraged to add unit-tests and integration-tests. Refer to the [testing documentation](/TESTING.md)
+for information on full test suite requirements.
 
 ### Releasing
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -64,6 +64,17 @@ possible torun a subset of the test suite by adding
 mvn test -DexcludedGroups=unlimited-crypto
 ```
 
+## Dry run
+	
+It's possible to print a list of which integration tests would run and their relevant
+parameters using the following invocation:
+	
+```
+mvn verify -Dit.dryrun=true
+```
+	
+Note: This has not yet been expanded to unit tests.
+	
 # Writing Tests
 
 The `java-manta-client` module contains unit tests. Integration tests generally

--- a/TESTING.md
+++ b/TESTING.md
@@ -66,8 +66,8 @@ mvn test -DexcludedGroups=unlimited-crypto
 
 ## Dry run
 	
-It's possible to print a list of which integration tests would run and their relevant
-parameters using the following invocation:
+The following invocation will print a list of which integration tests would run and their relevant
+parameters::
 	
 ```
 mvn verify -Dit.dryrun=true

--- a/TESTING.md
+++ b/TESTING.md
@@ -70,7 +70,7 @@ The following invocation will print a list of which integration tests would run 
 parameters::
 	
 ```
-mvn verify -Dit.dryrun=true
+mvn verify -Dit.dryRun=true
 ```
 	
 Note: This has not yet been expanded to unit tests.

--- a/java-manta-benchmark/src/main/java/com/joyent/manta/benchmark/Benchmark.java
+++ b/java-manta-benchmark/src/main/java/com/joyent/manta/benchmark/Benchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2016-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -45,6 +45,7 @@ import java.util.stream.Stream;
  * Manta performance from the command line.
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
 public final class Benchmark {
     /**
@@ -71,6 +72,16 @@ public final class Benchmark {
      * Time to wait until checking to see if a thread pool has finished.
      */
     private static final long CHECK_INTERVAL = Duration.ofSeconds(1).getSeconds();
+
+    /**
+     * String value for name of a put operation performed by client.
+     */
+    private static final String METHOD_PUT = "put";
+
+    /**
+     * String value for name of a put-directory operation from client.
+     */
+    private static final String METHOD_PUT_DIR = "putDir";
 
     /**
      * Manta client library.
@@ -179,6 +190,7 @@ public final class Benchmark {
      * @param iterations number of iterations to run
      * @throws IOException thrown when we can't communicate with the server
      */
+    @SuppressWarnings("Duplicates")
     private static void singleThreadedBenchmark(final String method,
                                                 final String path,
                                                 final int iterations) throws IOException {
@@ -192,9 +204,9 @@ public final class Benchmark {
         for (int i = 0; i < iterations; i++) {
             Duration[] durations;
 
-            if (method.equals("put")) {
+            if (method.equals(METHOD_PUT)) {
                 durations = measurePut(sizeInBytesOrNoOfDirs);
-            } else if (method.equals("putDir")) {
+            } else if (method.equals(METHOD_PUT_DIR)) {
                 durations = measurePutDir(sizeInBytesOrNoOfDirs);
             } else {
                 durations = measureGet(path);
@@ -231,6 +243,7 @@ public final class Benchmark {
      * @param iterations number of iterations to run
      * @param concurrency number of threads to run
      */
+    @SuppressWarnings("Duplicates")
     private static void multithreadedBenchmark(final String method,
                                                final String path,
                                                final int iterations,
@@ -250,9 +263,9 @@ public final class Benchmark {
             for (int i = 0; i < perThreadCount; i++) {
                 Duration[] durations;
 
-                if (method.equals("put")) {
+                if (method.equals(METHOD_PUT)) {
                     durations = measurePut(sizeInBytesOrNoOfDirs);
-                } else if (method.equals("putDir")) {
+                } else if (method.equals(METHOD_PUT_DIR)) {
                     durations = measurePutDir(sizeInBytesOrNoOfDirs);
                 } else {
                     durations = measureGet(path);

--- a/java-manta-benchmark/src/main/java/com/joyent/manta/benchmark/Benchmark.java
+++ b/java-manta-benchmark/src/main/java/com/joyent/manta/benchmark/Benchmark.java
@@ -45,7 +45,6 @@ import java.util.stream.Stream;
  * Manta performance from the command line.
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
- * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
 public final class Benchmark {
     /**

--- a/java-manta-client-kryo-serialization/src/test/resources/testng.xml
+++ b/java-manta-client-kryo-serialization/src/test/resources/testng.xml
@@ -1,8 +1,23 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite name="Kryo Serialization Test Suite" verbose="1">
     <test name="Serializer Tests">
+        <groups>
+            <define name="serializer" />
+            <run>
+                <exclude name="unlimited-crypto" />
+            </run>
+        </groups>
         <packages>
             <package name="com.joyent.manta.serialization.*" />
         </packages>
+    </test>
+    <test name="Encryption Cipher Tests">
+        <parameter name="usingEncryption" value="true" />
+        <groups>
+            <define name="unlimited-crypto" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.serialization.CipherSerializerTest" />
+        </classes>
     </test>
 </suite>

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaMetadata.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2015-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -171,8 +171,8 @@ public class MantaMetadata implements Map<String, String>, Cloneable, Serializab
     }
 
     @Override
-    public boolean equals(final Object object) {
-        return (object instanceof Map) && innerMap.equals(object);
+    public boolean equals(final Object o) {
+        return (o instanceof Map) && innerMap.equals(o);
     }
 
     @Override

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaMetadata.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaMetadata.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -35,6 +36,7 @@ import java.util.function.Function;
  * <p>This class is NOT thread-safe.</p>
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
 @NotThreadSafe
 public class MantaMetadata implements Map<String, String>, Cloneable, Serializable {
@@ -172,7 +174,15 @@ public class MantaMetadata implements Map<String, String>, Cloneable, Serializab
 
     @Override
     public boolean equals(final Object o) {
-        return (o instanceof Map) && innerMap.equals(o);
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Map)) {
+            return false;
+        }
+
+        final Map that = (Map) o;
+        return Objects.equals(innerMap, that);
     }
 
     @Override

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaObjectResponse.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaObjectResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2013-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -26,6 +26,7 @@ import static com.joyent.manta.http.MantaHttpHeaders.COMPUTED_MD5;
  * <p>I/O is performed via the methods on the {@link MantaClient} class.</p>
  *
  * @author <a href="https://github.com/yunong">Yunong Xiao</a>
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
 public class MantaObjectResponse implements MantaObject {
 
@@ -339,7 +340,7 @@ public class MantaObjectResponse implements MantaObject {
             return true;
         }
         if (o instanceof MantaObjectResponse) {
-            MantaObjectResponse that = (MantaObjectResponse)o;
+            final MantaObjectResponse that = (MantaObjectResponse)o;
             return Objects.equals(path, that.path)
                     && Objects.equals(getContentLength(), that.getContentLength())
                     && Objects.equals(getContentType(), that.getContentType())
@@ -347,7 +348,7 @@ public class MantaObjectResponse implements MantaObject {
                     && Objects.equals(getMtime(), that.getMtime())
                     && Objects.equals(httpHeaders, that.httpHeaders);
         } else if (o instanceof MantaObject) {
-            MantaObject that = (MantaObject)o;
+            final MantaObject that = (MantaObject)o;
             return Objects.equals(getContentLength(), that.getContentLength())
                     && Objects.equals(getContentType(), that.getContentType())
                     && Objects.equals(getEtag(), that.getEtag())

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/AbstractAesCipherDetails.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/AbstractAesCipherDetails.java
@@ -285,8 +285,7 @@ public abstract class AbstractAesCipherDetails implements SupportedCipherDetails
             return false;
         }
 
-        AbstractAesCipherDetails that = (AbstractAesCipherDetails)o;
-
+        final AbstractAesCipherDetails that = (AbstractAesCipherDetails)o;
         return authenticationTagOrHmacLength == that.authenticationTagOrHmacLength
                 && keyLengthBits == that.keyLengthBits
                 && isAEADCipher == that.isAEADCipher

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/AesCbcCipherDetails.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/AesCbcCipherDetails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -121,8 +121,8 @@ public final class AesCbcCipherDetails extends AbstractAesCipherDetails {
 
         // CBC requires an IV an extra block for chaining to work
         if (!hasIV && plaintextSize >= blockBytes) {
-            final double blocks = Math.floor(plaintextSize / ((long) blockBytes));
-            calculatedContentLength = (((long)blocks + 1) * blockBytes);
+            final long blocks = Math.floorDiv(plaintextSize, ((long) blockBytes));
+            calculatedContentLength = ((blocks + 1) * blockBytes);
         }
 
         // Append tag or hmac to the end of the stream

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/EncryptionContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/EncryptionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/EncryptionContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/EncryptionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -135,6 +135,7 @@ public class EncryptionContext {
      * the cipher is ready to be used to encrypt.
      * @param suppliedIv IV to use in case of a retry or test case, null indicates we should generate one
      */
+    @SuppressWarnings({"Duplicates"})
     private void initializeCipher(final byte[] suppliedIv) {
         try {
             final byte[] iv;
@@ -162,13 +163,11 @@ public class EncryptionContext {
         if (this == o) {
             return true;
         }
-
         if (!(o instanceof EncryptionContext)) {
             return false;
         }
 
         final EncryptionContext that = (EncryptionContext) o;
-
         return Objects.equals(key, that.key)
                && Objects.equals(cipherDetails, that.cipherDetails)
                && requireCloneableCipher == that.requireCloneableCipher;

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/EncryptionType.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/EncryptionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -81,6 +81,7 @@ public final class EncryptionType {
      * @param encryptionType string of encryption type and version to parse and validate
      * @throws MantaEncryptionException when encryption type can't be validated
      */
+    @SuppressWarnings({"Duplicates"})
     public static void validateEncryptionTypeIsSupported(final String encryptionType) {
         if (encryptionType == null) {
             String msg = "Invalid encryption type identifier must not be null";
@@ -156,7 +157,6 @@ public final class EncryptionType {
         }
 
         final EncryptionType that = (EncryptionType) o;
-
         return minVersionSupported == that.minVersionSupported
             && maxVersionSupported == that.maxVersionSupported
             && Objects.equals(name, that.name);

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/EncryptionType.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/EncryptionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/jobs/MantaJob.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/jobs/MantaJob.java
@@ -242,12 +242,11 @@ public class MantaJob {
         if (this == o) {
             return true;
         }
-
         if (!(o instanceof MantaJob)) {
             return false;
         }
 
-        MantaJob mantaJob = (MantaJob) o;
+        final MantaJob mantaJob = (MantaJob) o;
         return Objects.equals(id, mantaJob.id)
                 && Objects.equals(name, mantaJob.name)
                 && Objects.equals(state, mantaJob.state)

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/jobs/MantaJob.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/jobs/MantaJob.java
@@ -238,16 +238,16 @@ public class MantaJob {
     }
 
     @Override
-    public boolean equals(final Object that) {
-        if (this == that) {
+    public boolean equals(final Object o) {
+        if (this == o) {
             return true;
         }
 
-        if (!(that instanceof MantaJob)) {
+        if (!(o instanceof MantaJob)) {
             return false;
         }
 
-        MantaJob mantaJob = (MantaJob) that;
+        MantaJob mantaJob = (MantaJob) o;
         return Objects.equals(id, mantaJob.id)
                 && Objects.equals(name, mantaJob.name)
                 && Objects.equals(state, mantaJob.state)

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/jobs/MantaJob.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/jobs/MantaJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2015-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/jobs/MantaJobError.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/jobs/MantaJobError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2015-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -130,15 +130,15 @@ public class MantaJobError {
     }
 
     @Override
-    public boolean equals(final Object other) {
-        if (this == other) {
+    public boolean equals(final Object o) {
+        if (this == o) {
             return true;
         }
-        if (!(other instanceof MantaJobError)) {
+        if (!(o instanceof MantaJobError)) {
             return false;
         }
 
-        MantaJobError that = (MantaJobError) other;
+        MantaJobError that = (MantaJobError) o;
         return phase == that.phase
                 && Objects.equals(what, that.what)
                 && Objects.equals(p0input, that.p0input)

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/jobs/MantaJobError.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/jobs/MantaJobError.java
@@ -138,7 +138,7 @@ public class MantaJobError {
             return false;
         }
 
-        MantaJobError that = (MantaJobError) o;
+        final MantaJobError that = (MantaJobError) o;
         return phase == that.phase
                 && Objects.equals(what, that.what)
                 && Objects.equals(p0input, that.p0input)

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/jobs/MantaJobPhase.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/jobs/MantaJobPhase.java
@@ -198,14 +198,14 @@ public class MantaJobPhase {
     }
 
     @Override
-    public boolean equals(final Object other) {
-        if (this == other) {
+    public boolean equals(final Object o) {
+        if (this == o) {
             return true;
         }
-        if (!(other instanceof MantaJobPhase)) {
+        if (!(o instanceof MantaJobPhase)) {
             return false;
         }
-        MantaJobPhase that = (MantaJobPhase) other;
+        MantaJobPhase that = (MantaJobPhase) o;
         return Objects.equals(assets, that.assets)
                 && Objects.equals(exec, that.exec)
                 && Objects.equals(type, that.type)

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/jobs/MantaJobPhase.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/jobs/MantaJobPhase.java
@@ -205,7 +205,8 @@ public class MantaJobPhase {
         if (!(o instanceof MantaJobPhase)) {
             return false;
         }
-        MantaJobPhase that = (MantaJobPhase) o;
+
+        final MantaJobPhase that = (MantaJobPhase) o;
         return Objects.equals(assets, that.assets)
                 && Objects.equals(exec, that.exec)
                 && Objects.equals(type, that.type)

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/jobs/MantaJobPhase.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/jobs/MantaJobPhase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2015-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/multipart/AbstractMultipartUpload.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/multipart/AbstractMultipartUpload.java
@@ -52,13 +52,11 @@ public abstract class AbstractMultipartUpload implements MantaMultipartUpload {
         if (this == o) {
             return true;
         }
-
         if (!(o instanceof AbstractMultipartUpload)) {
             return false;
         }
 
         final MantaMultipartUpload that = (MantaMultipartUpload) o;
-
         return Objects.equals(id, that.getId())
             && Objects.equals(path, that.getPath());
     }

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/multipart/EncryptedMultipartUpload.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/multipart/EncryptedMultipartUpload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -112,13 +112,11 @@ public class EncryptedMultipartUpload<WRAPPED extends MantaMultipartUpload>
         if (this == o) {
             return true;
         }
-
         if (!(o instanceof EncryptedMultipartUpload)) {
             return false;
         }
 
         final EncryptedMultipartUpload<?> that = (EncryptedMultipartUpload<?>) o;
-
         return Objects.equals(wrapped, that.wrapped);
     }
 

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/multipart/EncryptedMultipartUpload.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/multipart/EncryptedMultipartUpload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/multipart/EncryptionState.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/multipart/EncryptionState.java
@@ -171,13 +171,11 @@ public class EncryptionState {
         if (this == o) {
             return true;
         }
-
         if (!(o instanceof EncryptionState)) {
             return false;
         }
 
         final EncryptionState that = (EncryptionState) o;
-
         return lastPartNumber == that.lastPartNumber
             && lastPartAuthWritten == that.lastPartAuthWritten
             && Objects.equals(encryptionContext, that.encryptionContext);

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/multipart/EncryptionStateSnapshot.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/multipart/EncryptionStateSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -100,7 +100,6 @@ class EncryptionStateSnapshot {
         if (this == o) {
             return true;
         }
-
         if (!(o instanceof EncryptionStateSnapshot)) {
             return false;
         }

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/multipart/MantaMultipartUploadTuple.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/multipart/MantaMultipartUploadTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2016-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -78,16 +78,16 @@ public class MantaMultipartUploadTuple implements Serializable,
     }
 
     @Override
-    public boolean equals(final Object that) {
-        if (this == that) {
+    public boolean equals(final Object o) {
+        if (this == o) {
             return true;
         }
 
-        if (!(that instanceof MantaMultipartUploadTuple)) {
+        if (!(o instanceof MantaMultipartUploadTuple)) {
             return false;
         }
 
-        MantaMultipartUploadTuple tuple = (MantaMultipartUploadTuple) that;
+        MantaMultipartUploadTuple tuple = (MantaMultipartUploadTuple) o;
         return partNumber == tuple.partNumber
                 && Objects.equals(etag, tuple.etag);
     }

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/multipart/MantaMultipartUploadTuple.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/multipart/MantaMultipartUploadTuple.java
@@ -82,13 +82,12 @@ public class MantaMultipartUploadTuple implements Serializable,
         if (this == o) {
             return true;
         }
-
         if (!(o instanceof MantaMultipartUploadTuple)) {
             return false;
         }
 
-        MantaMultipartUploadTuple tuple = (MantaMultipartUploadTuple) o;
-        return partNumber == tuple.partNumber
+        final MantaMultipartUploadTuple tuple = (MantaMultipartUploadTuple) o;
+        return Objects.equals(partNumber, tuple.partNumber)
                 && Objects.equals(etag, tuple.etag);
     }
 

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/multipart/ServerSideMultipartUpload.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/multipart/ServerSideMultipartUpload.java
@@ -61,8 +61,7 @@ public class ServerSideMultipartUpload extends AbstractMultipartUpload {
             return false;
         }
 
-        ServerSideMultipartUpload that = (ServerSideMultipartUpload)o;
-
+        final ServerSideMultipartUpload that = (ServerSideMultipartUpload)o;
         return Objects.equals(partsDirectory, that.partsDirectory);
     }
 

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/multipart/ServerSideMultipartUpload.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/multipart/ServerSideMultipartUpload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/BaseChainedConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/BaseChainedConfigContext.java
@@ -958,16 +958,16 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
     }
 
     @Override
-    public boolean equals(final Object other) {
-        if (this == other) {
+    public boolean equals(final Object o) {
+        if (this == o) {
             return true;
         }
 
-        if (!(other instanceof BaseChainedConfigContext)) {
+        if (!(o instanceof BaseChainedConfigContext)) {
             return false;
         }
 
-        BaseChainedConfigContext that = (BaseChainedConfigContext) other;
+        BaseChainedConfigContext that = (BaseChainedConfigContext) o;
         return Objects.equals(mantaURL, that.mantaURL)
                 && Objects.equals(account, that.account)
                 && Objects.equals(mantaKeyId, that.mantaKeyId)

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/BaseChainedConfigContext.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/config/BaseChainedConfigContext.java
@@ -962,12 +962,11 @@ public abstract class BaseChainedConfigContext implements SettableConfigContext<
         if (this == o) {
             return true;
         }
-
         if (!(o instanceof BaseChainedConfigContext)) {
             return false;
         }
 
-        BaseChainedConfigContext that = (BaseChainedConfigContext) o;
+        final BaseChainedConfigContext that = (BaseChainedConfigContext) o;
         return Objects.equals(mantaURL, that.mantaURL)
                 && Objects.equals(account, that.account)
                 && Objects.equals(mantaKeyId, that.mantaKeyId)

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/domain/ErrorDetail.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/domain/ErrorDetail.java
@@ -126,13 +126,11 @@ public class ErrorDetail implements Entity {
         if (this == o) {
             return true;
         }
-
         if (!(o instanceof ErrorDetail)) {
             return false;
         }
 
         final ErrorDetail that = (ErrorDetail) o;
-
         return Objects.equals(code, that.code)
                 && Objects.equals(message, that.message)
                 && Objects.equals(errors, that.errors);

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/exception/MantaErrorCode.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/exception/MantaErrorCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2015-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * @see <a href="https://apidocs.joyent.com/manta/api.html#errors">Manta Errors</a>
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
 @SuppressWarnings("checkstyle:JavadocVariable")
 public enum MantaErrorCode {
@@ -89,6 +90,7 @@ public enum MantaErrorCode {
     ROOT_DIRECTORY_ERROR("RootDirectory"),
     SECURE_TRANSPORT_REQUIRED_ERROR("SecureTransportRequired"),
     SERVICE_UNAVAILABLE_ERROR("ServiceUnavailable"),
+    SNAPLINKS_DISABLED_ERROR("SnaplinksDisabledError"),
     SOURCE_OBJECT_NOT_FOUND_ERROR("SourceObjectNotFound"),
     SSL_REQUIRED_ERROR("SSLRequired"),
     UPLOAD_ABANDONED_ERROR("UploadAbandoned"),

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/HttpRange.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/HttpRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2018-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/HttpRange.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/HttpRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -8,7 +8,6 @@
 package com.joyent.manta.http;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.http.ProtocolException;
 
 import java.util.Objects;
@@ -20,6 +19,7 @@ import static org.apache.commons.lang3.Validate.notNull;
  * <a href="https://tools.ietf.org/html/rfc7233#section-4.2">Content-Range</a> headers.
  *
  * @author <a href="https://github.com/tjcelaya">Tomas Celaya</a>
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  * @since 3.2.2
  */
 public abstract class HttpRange {
@@ -309,18 +309,14 @@ public abstract class HttpRange {
         if (this == o) {
             return true;
         }
-
         if (!(o instanceof HttpRange)) {
             return false;
         }
 
         final HttpRange that = (HttpRange) o;
-
-        return new EqualsBuilder()
-                .append(this.startInclusive, that.startInclusive)
-                .append(this.endInclusive, that.endInclusive)
-                .append(this.size, that.size)
-                .build();
+        return startInclusive == that.startInclusive
+                && Objects.equals(this.endInclusive, that.endInclusive)
+                && Objects.equals(this.size, that.size);
     }
 
     @Override

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/PlaintextByteRangePosition.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/PlaintextByteRangePosition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/PlaintextByteRangePosition.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/http/PlaintextByteRangePosition.java
@@ -88,12 +88,11 @@ class PlaintextByteRangePosition {
         if (this == o) {
             return true;
         }
-
         if (!(o instanceof PlaintextByteRangePosition)) {
             return false;
         }
 
-        PlaintextByteRangePosition that = (PlaintextByteRangePosition) o;
+        final PlaintextByteRangePosition that = (PlaintextByteRangePosition) o;
         return initialPlaintextSkipBytes == that.initialPlaintextSkipBytes
                 && plaintextRangeLength == that.plaintextRangeLength
                 && plaintextStart == that.plaintextStart

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/util/ConcurrentWeakIdentityHashMap.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/util/ConcurrentWeakIdentityHashMap.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ConcurrentMap;
  *
  * @see <a href="https://github.com/ehcache/ehcache3/blob/351a49a45afbf18c48df665210b5cf07f5e7b221/core/src/main/java/org/ehcache/core/internal/util/ConcurrentWeakIdentityHashMap.java">github page of source</a>
  * @author Alex Snaps
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
 @SuppressWarnings("EqualsGetClass")
 public class ConcurrentWeakIdentityHashMap<K, V> implements ConcurrentMap<K, V> {
@@ -204,7 +205,14 @@ public class ConcurrentWeakIdentityHashMap<K, V> implements ConcurrentMap<K, V> 
 
         @Override
         public boolean equals(final Object o) {
-            return o != null && o.getClass() == this.getClass() && (this == o || this.get() == ((WeakReference)o).get());
+            if (o != null) if (o.getClass() == this.getClass()) {
+                if (this == o) {
+                    return true;
+                }
+                final WeakReference that = (WeakReference) o;
+                return this.get() == that.get();
+            }
+            return false;
         }
 
         @Override

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/util/ConcurrentWeakIdentityHashMap.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/util/ConcurrentWeakIdentityHashMap.java
@@ -203,8 +203,8 @@ public class ConcurrentWeakIdentityHashMap<K, V> implements ConcurrentMap<K, V> 
         }
 
         @Override
-        public boolean equals(final Object obj) {
-            return obj != null && obj.getClass() == this.getClass() && (this == obj || this.get() == ((WeakReference)obj).get());
+        public boolean equals(final Object o) {
+            return o != null && o.getClass() == this.getClass() && (this == o || this.get() == ((WeakReference)o).get());
         }
 
         @Override

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/util/LookupMap.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/util/LookupMap.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -81,6 +82,13 @@ public class LookupMap<K extends String, V> implements Map<K, V>  {
                || map.getClass().getName().equals(APACHE_UNMODIFIABLE_MAP)
                || map.getClass().getName().equals(IMMUTABLE_MAP)
                || map instanceof UnmodifiableMap;
+    }
+
+    /**
+     * @return the key set all in lowercase.
+     */
+    public Set<K> lowercaseKeySet() {
+        return this.lowercaseWrapped.keySet();
     }
 
     /**
@@ -162,9 +170,16 @@ public class LookupMap<K extends String, V> implements Map<K, V>  {
     }
 
     @Override
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(final Object o) {
-        return wrapped.equals(o);
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Map)) {
+            return false;
+        }
+
+        final Map that = (Map) o;
+        return Objects.equals(wrapped, that);
     }
 
     @Override

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/util/LookupMap.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/util/LookupMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -26,6 +26,7 @@ import java.util.function.Function;
  * @param <V> value to be looking up
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  * @since 3.0.0
  */
 public class LookupMap<K extends String, V> implements Map<K, V>  {
@@ -39,6 +40,21 @@ public class LookupMap<K extends String, V> implements Map<K, V>  {
      * Wrapped unmodifiable case-insensitive instance providing data.
      */
     private final CaseInsensitiveMap<K, V> lowercaseWrapped;
+
+    /**
+     * Class name for unmodifiable maps in Java Utils.
+     */
+    private static final String JAVA_UNMODIFIABLE_MAP = "java.util.Collections$UnmodifiableMap";
+
+    /**
+     * Class name for unmodifiable maps in Apache Collections.
+     */
+    private static final String APACHE_UNMODIFIABLE_MAP = "org.apache.commons.collections4.map.UnmodifiableMap";
+
+    /**
+     * Class name for immutable maps in Google Collections.
+     */
+    private static final String IMMUTABLE_MAP = "com.google.common.collect.ImmutableMap";
 
     /**
      * Creates a new instance of a lookup map backed by the specified map.
@@ -61,17 +77,10 @@ public class LookupMap<K extends String, V> implements Map<K, V>  {
      * @return true if unmodifiable
      */
     private boolean isUnmodifiable(final Map<K, V> map) {
-        return map.getClass().getName().equals("java.util.Collections$UnmodifiableMap")
-               || map.getClass().getName().equals("org.apache.commons.collections4.map.UnmodifiableMap")
-               || map.getClass().getName().equals("com.google.common.collect.ImmutableMap")
+        return map.getClass().getName().equals(JAVA_UNMODIFIABLE_MAP)
+               || map.getClass().getName().equals(APACHE_UNMODIFIABLE_MAP)
+               || map.getClass().getName().equals(IMMUTABLE_MAP)
                || map instanceof UnmodifiableMap;
-    }
-
-    /**
-     * @return the key set all in lowercase.
-     */
-    public Set<K> lowercaseKeySet() {
-        return this.lowercaseWrapped.keySet();
     }
 
     /**

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/util/LookupMap.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/util/LookupMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/MetricReporterSupplierTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/MetricReporterSupplierTest.java
@@ -32,7 +32,7 @@ public class MetricReporterSupplierTest {
         Assert.assertThrows(NullPointerException.class, () -> new MetricReporterSupplier(null));
     }
 
-    public void createsAndStartsJmxReporter() throws MalformedObjectNameException, InterruptedException {
+    public void createsAndStartsJmxReporter() throws MalformedObjectNameException {
         final UUID clientId = UUID.randomUUID();
         final MetricRegistry registry = new MetricRegistry();
         registry.meter(METRIC_NAME_RETRIES);
@@ -50,6 +50,7 @@ public class MetricReporterSupplierTest {
 
         assertFalse(platformMBeanServer.isRegistered(buildObjectName(clientId, METRIC_NAME_RETRIES)));
     }
+
     public void createsAndStartsSlf4jReporter() {
         final MantaClientMetricConfiguration metricConfig = new MantaClientMetricConfiguration(UUID.randomUUID(), new MetricRegistry(), MetricReporterMode.SLF4J, 1000);
         final Closeable jmxReporter = new MetricReporterSupplier(metricConfig).get();
@@ -58,6 +59,8 @@ public class MetricReporterSupplierTest {
         final Slf4jReporter reporter = (Slf4jReporter) jmxReporter;
         reporter.close();
     }
+
+    // TEST UTILITY METHOD
 
     private ObjectName buildObjectName(final UUID clientId, final String beanName) throws MalformedObjectNameException {
         return new ObjectName(String.format(MantaClientAgent.FMT_MBEAN_OBJECT_NAME, beanName, clientId));

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/crypto/SupportedCiphersLookupMapTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/crypto/SupportedCiphersLookupMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -15,6 +15,7 @@ import java.security.Provider;
 import java.util.List;
 
 import static com.joyent.manta.client.crypto.SupportedCiphersLookupMap.INSTANCE;
+import static com.joyent.manta.client.crypto.ExternalSecurityProviderLoader.PKCS11_PROVIDER_NAME;
 
 @SuppressWarnings("BadImport")
 @Test
@@ -51,7 +52,7 @@ public class SupportedCiphersLookupMapTest {
             for (SupportedCipherDetails cipherDetails : INSTANCE.values()) {
                 /* Libnss doesn't support accessing GCM, so we are not able to
                  * use from that provider. */
-                if (provider.getName().equals("SunPKCS11-NSS") && cipherDetails instanceof AesGcmCipherDetails) {
+                if (provider.getName().equals(PKCS11_PROVIDER_NAME) && cipherDetails instanceof AesGcmCipherDetails) {
                     continue;
                 }
 

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/crypto/SupportedCiphersLookupMapTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/crypto/SupportedCiphersLookupMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/java-manta-client-unshaded/src/test/resources/testng.xml
+++ b/java-manta-client-unshaded/src/test/resources/testng.xml
@@ -111,7 +111,21 @@
             <class name="com.joyent.manta.client.crypto.MultiCryptoProviderDecryptionTest" />
         </classes>
     </test>
-
+    <test name="Encryption Cipher Tests">
+        <parameter name="usingEncryption" value="true" />
+        <groups>
+            <define name="unlimited-crypto" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.crypto.AesGcmCipherDetailsTest" />
+            <class name="com.joyent.manta.client.crypto.SupportedCiphersLookupMapTest" />
+            <class name="com.joyent.manta.client.crypto.MantaEncryptedObjectInputStreamTest" />
+            <class name="com.joyent.manta.client.crypto.MantaEncryptedObjectInputStreamAutoFailureRecoveryTest" />
+            <class name="com.joyent.manta.http.EncryptedHttpHelperTest" />
+            <class name="com.joyent.manta.util.CipherClonerTest" />
+            <class name="com.joyent.manta.util.HmacClonerTest" />
+        </classes>
+    </test>
     <!-- This is commented out because it is an integration test and it doesn't
          play nicely with unit test only runs in CI -->
     <!--<test name="Integration Tests Depending on Shaded Resources">-->

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientDirectoriesIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientDirectoriesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2015-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -32,7 +32,7 @@ import static com.joyent.manta.util.MantaUtils.writeablePrefixPaths;
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  */
-@Test(groups = { "directory" })
+@Test(groups = {"directory"})
 public class MantaClientDirectoriesIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(MantaClientDirectoriesIT.class);

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientErrorIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientErrorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2015-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -16,8 +16,6 @@ import com.joyent.test.util.MantaFunction;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Optional;
-import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -33,8 +31,9 @@ import static com.joyent.manta.exception.MantaErrorCode.RESOURCE_NOT_FOUND_ERROR
  * failures.
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
-@Test(groups = { "error" })
+@Test(groups = {"error"})
 public class MantaClientErrorIT {
     private MantaClient mantaClient;
 
@@ -43,11 +42,9 @@ public class MantaClientErrorIT {
     private String testPathPrefix;
 
     @BeforeClass
-    @Parameters({"usingEncryption"})
-    public void beforeClass(@Optional Boolean usingEncryption) throws IOException {
-
+    public void beforeClass() throws IOException {
         // Let TestNG configuration take precedence over environment variables
-        config = new IntegrationTestConfigContext(usingEncryption);
+        config = new IntegrationTestConfigContext();
 
         mantaClient = new MantaClient(config);
         testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
@@ -52,24 +52,27 @@ import static com.joyent.manta.exception.MantaErrorCode.RESOURCE_NOT_FOUND_ERROR
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
-@Test
+@Test(groups = {"encryptable"})
 public class MantaClientIT {
 
     private static final String TEST_DATA = "EPISODEII_IS_BEST_EPISODE";
 
-    private MantaClient mantaClient;
+    private final MantaClient mantaClient;
 
-    private String testPathPrefix;
+    private final String testPathPrefix;
 
-    @BeforeClass
-    @Parameters({"usingEncryption"})
-    public void beforeClass(@Optional Boolean usingEncryption) throws IOException {
+    @Parameters({"encryptionCipher"})
+    public MantaClientIT(final @Optional String encryptionCipher) {
 
         // Let TestNG configuration take precedence over environment variables
-        ConfigContext config = new IntegrationTestConfigContext(usingEncryption);
+        ConfigContext config = new IntegrationTestConfigContext(encryptionCipher);
 
         mantaClient = new MantaClient(config);
         testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
+    }
+
+    @BeforeClass
+    public void beforeClass() throws IOException {
         mantaClient.putDirectory(testPathPrefix, true);
     }
 

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientMetadataIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientMetadataIT.java
@@ -26,8 +26,9 @@ import java.util.UUID;
  * Tests for verifying the behavior of metadata with {@link MantaClient}.
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
-@Test(groups = { "metadata" })
+@Test(groups = {"metadata"})
 public class MantaClientMetadataIT {
     private static final String TEST_DATA = "EPISODEII_IS_BEST_EPISODE";
 
@@ -35,15 +36,19 @@ public class MantaClientMetadataIT {
 
     private String testPathPrefix;
 
-    @BeforeClass
-    @Parameters({"usingEncryption"})
-    public void beforeClass(@Optional Boolean usingEncryption) throws IOException {
+    @Parameters({"encryptionCipher"})
+    public MantaClientMetadataIT(final @Optional String encryptionCipher) {
 
         // Let TestNG configuration take precedence over environment variables
-        ConfigContext config = new IntegrationTestConfigContext(usingEncryption);
+        ConfigContext config = new IntegrationTestConfigContext(encryptionCipher);
 
         mantaClient = new MantaClient(config);
         testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
+
+    }
+
+    @BeforeClass
+    public void beforeClass() throws IOException {
         mantaClient.putDirectory(testPathPrefix, true);
     }
 
@@ -177,7 +182,7 @@ public class MantaClientMetadataIT {
         }
     }
 
-    @Test(groups = "encrypted")
+    @Test(groups = "encryptable")
     public void verifyAddEncryptedMetadataToObjectOnPut() throws IOException {
         if (!mantaClient.getContext().isClientEncryptionEnabled()) {
             throw new SkipException("Test is only relevant when client-side encryption is enabled");
@@ -207,7 +212,7 @@ public class MantaClientMetadataIT {
         Assert.assertEquals(get.getHeaderAsString("e-force"), "true");
     }
 
-    @Test(groups = "encrypted")
+    @Test(groups = "encryptable")
     public final void verifyEncryptedMetadataCanBeAddedLater() throws IOException {
         if (!mantaClient.getContext().isClientEncryptionEnabled()) {
             throw new SkipException("Test is only relevant when client-side encryption is enabled");

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientMetadataIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientMetadataIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2015-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -27,7 +27,7 @@ import java.util.UUID;
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  */
-@Test( groups = { "metadata" })
+@Test(groups = { "metadata" })
 public class MantaClientMetadataIT {
     private static final String TEST_DATA = "EPISODEII_IS_BEST_EPISODE";
 

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientPutIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientPutIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2016-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -42,7 +42,13 @@ import java.util.UUID;
 
 import static com.joyent.manta.exception.MantaErrorCode.RESOURCE_NOT_FOUND_ERROR;
 
-@Test
+/**
+ * Tests the basic functionality of the put operations in {@link MantaClient} class.
+ *
+ * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
+ */
+@Test(groups = {"put"})
 public class MantaClientPutIT {
 
     private static final String TEST_DATA = "EPISODEII_IS_BEST_EPISODE";

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientRangeIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientRangeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -7,7 +7,11 @@
  */
 package com.joyent.manta.client;
 
-import com.joyent.manta.config.*;
+import com.joyent.manta.config.BaseChainedConfigContext;
+import com.joyent.manta.config.ConfigContext;
+import com.joyent.manta.config.EncryptionAuthenticationMode;
+import com.joyent.manta.config.IntegrationTestConfigContext;
+import com.joyent.manta.config.SettableConfigContext;
 import com.joyent.manta.http.MantaHttpHeaders;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -23,6 +27,13 @@ import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.UUID;
 
+/**
+ * Tests for verifying the correct behavior of range operations performed by
+ * the {@link MantaClient} class.
+ *
+ * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
+ */
 @Test
 public class MantaClientRangeIT {
     private static final String TEST_DATA =
@@ -49,23 +60,29 @@ public class MantaClientRangeIT {
             "Girt with a seint* of silk, with barres small; " +
             "Of his array tell I no longer tale.";
 
-    private MantaClient mantaClient;
+    private final MantaClient mantaClient;
 
-    private String testPathPrefix;
+    private final ConfigContext config;
 
-    @BeforeClass
-    @Parameters({"usingEncryption"})
-    public void beforeClass(@Optional Boolean usingEncryption) throws IOException {
+    private final String testPathPrefix;
+
+    @Parameters({"encryptionCipher"})
+    public MantaClientRangeIT(final @Optional String encryptionCipher) {
+
         // Let TestNG configuration take precedence over environment variables
-        SettableConfigContext<BaseChainedConfigContext> config = new IntegrationTestConfigContext(usingEncryption);
-
+        SettableConfigContext<BaseChainedConfigContext> config = new IntegrationTestConfigContext(encryptionCipher);
         // Range request have to be in optional authentication mode
         if (config.isClientEncryptionEnabled()) {
             config.setEncryptionAuthenticationMode(EncryptionAuthenticationMode.Optional);
         }
 
         mantaClient = new MantaClient(config);
+        this.config = config;
         testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
+
+    }
+    @BeforeClass
+    public void beforeClass() throws IOException {
         mantaClient.putDirectory(testPathPrefix, true);
     }
 

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSeekableByteChannelIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSeekableByteChannelIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2015-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -36,22 +36,20 @@ import java.util.UUID;
  * {@link MantaClient}.
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
-@Test(groups = { "seekable" })
+@Test(groups = {"seekable", "encryptable"})
 public class MantaClientSeekableByteChannelIT {
     private static final String TEST_DATA = "EPISODEII_IS_BEST_EPISODE";
 
-    private MantaClient mantaClient;
+    private final MantaClient mantaClient;
 
-    private String testPathPrefix;
+    private final String testPathPrefix;
 
-
-    @BeforeClass
-    @Parameters({"usingEncryption"})
-    public void beforeClass(@Optional Boolean usingEncryption) throws IOException {
-
+    @Parameters({"encryptionCipher"})
+    public MantaClientSeekableByteChannelIT(final @Optional String encryptionCipher) {
         // Let TestNG configuration take precedence over environment variables
-        SettableConfigContext<BaseChainedConfigContext> config = new IntegrationTestConfigContext(usingEncryption);
+        SettableConfigContext<BaseChainedConfigContext> config = new IntegrationTestConfigContext(encryptionCipher);
 
         // Range request have to be in optional authentication mode
         if (config.isClientEncryptionEnabled()) {
@@ -60,6 +58,10 @@ public class MantaClientSeekableByteChannelIT {
 
         mantaClient = new MantaClient(config);
         testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
+    }
+
+    @BeforeClass
+    public void beforeClass(@Optional Boolean usingEncryption) throws IOException {
         mantaClient.putDirectory(testPathPrefix, true);
     }
 
@@ -68,7 +70,6 @@ public class MantaClientSeekableByteChannelIT {
         IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
-    @Test
     public final void seekableByteSize() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -82,7 +83,6 @@ public class MantaClientSeekableByteChannelIT {
         }
     }
 
-    @Test
     public final void getAllSeekableBytes() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -94,7 +94,6 @@ public class MantaClientSeekableByteChannelIT {
         }
     }
 
-    @Test
     public final void getAllSeekableBytesAtPosition() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -109,7 +108,6 @@ public class MantaClientSeekableByteChannelIT {
         }
     }
 
-    @Test
     public final void readFromDifferentPositions() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -133,7 +131,6 @@ public class MantaClientSeekableByteChannelIT {
         }
     }
 
-    @Test
     public final void readAllSeekableBytesFromPositionAsInputStream() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -157,7 +154,6 @@ public class MantaClientSeekableByteChannelIT {
         }
     }
 
-    @Test
     public final void skipUsingInputStream() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -223,7 +219,6 @@ public class MantaClientSeekableByteChannelIT {
         }
     }
 
-    @Test( groups = { "seekable" })
     public final void getFromForwardPosition() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -241,7 +236,6 @@ public class MantaClientSeekableByteChannelIT {
         }
     }
 
-    @Test( groups = { "seekable" } )
     public final void getFromBaseChannelThenForwardPosition() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -262,7 +256,6 @@ public class MantaClientSeekableByteChannelIT {
         }
     }
 
-    @Test( groups = { "seekable" } )
     public final void getFromForwardPositionThenBackwardPosition() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSeekableByteChannelIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSeekableByteChannelIT.java
@@ -61,7 +61,7 @@ public class MantaClientSeekableByteChannelIT {
     }
 
     @BeforeClass
-    public void beforeClass(@Optional Boolean usingEncryption) throws IOException {
+    public void beforeClass() throws IOException {
         mantaClient.putDirectory(testPathPrefix, true);
     }
 

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSnapLinksIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSnapLinksIT.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2019, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.manta.client;
+
+import com.joyent.manta.config.ConfigContext;
+import com.joyent.manta.config.IntegrationTestConfigContext;
+import com.joyent.manta.exception.MantaClientHttpResponseException;
+import com.joyent.manta.http.MantaHttpHeaders;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.*;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static com.joyent.manta.exception.MantaErrorCode.SNAPLINKS_DISABLED_ERROR;
+import static com.joyent.manta.client.MantaClient.SEPARATOR;
+
+/**
+ * Tests the basic functionality of operations related to snaplinks
+ * for the {@link MantaClient} class.
+ * <p>
+ * Since we want to make it possible to run this test without a code change, this test throws a {@link
+ * org.testng.SkipException} if snaplinks are disabled for the "manta.user" account, the method
+ * {@link MantaClientSnapLinksIT#putSnapLinkAndSkipIfUnsupported(String, String)} will skip this integration-test from running.
+ * </p>
+ * <p>Remember to also pass system properties for client configuration (manta.user/etc.) or set the values in the
+ * environment (MANTA_USER/etc).
+ * </p>
+ *
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
+ */
+@Test(groups = "snaplinks")
+public class MantaClientSnapLinksIT {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MantaClientSnapLinksIT.class);
+
+    private static final String TEST_DATA = "Arise,Awake And Do Not Stop Until Your Goal Is Reached.";
+
+    private MantaClient mantaClient;
+
+    private String testPathPrefix;
+
+    @BeforeClass
+    @Parameters({"usingEncryption"})
+    public void beforeClass(@Optional Boolean usingEncryption) throws IOException {
+
+        // Let TestNG configuration take precedence over environment variables
+        ConfigContext config = new IntegrationTestConfigContext(usingEncryption);
+
+        mantaClient = new MantaClient(config);
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
+        mantaClient.putDirectory(testPathPrefix, true);
+    }
+
+    @AfterClass
+    public void afterClass() throws IOException {
+        IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
+    }
+
+    @Test(dependsOnMethods = "testPutLink")
+    public final void canMoveDirectoryWithContents() throws IOException {
+        final String name = "source-" + UUID.randomUUID().toString();
+        final String source = testPathPrefix + name + MantaClient.SEPARATOR;
+        final String destination = testPathPrefix + "dest-" + UUID.randomUUID() + SEPARATOR;
+        moveDirectoryWithContents(source, destination);
+    }
+
+    @Test(dependsOnMethods = "testPutLink")
+    public final void canMoveFileToDifferentPrecreatedDirectory() throws IOException {
+        final String name = UUID.randomUUID().toString();
+        final String path = testPathPrefix + name;
+        mantaClient.put(path, TEST_DATA);
+        final String newDir = testPathPrefix + "subdir-" + UUID.randomUUID() + SEPARATOR;
+        mantaClient.putDirectory(newDir);
+        final String newPath = newDir + "this-is-a-new-name.txt";
+
+        mantaClient.move(path, newPath);
+        final String movedContent = mantaClient.getAsString(newPath);
+        Assert.assertEquals(movedContent, TEST_DATA);
+    }
+
+    @Test(dependsOnMethods = "testPutLink")
+    public final void canMoveFileToDifferentUncreatedDirectoryCreationEnabled() throws IOException {
+        final String name = UUID.randomUUID().toString();
+        final String path = testPathPrefix + name;
+        mantaClient.put(path, TEST_DATA);
+        final String newDir = testPathPrefix + "subdir-" + UUID.randomUUID() + SEPARATOR;
+
+        final String newPath = newDir + "this-is-a-new-name.txt";
+
+        mantaClient.move(path, newPath, true);
+        final String movedContent = mantaClient.getAsString(newPath);
+        Assert.assertEquals(movedContent, TEST_DATA);
+    }
+
+    public final void testHead() throws IOException {
+        final String objectName = UUID.randomUUID().toString();
+        final String path = testPathPrefix + objectName;
+
+        mantaClient.put(path, TEST_DATA);
+        final MantaObjectResponse mantaObjectHead = mantaClient.head(testPathPrefix + objectName);
+        Assert.assertNotNull(mantaObjectHead);
+        Assert.assertNotNull(mantaObjectHead.getContentType());
+        Assert.assertNotNull(mantaObjectHead.getContentLength());
+        Assert.assertNotNull(mantaObjectHead.getEtag());
+        Assert.assertNotNull(mantaObjectHead.getMtime());
+        Assert.assertNotNull(mantaObjectHead.getPath());
+
+        final String directoryName = UUID.randomUUID().toString();
+        mantaClient.putDirectory(testPathPrefix + directoryName, null);
+        final MantaObjectResponse mantaDirectoryHead = mantaClient.head(testPathPrefix + directoryName);
+        Assert.assertNotNull(mantaDirectoryHead);
+        Assert.assertNotNull(mantaDirectoryHead.getContentType());
+        Assert.assertNull(mantaDirectoryHead.getContentLength());
+        Assert.assertNull(mantaDirectoryHead.getEtag());
+        Assert.assertNotNull(mantaDirectoryHead.getMtime());
+        Assert.assertNotNull(mantaDirectoryHead.getPath());
+
+        final String linkName = UUID.randomUUID().toString();
+        putSnapLinkAndSkipIfUnsupported(testPathPrefix + linkName, testPathPrefix + objectName);
+        final MantaObjectResponse mantaLinkHead = mantaClient.head(testPathPrefix + linkName);
+        Assert.assertNotNull(mantaLinkHead);
+        Assert.assertNotNull(mantaLinkHead.getContentType());
+        Assert.assertNotNull(mantaLinkHead.getContentLength());
+        Assert.assertNotNull(mantaLinkHead.getEtag());
+        Assert.assertNotNull(mantaLinkHead.getMtime());
+        Assert.assertNotNull(mantaLinkHead.getPath());
+
+        Assert.assertEquals(mantaObjectHead.getContentType(), mantaLinkHead.getContentType());
+        Assert.assertEquals(mantaObjectHead.getContentLength(), mantaLinkHead.getContentLength());
+        Assert.assertEquals(mantaObjectHead.getEtag(), mantaLinkHead.getEtag());
+    }
+
+    public final void testPutLink() throws IOException {
+        final String name = UUID.randomUUID().toString();
+        final String path = testPathPrefix + name;
+        mantaClient.put(path, TEST_DATA);
+
+        final String link = UUID.randomUUID().toString();
+        putSnapLinkAndSkipIfUnsupported(testPathPrefix + link, testPathPrefix + name);
+        final String linkContent = mantaClient.getAsString(testPathPrefix + link);
+        Assert.assertEquals(linkContent, TEST_DATA);
+    }
+
+    public final void testPutJsonLink() throws IOException {
+        final String name = UUID.randomUUID().toString();
+        final String path = testPathPrefix + name + ".json";
+        final String testData = "{}";
+
+        MantaHttpHeaders headers = new MantaHttpHeaders();
+        headers.setContentType("application/json");
+        mantaClient.put(path, testData, headers);
+
+        final String linkPath = testPathPrefix + UUID.randomUUID() + ".json";
+        putSnapLinkAndSkipIfUnsupported(linkPath, path);
+        final String linkContent = mantaClient.getAsString(linkPath);
+        Assert.assertEquals(linkContent, testData);
+    }
+
+    // TEST UTILITY METHODS
+
+    private void moveDirectoryWithContents(final String source, final String destination) throws IOException {
+        mantaClient.putDirectory(source);
+
+        mantaClient.putDirectory(source + "dir1");
+        mantaClient.putDirectory(source + "dir2");
+        mantaClient.putDirectory(source + "dir3");
+
+        mantaClient.put(source + "file1.txt", TEST_DATA);
+        mantaClient.put(source + "file2.txt", TEST_DATA);
+        mantaClient.put(source + "dir1/file3.txt", TEST_DATA);
+        mantaClient.put(source + "dir1/file4.txt", TEST_DATA);
+        mantaClient.put(source + "dir3/file5.txt", TEST_DATA);
+
+        mantaClient.move(source, destination);
+        boolean newLocationExists = mantaClient.existsAndIsAccessible(destination);
+        Assert.assertTrue(newLocationExists, "Destination directory doesn't exist: "
+                + destination);
+
+        MantaObjectResponse headDestination = mantaClient.head(destination);
+
+        boolean isDirectory = headDestination.isDirectory();
+        Assert.assertTrue(isDirectory, "Destination wasn't created as a directory");
+
+        Long resultSetSize = headDestination.getHttpHeaders().getResultSetSize();
+        Assert.assertEquals(resultSetSize.longValue(), 5L,
+                "Destination directory doesn't have the same number of entries as source");
+
+        Assert.assertTrue(mantaClient.existsAndIsAccessible(destination + "file1.txt"));
+        Assert.assertTrue(mantaClient.existsAndIsAccessible(destination + "file2.txt"));
+        Assert.assertTrue(mantaClient.existsAndIsAccessible(destination + "dir1"));
+        Assert.assertTrue(mantaClient.existsAndIsAccessible(destination + "dir2"));
+        Assert.assertTrue(mantaClient.existsAndIsAccessible(destination + "dir3"));
+        Assert.assertTrue(mantaClient.existsAndIsAccessible(destination + "dir1/file3.txt"));
+        Assert.assertTrue(mantaClient.existsAndIsAccessible(destination + "dir1/file4.txt"));
+        Assert.assertTrue(mantaClient.existsAndIsAccessible(destination + "dir3/file5.txt"));
+
+        boolean sourceIsDeleted = !mantaClient.existsAndIsAccessible(source);
+        Assert.assertTrue(sourceIsDeleted, "Source directory didn't get deleted: "
+                + source);
+    }
+
+    private void putSnapLinkAndSkipIfUnsupported(final String linkPath, final String objectPath) throws IOException {
+        try {
+            mantaClient.putSnapLink(linkPath, objectPath, null);
+        } catch (MantaClientHttpResponseException e) {
+            if (e.getServerCode().equals(SNAPLINKS_DISABLED_ERROR)) {
+                final String message =
+                        "This integration-test class can't be run since SnapLinks" +
+                                "have been disabled for this account";
+                LOG.warn(message);
+                throw new SkipException(message, e);
+            }
+
+            throw e;
+        }
+    }
+}

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSnapLinksIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSnapLinksIT.java
@@ -37,7 +37,7 @@ import static com.joyent.manta.client.MantaClient.SEPARATOR;
  *
  * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
-@Test(groups = "snaplinks")
+@Test(groups = {"snaplinks"})
 public class MantaClientSnapLinksIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(MantaClientSnapLinksIT.class);

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorIT.java
@@ -12,8 +12,6 @@ import com.joyent.manta.config.IntegrationTestConfigContext;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Optional;
-import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
 import java.io.IOException;

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorIT.java
@@ -36,11 +36,10 @@ public class MantaDirectoryListingIteratorIT {
     private String testPathPrefix;
 
     @BeforeClass
-    @Parameters({"usingEncryption"})
-    public void beforeClass(@Optional Boolean usingEncryption) throws IOException {
+    public void beforeClass() throws IOException {
 
         // Let TestNG configuration take precedence over environment variables
-        final ConfigContext config = new IntegrationTestConfigContext(usingEncryption);
+        ConfigContext config = new IntegrationTestConfigContext();
 
         mantaClient = new MantaClient(config);
         testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2015-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -27,7 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  */
-@Test
+@Test(groups={"directory"})
 public class MantaDirectoryListingIteratorIT {
     private static final String TEST_DATA = "EPISODEII_IS_BEST_EPISODE";
 

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaObjectOutputStreamIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaObjectOutputStreamIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2016-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -29,23 +29,34 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.UUID;
 
-@Test
+/**
+ * Tests for verifying the behavior of {@link MantaObjectOutputStream} with
+ * {@link MantaClient}.
+ *
+ * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
+ */
+@Test(groups = {"encryptable"})
 public class MantaObjectOutputStreamIT {
     private static final String TEST_DATA = "EPISODEII_IS_BEST_EPISODE";
 
-    private MantaClient mantaClient;
+    private final MantaClient mantaClient;
 
-    private String testPathPrefix;
+    private final String testPathPrefix;
+
+    @Parameters({"encryptionCipher"})
+    public MantaObjectOutputStreamIT(final @Optional String encryptionCipher) throws IOException {
+
+        // Let TestNG configuration take precedence over environment variables
+        ConfigContext config = new IntegrationTestConfigContext(encryptionCipher);
+
+        mantaClient = new MantaClient(config);
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
+    }
 
     @BeforeClass()
     @Parameters({"usingEncryption"})
     public void beforeClass(@Optional Boolean usingEncryption) throws IOException {
-
-        // Let TestNG configuration take precedence over environment variables
-        ConfigContext config = new IntegrationTestConfigContext(usingEncryption);
-
-        mantaClient = new MantaClient(config);
-        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
         mantaClient.putDirectory(testPathPrefix, true);
     }
 

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaObjectOutputStreamIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaObjectOutputStreamIT.java
@@ -55,8 +55,7 @@ public class MantaObjectOutputStreamIT {
     }
 
     @BeforeClass()
-    @Parameters({"usingEncryption"})
-    public void beforeClass(@Optional Boolean usingEncryption) throws IOException {
+    public void beforeClass() throws IOException {
         mantaClient.putDirectory(testPathPrefix, true);
     }
 

--- a/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaClientJobIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaClientJobIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2015-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -36,7 +36,7 @@ import java.util.stream.Stream;
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  */
-@Test(groups = { "job" }, retryAnalyzer = ThreeTriesRetryAnalyzer.class)
+@Test(groups = { "jobs" }, retryAnalyzer = ThreeTriesRetryAnalyzer.class)
 public class MantaClientJobIT {
     private static final Logger LOG = LoggerFactory.getLogger(MantaClientJobIT.class);
 
@@ -167,7 +167,7 @@ public class MantaClientJobIT {
         }
     }
 
-    @Test(dependsOnMethods = { "createJob", "getJob" })
+    @Test(dependsOnMethods = { "createJob", "getJob" }, groups = { "nightly" })
     public void canListAllJobIDs() throws IOException, InterruptedException {
         final MantaJob job1 = buildJob();
         final UUID job1id = mantaClient.createJob(job1);
@@ -197,7 +197,7 @@ public class MantaClientJobIT {
      * and development environments. The code path for testing job lists is
      * tested elsewhere, but not the specific operation of listing ALL jobs.
      */
-    @Test(enabled = false, dependsOnMethods = { "createJob", "getJob" })
+    @Test(enabled = false, dependsOnMethods = { "createJob", "getJob" }, groups = { "nightly" })
     public void canListAllJobs() throws IOException, InterruptedException {
         final MantaJob job1 = buildJob();
         final UUID job1id = mantaClient.createJob(job1);
@@ -228,7 +228,7 @@ public class MantaClientJobIT {
         }
     }
 
-    @Test(dependsOnMethods = { "createJob", "getJob" })
+    @Test(dependsOnMethods = { "createJob", "getJob" }, groups = { "nightly" })
     public void canListAllRunningJobIDs() throws IOException, InterruptedException {
         final MantaJob job1 = buildJob();
         final UUID job1id = mantaClient.createJob(job1);
@@ -261,7 +261,7 @@ public class MantaClientJobIT {
         }
     }
 
-    @Test(dependsOnMethods = { "createJob", "getJob" })
+    @Test(dependsOnMethods = { "createJob", "getJob" }, groups = { "nightly" })
     public void canListAllRunningJobs() throws IOException, InterruptedException {
         final MantaJob job1 = buildJob();
         final UUID job1id = mantaClient.createJob(job1);

--- a/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaClientJobIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaClientJobIT.java
@@ -167,7 +167,7 @@ public class MantaClientJobIT {
         }
     }
 
-    @Test(dependsOnMethods = { "createJob", "getJob" }, groups = { "nightly" })
+    @Test(enabled = false, dependsOnMethods = { "createJob", "getJob" }, groups = { "nightly" })
     public void canListAllJobIDs() throws IOException, InterruptedException {
         final MantaJob job1 = buildJob();
         final UUID job1id = mantaClient.createJob(job1);
@@ -228,7 +228,7 @@ public class MantaClientJobIT {
         }
     }
 
-    @Test(dependsOnMethods = { "createJob", "getJob" }, groups = { "nightly" })
+    @Test(enabled = false, dependsOnMethods = { "createJob", "getJob" }, groups = { "nightly" })
     public void canListAllRunningJobIDs() throws IOException, InterruptedException {
         final MantaJob job1 = buildJob();
         final UUID job1id = mantaClient.createJob(job1);
@@ -261,7 +261,7 @@ public class MantaClientJobIT {
         }
     }
 
-    @Test(dependsOnMethods = { "createJob", "getJob" }, groups = { "nightly" })
+    @Test(enabled = false, dependsOnMethods = { "createJob", "getJob" }, groups = { "nightly" })
     public void canListAllRunningJobs() throws IOException, InterruptedException {
         final MantaJob job1 = buildJob();
         final UUID job1id = mantaClient.createJob(job1);

--- a/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaJobBuilderIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaJobBuilderIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2015-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  */
-@Test(dependsOnGroups = "job")
+@Test(dependsOnGroups = "jobs")
 public class MantaJobBuilderIT {
     private static final String TEST_DATA =
               "line 01 aa\n"

--- a/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaJobBuilderIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaJobBuilderIT.java
@@ -29,8 +29,9 @@ import java.util.stream.Collectors;
  * Tests the execution of Manta compute jobs using the builder fluent interface.
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @author <a href="https://github.com/nairashwin952013>Ashwin A Nair</a>
  */
-@Test(dependsOnGroups = "jobs")
+@Test(groups = "jobs")
 public class MantaJobBuilderIT {
     private static final String TEST_DATA =
               "line 01 aa\n"

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedJobsMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedJobsMultipartManagerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -55,7 +55,7 @@ import static org.testng.Assert.fail;
 /* Tests are disabled because functionality is obsolete and overall test runtime
  * is very long and expensive. */
 @Deprecated
-@Test(groups = { "encrypted" }, enabled = false)
+@Test(groups = { "nightly" }, enabled = false)
 public class EncryptedJobsMultipartManagerIT {
     private MantaClient mantaClient;
     private EncryptedJobsMultipartManager multipart;

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -28,7 +28,6 @@ import org.testng.AssertJUnit;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
@@ -47,29 +46,44 @@ import java.util.stream.Stream;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-@Test(groups = { "encrypted" })
+/**
+ * Tests for verifying the behavior of {@link EncryptedServerSideMultipartManager} with
+ * {@link MantaClient}.
+ *
+ * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
+ */
+@Test(groups = {"encryptable", "multipart"})
 @SuppressWarnings("Duplicates")
 public class EncryptedServerSideMultipartManagerIT {
-    private MantaClient mantaClient;
+    private final ConfigContext config;
 
-    private EncryptedServerSideMultipartManager multipart;
+    private final MantaClient mantaClient;
+
+    private final EncryptedServerSideMultipartManager multipart;
 
     private static final int FIVE_MB = 5242880;
 
     private static final String TEST_FILENAME = "Master-Yoda.jpg";
 
-    private String testPathPrefix;
+    private final String testPathPrefix;
+
+    public EncryptedServerSideMultipartManagerIT(final @org.testng.annotations.Optional String encryptionCipher) {
+
+        // Let TestNG configuration take precedence over environment variables
+        config = new IntegrationTestConfigContext(encryptionCipher);
+
+        mantaClient = new MantaClient(config);
+
+        multipart = new EncryptedServerSideMultipartManager(this.mantaClient);
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
+    }
 
     @BeforeClass()
-    @Parameters({"usingEncryption"})
-    public void beforeClass(@org.testng.annotations.Optional Boolean usingEncryption) throws IOException {
-        // Let TestNG configuration take precedence over environment variables
-        ConfigContext config = new IntegrationTestConfigContext(usingEncryption);
-
+    public void beforeClass() throws IOException {
         if (!config.isClientEncryptionEnabled()) {
             throw new SkipException("Skipping tests if encryption is disabled");
         }
-        mantaClient = new MantaClient(config);
 
         // sanity check
         if (!mantaClient.existsAndIsAccessible(config.getMantaHomeDirectory())) {
@@ -81,8 +95,6 @@ public class EncryptedServerSideMultipartManagerIT {
             throw new SkipException("Server side uploads aren't supported in this Manta version");
         }
 
-        multipart = new EncryptedServerSideMultipartManager(this.mantaClient);
-        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
         mantaClient.putDirectory(testPathPrefix, true);
     }
 

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerSerializationIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerSerializationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -24,6 +24,7 @@ import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Optional;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
@@ -36,7 +37,14 @@ import javax.crypto.SecretKey;
 
 import static org.testng.Assert.fail;
 
-@Test(groups = { "encrypted" })
+/**
+ * Tests for verifying the behavior of {@link com.joyent.manta.serialization.EncryptedMultipartSerializer}
+ * and {@link EncryptedServerSideMultipartManager} with {@link MantaClient}.
+ *
+ * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
+ */
+@Test(groups = {"encryptable", "multipart"})
 @SuppressWarnings("Duplicates")
 public class EncryptedServerSideMultipartManagerSerializationIT {
     private static final Logger LOGGER = LoggerFactory.getLogger
@@ -52,24 +60,27 @@ public class EncryptedServerSideMultipartManagerSerializationIT {
 
     private ConfigContext config;
 
-    @BeforeClass()
-    @Parameters({"usingEncryption"})
-    public void beforeClass(@org.testng.annotations.Optional Boolean usingEncryption) throws IOException {
+    @Parameters({"encryptionCipher"})
+    public EncryptedServerSideMultipartManagerSerializationIT(final @Optional String encryptionCipher) throws IOException {
         // Let TestNG configuration take precedence over environment variables
-        this.config = new IntegrationTestConfigContext(usingEncryption);
 
+        config = new IntegrationTestConfigContext(encryptionCipher);
+        mantaClient = new MantaClient(config);
+        multipart = new EncryptedServerSideMultipartManager(this.mantaClient);
+        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
+    }
+
+    @BeforeClass()
+    public void beforeClass() throws IOException {
         if (!config.isClientEncryptionEnabled()) {
             throw new SkipException("Skipping tests if encryption is disabled");
         }
-        mantaClient = new MantaClient(config);
 
         if (!mantaClient.existsAndIsAccessible(config.getMantaHomeDirectory()
                 + MantaClient.SEPARATOR + "uploads")) {
             throw new SkipException("Server side uploads aren't supported in this Manta version");
         }
 
-        multipart = new EncryptedServerSideMultipartManager(this.mantaClient);
-        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
         mantaClient.putDirectory(testPathPrefix, true);
     }
 

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerSerializationIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerSerializationIT.java
@@ -25,7 +25,6 @@ import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Optional;
-import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -47,25 +46,27 @@ import static org.testng.Assert.fail;
 @Test(groups = {"encryptable", "multipart"})
 @SuppressWarnings("Duplicates")
 public class EncryptedServerSideMultipartManagerSerializationIT {
-    private static final Logger LOGGER = LoggerFactory.getLogger
-            (EncryptedServerSideMultipartManagerSerializationIT.class);
-    private MantaClient mantaClient;
-    private EncryptedServerSideMultipartManager multipart;
+    private static final Logger LOGGER = LoggerFactory.getLogger(EncryptedServerSideMultipartManagerSerializationIT.class);
+
+    private final MantaClient mantaClient;
+
+    private final EncryptedServerSideMultipartManager multipart;
 
     private static final int FIVE_MB = 5242880;
 
-    private String testPathPrefix;
+    private final String testPathPrefix;
 
     private Kryo kryo = new Kryo();
 
-    private ConfigContext config;
+    private final ConfigContext config;
 
-    @Parameters({"encryptionCipher"})
-    public EncryptedServerSideMultipartManagerSerializationIT(final @Optional String encryptionCipher) throws IOException {
+    public EncryptedServerSideMultipartManagerSerializationIT(final @Optional String encryptionCipher) {
+
         // Let TestNG configuration take precedence over environment variables
-
         config = new IntegrationTestConfigContext(encryptionCipher);
+
         mantaClient = new MantaClient(config);
+
         multipart = new EncryptedServerSideMultipartManager(this.mantaClient);
         testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
     }

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/JobsMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/JobsMultipartManagerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2016-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -52,7 +52,7 @@ import static org.testng.Assert.fail;
 /* Tests are disabled because functionality is obsolete and overall test runtime
  * is very long and expensive. */
 @Deprecated
-@Test(enabled = false)
+@Test(groups = { "nightly" }, enabled = false)
 public class JobsMultipartManagerIT {
     private MantaClient mantaClient;
     private JobsMultipartManager multipart;

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/ServerSideMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/ServerSideMultipartManagerIT.java
@@ -91,7 +91,7 @@ public class ServerSideMultipartManagerIT {
         }
     }
 
-    @Test(groups = { "nightly" })
+    @Test(groups = { "nightly" }, enabled = false)
     public final void canListUploadsInProgress() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/ServerSideMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/ServerSideMultipartManagerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -91,6 +91,7 @@ public class ServerSideMultipartManagerIT {
         }
     }
 
+    @Test(groups = { "nightly" })
     public final void canListUploadsInProgress() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;

--- a/java-manta-it/src/test/java/com/joyent/manta/config/IntegrationTestConfigContext.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/config/IntegrationTestConfigContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2015-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -28,6 +28,7 @@ import static com.joyent.manta.client.MantaClient.SEPARATOR;
  * and allows for TestNG parameters to be loaded.
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
 public class IntegrationTestConfigContext extends SystemSettingsConfigContext {
 
@@ -50,6 +51,16 @@ public class IntegrationTestConfigContext extends SystemSettingsConfigContext {
         super(enableTestEncryption(new StandardConfigContext(),
                 (encryptionEnabled() && usingEncryption == null) ||
                         BooleanUtils.isTrue(usingEncryption), encryptionCipher()));
+    }
+
+    /**
+     * Populate configuration from defaults, environment variables, system
+     * properties and an addition context passed in. Assigns hard-coded
+     * client-side encryption cipher algorithm settings.
+     */
+    public IntegrationTestConfigContext(final String encryptionCipher) {
+        this(encryptionCipher != null, encryptionCipher);
+
     }
 
     /**
@@ -84,7 +95,10 @@ public class IntegrationTestConfigContext extends SystemSettingsConfigContext {
             SecretKey key = SecretKeyUtils.generate(cipherDetails);
             context.setEncryptionPrivateKeyBytes(key.getEncoded());
 
-            System.out.printf("Unique secret key used for test (base64):\n%s\n",
+            System.out.printf(
+                    "Integration test encryption enabled: %s\n"
+                    + "Unique secret key used for test (base64):\n%s\n",
+                    cipherDetails.getCipherId(),
                     Base64.getEncoder().encodeToString(key.getEncoded()));
         }
 

--- a/java-manta-it/src/test/java/com/joyent/manta/http/MantaHttpHeadersIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/http/MantaHttpHeadersIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2015-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/java-manta-it/src/test/java/com/joyent/test/util/MantaPathSuiteListener.java
+++ b/java-manta-it/src/test/java/com/joyent/test/util/MantaPathSuiteListener.java
@@ -40,7 +40,7 @@ public class MantaPathSuiteListener implements ISuiteListener {
         String path = IntegrationTestConfigContext.generateSuiteBasePath(config);
 
         if (ObjectUtils.firstNonNull(
-                BooleanUtils.toBoolean(System.getProperty("it.dryrun")),
+                BooleanUtils.toBoolean(System.getProperty("it.dryRun")),
                 false)) {
             LOG.warn("Skipping suite cleanup since dry-run is enabled.");
             return;

--- a/java-manta-it/src/test/java/com/joyent/test/util/MantaPathSuiteListener.java
+++ b/java-manta-it/src/test/java/com/joyent/test/util/MantaPathSuiteListener.java
@@ -10,6 +10,8 @@ package com.joyent.test.util;
 import com.joyent.manta.client.MantaClient;
 import com.joyent.manta.config.ConfigContext;
 import com.joyent.manta.config.IntegrationTestConfigContext;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.ISuite;
@@ -32,8 +34,18 @@ public class MantaPathSuiteListener implements ISuiteListener {
 
     @Override
     public void onFinish(ISuite suite) {
+        LOG.info("Expected test count: " + TestListingInterceptor.getObservedTestCount());
+
         MantaClient mantaClient = new MantaClient(config);
         String path = IntegrationTestConfigContext.generateSuiteBasePath(config);
+
+        if (ObjectUtils.firstNonNull(
+                BooleanUtils.toBoolean(System.getProperty("it.dryrun")),
+                false)) {
+            LOG.warn("Skipping suite cleanup since dry-run is enabled.");
+            return;
+        }
+
         try {
             if (mantaClient.isDirectoryEmpty(path)) {
                 LOG.info("Removing base suite path: {}", path);

--- a/java-manta-it/src/test/java/com/joyent/test/util/TestListingInterceptor.java
+++ b/java-manta-it/src/test/java/com/joyent/test/util/TestListingInterceptor.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 /**
  * Test method listener for determining which tests will actually run.
  *
- * Enabled by: -Dit.dryrun=true
+ * Enabled by: -Dit.dryRun=true
  * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
 public class TestListingInterceptor implements IMethodInterceptor, ISuiteListener {
@@ -42,7 +42,7 @@ public class TestListingInterceptor implements IMethodInterceptor, ISuiteListene
 
     static {
         DRY_RUN_ENABLED = ObjectUtils.firstNonNull(
-                BooleanUtils.toBoolean(System.getProperty("it.dryrun")),
+                BooleanUtils.toBoolean(System.getProperty("it.dryRun")),
                 false);
     }
 
@@ -80,10 +80,10 @@ public class TestListingInterceptor implements IMethodInterceptor, ISuiteListene
         final String[] sortedTests = observedTests.toArray(new String[0]);
         Arrays.sort(sortedTests);
 
-        System.out.println("DRY-RUN: Listing ["+ sortedTests.length +"] tests that would have run");
+        LOG.info("DRY-RUN: Listing ["+ sortedTests.length +"] tests that would have run");
 
         for (final String testNameAndParams : sortedTests) {
-            System.out.println(testNameAndParams);
+            LOG.info(testNameAndParams);
         }
     }
 }

--- a/java-manta-it/src/test/java/com/joyent/test/util/TestListingInterceptor.java
+++ b/java-manta-it/src/test/java/com/joyent/test/util/TestListingInterceptor.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2019, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.test.util;
+
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.IMethodInstance;
+import org.testng.IMethodInterceptor;
+import org.testng.ISuite;
+import org.testng.ISuiteListener;
+import org.testng.ITestContext;
+import org.testng.ITestNGMethod;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * Test method listener for determining which tests will actually run.
+ *
+ * Enabled by: -Dit.dryrun=true
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
+ */
+public class TestListingInterceptor implements IMethodInterceptor, ISuiteListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TestListingInterceptor.class);
+
+    private static final List<IMethodInstance> EMPTY_LIST = new ArrayList<>(0);
+
+    private static final ConcurrentLinkedQueue<String> observedTests = new ConcurrentLinkedQueue<>();
+
+    private static final boolean DRY_RUN_ENABLED;
+
+    static {
+        DRY_RUN_ENABLED = ObjectUtils.firstNonNull(
+                BooleanUtils.toBoolean(System.getProperty("it.dryrun")),
+                false);
+    }
+
+    public static int getObservedTestCount() {
+        return observedTests.size();
+    }
+
+    @Override
+    public List<IMethodInstance> intercept(final List<IMethodInstance> methods, final ITestContext context) {
+        for (final IMethodInstance method : methods) {
+            final ITestNGMethod testNGMethod = method.getMethod();
+            final String testName = testNGMethod.getQualifiedName();
+            final Map<String, String> params = testNGMethod.findMethodParameters(testNGMethod.getXmlTest());
+            final String paramsDetails = !params.isEmpty() ? params.toString() : "";
+            observedTests.add(testName + ' ' + paramsDetails);
+        }
+
+        if (DRY_RUN_ENABLED) {
+            return EMPTY_LIST;
+        }
+
+        return methods;
+    }
+
+    @Override
+    public void onStart(final ISuite suite) {
+    }
+
+    @Override
+    public void onFinish(final ISuite suite) {
+        if (!DRY_RUN_ENABLED) {
+            return;
+        }
+
+        final String[] sortedTests = observedTests.toArray(new String[0]);
+        Arrays.sort(sortedTests);
+
+        System.out.println("DRY-RUN: Listing ["+ sortedTests.length +"] tests that would have run");
+
+        for (final String testNameAndParams : sortedTests) {
+            System.out.println(testNameAndParams);
+        }
+    }
+}

--- a/java-manta-it/src/test/resources/testng-it.xml
+++ b/java-manta-it/src/test/resources/testng-it.xml
@@ -71,7 +71,15 @@
             </package>
         </packages>
     </test>
-
+    <test name="Manta Client Snaplinks Tests ">
+        <parameter name="usingEncryption" value="true"/>
+        <groups>
+            <define name="snaplinks" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientSnapLinksIT" />
+        </classes>
+    </test>
     <test name="Manta Job Tests">
         <packages>
             <package name="com.joyent.manta.client.jobs.*"/>

--- a/java-manta-it/src/test/resources/testng-it.xml
+++ b/java-manta-it/src/test/resources/testng-it.xml
@@ -19,6 +19,7 @@
         <classes>
             <class name="com.joyent.manta.client.MantaClientDirectoriesIT" />
             <class name="com.joyent.manta.client.MantaDirectoryListingIteratorIT" />
+            <class name="com.joyent.manta.client.MantaClientMetadataIT" />
         </classes>
     </test>
     <test name="Manta Client Http Headers Tests">
@@ -29,14 +30,56 @@
             <class name="com.joyent.manta.http.MantaHttpHeadersIT" />
         </classes>
     </test>
+    <test name="Manta Client Metadata Tests [Metadata Operations]">
+        <groups>
+            <define name="metadata" />
+            <run>
+                <exclude name="directory" />
+            </run>
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientMetadataIT" />
+        </classes>
+    </test>
+    <test name="Manta Client Integration Tests [Move Operations]">
+        <groups>
+            <define name="move" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientIT" />
+        </classes>
+    </test>
+    <test name="Manta Client Error Tests ">
+        <groups>
+            <define name="error" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientErrorIT" />
+        </classes>
+    </test>
+    <test name="Manta Client Integration Tests [Modified Time]">
+        <groups>
+            <define name="mtime" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientIT" />
+        </classes>
+    </test>
     <test name="Manta Client Integration Tests [Unencrypted]">
         <groups>
+            <define name="unencrypted" />
             <run>
+                <include name="directory" />
                 <include name="error" />
                 <include name="headers" />
+                <include name="move" />
+                <include name="mtime" />
+                <include name="metadata" />
                 <exclude name="encryptable" />
+                <exclude name="cbc-cipher" />
+                <exclude name="ctr-cipher" />
+                <exclude name="gcm-cipher" />
                 <exclude name="encryption-provider" />
-                <exclude name="directory" />
                 <exclude name="jobs" />
                 <exclude name="nightly" />
                 <exclude name="seekable" />
@@ -48,14 +91,12 @@
           so we resort to listing all desired unencrypted tests. This also helps discoverability!
           -->
         <classes>
-            <class name="com.joyent.manta.client.MantaClientDirectoriesIT" />
             <class name="com.joyent.manta.client.MantaClientFindIT" />
             <class name="com.joyent.manta.client.MantaClientIT" />
             <class name="com.joyent.manta.client.MantaClientMetadataIT" />
             <class name="com.joyent.manta.client.MantaClientRangeIT" />
             <class name="com.joyent.manta.client.MantaClientSeekableByteChannelIT" />
             <class name="com.joyent.manta.client.MantaClientSigningIT" />
-            <class name="com.joyent.manta.client.MantaDirectoryListingIteratorIT" />
             <class name="com.joyent.manta.client.MantaObjectOutputStreamIT" />
 
             <!-- Jobs-based MPU tests-->
@@ -63,9 +104,11 @@
             <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
         </classes>
     </test>
+
     <!-- We run many of the integration tests over again using client-side encryption -->
     <test name="Manta Client Heavyweight Tests">
         <parameter name="usingEncryption" value="true" />
+        <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
         <groups>
             <define name="nightly" />
         </groups>
@@ -74,6 +117,22 @@
             <class name="com.joyent.manta.client.multipart.EncryptedJobsMultipartManagerIT" />
             <class name="com.joyent.manta.client.multipart.JobsMultipartManagerIT" />
             <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
+        </classes>
+    </test>
+    <test name="Manta Client Encrypted Integration Tests">
+        <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
+        <groups>
+            <define name="encryptable" />
+            <run>
+                <include name="put" />
+                <exclude name="seekable" />
+                <exclude name="multipart" />
+            </run>
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientIT" />
+            <class name="com.joyent.manta.client.MantaClientMetadataIT" />
+            <class name="com.joyent.manta.client.MantaObjectOutputStreamIT" />
         </classes>
     </test>
     <test name="Manta Client Put Operations Integration Tests">
@@ -85,15 +144,6 @@
             <class name="com.joyent.manta.client.MantaClientPutIT" />
         </classes>
     </test>
-    <test name="Manta Client Integration Tests [Modified Time]">
-        <parameter name="usingEncryption" value="true" />
-        <groups>
-            <define name="mtime" />
-        </groups>
-        <classes>
-            <class name="com.joyent.manta.client.MantaClientIT" />
-        </classes>
-    </test>
     <test name="Manta Client Seekable Channel Tests">
         <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
         <groups>
@@ -103,42 +153,21 @@
             <class name="com.joyent.manta.client.MantaClientSeekableByteChannelIT" />
         </classes>
     </test>
-    <test name="Manta Client Integration Tests [Move Operations]">
-        <groups>
-            <define name="move" />
-        </groups>
-        <classes>
-            <class name="com.joyent.manta.client.MantaClientIT" />
-        </classes>
-    </test>
-    <test name="Manta Client Metadata Tests [Metadata Operations]">
-        <groups>
-            <define name="metadata" />
-        </groups>
-        <classes>
-            <class name="com.joyent.manta.client.MantaClientIT" />
-        </classes>
-    </test>
     <test name="Manta Client Integration Tests [AES128/CTR Encrypted]">
         <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
         <groups>
+            <define name="ctr-cipher" />
             <run>
-                <include name="put" />
-                <include name="seekable" />
+                <include name="encryptable" />
                 <exclude name="encryption-provider" />
                 <exclude name="nightly" />
             </run>
         </groups>
         <classes>
-            <class name="com.joyent.manta.client.MantaClientIT" />
-            <class name="com.joyent.manta.client.MantaClientMetadataIT" />
-            <class name="com.joyent.manta.client.MantaObjectOutputStreamIT" />
-
             <!-- Range Operations only support AES/CTR -->
             <class name="com.joyent.manta.client.MantaClientRangeIT" />
 
             <!-- MPU only supports AES/CTR -->
-            <class name="com.joyent.manta.client.multipart.EncryptedJobsMultipartManagerIT" />
             <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerIT" />
             <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerSerializationIT" />
         </classes>
@@ -146,32 +175,26 @@
     <test name="Manta Client Integration Tests [AES128/GCM Encrypted]">
         <parameter name="encryptionCipher" value="AES128/GCM/NoPadding"/>
         <groups>
+            <define name="gcm-cipher" />
             <run>
-                <include name="put" />
+                <include name="encryptable" />
                 <exclude name="encryption-provider" />
                 <exclude name="nightly" />
+                <exclude name="multipart" />
             </run>
         </groups>
-        <classes>
-            <class name="com.joyent.manta.client.MantaClientIT" />
-            <class name="com.joyent.manta.client.MantaClientMetadataIT" />
-            <class name="com.joyent.manta.client.MantaObjectOutputStreamIT" />
-        </classes>
     </test>
     <test name="Manta Client Integration Tests [AES128/CBC Encrypted]">
         <parameter name="encryptionCipher" value="AES128/CBC/PKCS5Padding"/>
         <groups>
+            <define name="cbc-cipher" />
             <run>
-                <include name="put" />
+                <include name="encryptable"/>
                 <exclude name="encryption-provider" />
                 <exclude name="nightly" />
+                <exclude name="multipart" />
             </run>
         </groups>
-        <classes>
-            <class name="com.joyent.manta.client.MantaClientIT" />
-            <class name="com.joyent.manta.client.MantaClientMetadataIT" />
-            <class name="com.joyent.manta.client.MantaObjectOutputStreamIT" />
-        </classes>
     </test>
     <test name="Manta Client Snaplinks Tests ">
         <parameter name="usingEncryption" value="true"/>
@@ -182,12 +205,14 @@
             <class name="com.joyent.manta.client.MantaClientSnapLinksIT" />
         </classes>
     </test>
-    <test name="Manta Client Error Tests ">
+    <test name="Manta Client Encrypted Multipart Tests ">
+        <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
         <groups>
-            <define name="error" />
+            <define name="multipart" />
         </groups>
         <classes>
-            <class name="com.joyent.manta.client.MantaClientErrorIT" />
+            <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerIT" />
+            <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerSerializationIT" />
         </classes>
     </test>
 

--- a/java-manta-it/src/test/resources/testng-it.xml
+++ b/java-manta-it/src/test/resources/testng-it.xml
@@ -3,6 +3,7 @@
 
     <listeners>
         <listener class-name="com.joyent.test.util.MantaPathSuiteListener"/>
+        <listener class-name="com.joyent.test.util.TestListingInterceptor" />
     </listeners>
 
     <test name="Manta Client Integration Test Helper Class Tests">
@@ -20,23 +21,47 @@
             <class name="com.joyent.manta.client.MantaDirectoryListingIteratorIT" />
         </classes>
     </test>
+    <test name="Manta Client Http Headers Tests">
+        <groups>
+            <define name="headers" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.http.MantaHttpHeadersIT" />
+        </classes>
+    </test>
     <test name="Manta Client Integration Tests [Unencrypted]">
         <groups>
             <run>
-                <exclude name="encrypted" />
+                <include name="error" />
+                <include name="headers" />
+                <exclude name="encryptable" />
                 <exclude name="encryption-provider" />
                 <exclude name="directory" />
                 <exclude name="jobs" />
                 <exclude name="nightly" />
+                <exclude name="seekable" />
             </run>
         </groups>
-        <packages>
-            <package name="com.joyent.manta.client.*">
-                <exclude name="com.joyent.manta.client.jobs"/>
-            </package>
-            <package name="com.joyent.manta.client.multipart.*"/>
-            <package name="com.joyent.manta.http.*"/>
-        </packages>
+        <!--
+          excluding tests by group only works if everything is in a group. e.g. we are currently unable to exclude
+          EncryptedServerSideMultipartManagerSerializationIT by adding groups > run > exclude = "encryptable" group
+          so we resort to listing all desired unencrypted tests. This also helps discoverability!
+          -->
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientDirectoriesIT" />
+            <class name="com.joyent.manta.client.MantaClientFindIT" />
+            <class name="com.joyent.manta.client.MantaClientIT" />
+            <class name="com.joyent.manta.client.MantaClientMetadataIT" />
+            <class name="com.joyent.manta.client.MantaClientRangeIT" />
+            <class name="com.joyent.manta.client.MantaClientSeekableByteChannelIT" />
+            <class name="com.joyent.manta.client.MantaClientSigningIT" />
+            <class name="com.joyent.manta.client.MantaDirectoryListingIteratorIT" />
+            <class name="com.joyent.manta.client.MantaObjectOutputStreamIT" />
+
+            <!-- Jobs-based MPU tests-->
+            <class name="com.joyent.manta.client.multipart.JobsMultipartManagerIT" />
+            <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
+        </classes>
     </test>
     <!-- We run many of the integration tests over again using client-side encryption -->
     <test name="Manta Client Heavyweight Tests">
@@ -51,6 +76,15 @@
             <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
         </classes>
     </test>
+    <test name="Manta Client Put Operations Integration Tests">
+        <parameter name="usingEncryption" value="true" />
+        <groups>
+            <define name="put" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientPutIT" />
+        </classes>
+    </test>
     <test name="Manta Client Integration Tests [Modified Time]">
         <parameter name="usingEncryption" value="true" />
         <groups>
@@ -60,8 +94,16 @@
             <class name="com.joyent.manta.client.MantaClientIT" />
         </classes>
     </test>
+    <test name="Manta Client Seekable Channel Tests">
+        <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
+        <groups>
+            <define name="seekable" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientSeekableByteChannelIT" />
+        </classes>
+    </test>
     <test name="Manta Client Integration Tests [Move Operations]">
-        <parameter name="usingEncryption" value="true" />
         <groups>
             <define name="move" />
         </groups>
@@ -70,7 +112,6 @@
         </classes>
     </test>
     <test name="Manta Client Metadata Tests [Metadata Operations]">
-        <parameter name="usingEncryption" value="true" />
         <groups>
             <define name="metadata" />
         </groups>
@@ -79,50 +120,58 @@
         </classes>
     </test>
     <test name="Manta Client Integration Tests [AES128/CTR Encrypted]">
-        <parameter name="usingEncryption" value="true"/>
         <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
         <groups>
             <run>
+                <include name="put" />
+                <include name="seekable" />
                 <exclude name="encryption-provider" />
                 <exclude name="nightly" />
             </run>
         </groups>
-        <packages>
-            <package name="com.joyent.manta.client.*">
-                <exclude name="com.joyent.manta.client.jobs"/>
-            </package>
-            <package name="com.joyent.manta.client.multipart.*"/>
-        </packages>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientIT" />
+            <class name="com.joyent.manta.client.MantaClientMetadataIT" />
+            <class name="com.joyent.manta.client.MantaObjectOutputStreamIT" />
+
+            <!-- Range Operations only support AES/CTR -->
+            <class name="com.joyent.manta.client.MantaClientRangeIT" />
+
+            <!-- MPU only supports AES/CTR -->
+            <class name="com.joyent.manta.client.multipart.EncryptedJobsMultipartManagerIT" />
+            <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerIT" />
+            <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerSerializationIT" />
+        </classes>
     </test>
     <test name="Manta Client Integration Tests [AES128/GCM Encrypted]">
-        <parameter name="usingEncryption" value="true"/>
         <parameter name="encryptionCipher" value="AES128/GCM/NoPadding"/>
         <groups>
             <run>
+                <include name="put" />
                 <exclude name="encryption-provider" />
                 <exclude name="nightly" />
             </run>
         </groups>
-        <packages>
-            <package name="com.joyent.manta.client.*">
-                <exclude name="com.joyent.manta.client.jobs"/>
-            </package>
-        </packages>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientIT" />
+            <class name="com.joyent.manta.client.MantaClientMetadataIT" />
+            <class name="com.joyent.manta.client.MantaObjectOutputStreamIT" />
+        </classes>
     </test>
     <test name="Manta Client Integration Tests [AES128/CBC Encrypted]">
-        <parameter name="usingEncryption" value="true"/>
         <parameter name="encryptionCipher" value="AES128/CBC/PKCS5Padding"/>
         <groups>
             <run>
+                <include name="put" />
                 <exclude name="encryption-provider" />
                 <exclude name="nightly" />
             </run>
         </groups>
-        <packages>
-            <package name="com.joyent.manta.client.*">
-                <exclude name="com.joyent.manta.client.jobs"/>
-            </package>
-        </packages>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientIT" />
+            <class name="com.joyent.manta.client.MantaClientMetadataIT" />
+            <class name="com.joyent.manta.client.MantaObjectOutputStreamIT" />
+        </classes>
     </test>
     <test name="Manta Client Snaplinks Tests ">
         <parameter name="usingEncryption" value="true"/>
@@ -133,6 +182,16 @@
             <class name="com.joyent.manta.client.MantaClientSnapLinksIT" />
         </classes>
     </test>
+    <test name="Manta Client Error Tests ">
+        <groups>
+            <define name="error" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientErrorIT" />
+        </classes>
+    </test>
+
+    <!-- Jobs tests not related to MPU -->
     <test name="Manta Job Tests">
         <groups>
             <define name="jobs" />
@@ -142,6 +201,7 @@
         </groups>
         <classes>
             <class name="com.joyent.manta.client.jobs.MantaClientJobIT" />
+            <class name="com.joyent.manta.client.jobs.MantaJobBuilderIT" />
         </classes>
     </test>
 </suite>

--- a/java-manta-it/src/test/resources/testng-it.xml
+++ b/java-manta-it/src/test/resources/testng-it.xml
@@ -11,12 +11,23 @@
             <class name="com.joyent.test.util.RandomInputStreamTest"/>
         </classes>
     </test>
-
+    <test name="Manta Client Directory Tests">
+        <groups>
+            <define name="directory" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientDirectoriesIT" />
+            <class name="com.joyent.manta.client.MantaDirectoryListingIteratorIT" />
+        </classes>
+    </test>
     <test name="Manta Client Integration Tests [Unencrypted]">
         <groups>
             <run>
-                <exclude name="encrypted"/>
+                <exclude name="encrypted" />
                 <exclude name="encryption-provider" />
+                <exclude name="directory" />
+                <exclude name="jobs" />
+                <exclude name="nightly" />
             </run>
         </groups>
         <packages>
@@ -28,12 +39,52 @@
         </packages>
     </test>
     <!-- We run many of the integration tests over again using client-side encryption -->
+    <test name="Manta Client Heavyweight Tests">
+        <parameter name="usingEncryption" value="true" />
+        <groups>
+            <define name="nightly" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.jobs.MantaClientJobIT" />
+            <class name="com.joyent.manta.client.multipart.EncryptedJobsMultipartManagerIT" />
+            <class name="com.joyent.manta.client.multipart.JobsMultipartManagerIT" />
+            <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
+        </classes>
+    </test>
+    <test name="Manta Client Integration Tests [Modified Time]">
+        <parameter name="usingEncryption" value="true" />
+        <groups>
+            <define name="mtime" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientIT" />
+        </classes>
+    </test>
+    <test name="Manta Client Integration Tests [Move Operations]">
+        <parameter name="usingEncryption" value="true" />
+        <groups>
+            <define name="move" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientIT" />
+        </classes>
+    </test>
+    <test name="Manta Client Metadata Tests [Metadata Operations]">
+        <parameter name="usingEncryption" value="true" />
+        <groups>
+            <define name="metadata" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientIT" />
+        </classes>
+    </test>
     <test name="Manta Client Integration Tests [AES128/CTR Encrypted]">
         <parameter name="usingEncryption" value="true"/>
         <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
         <groups>
             <run>
                 <exclude name="encryption-provider" />
+                <exclude name="nightly" />
             </run>
         </groups>
         <packages>
@@ -49,6 +100,7 @@
         <groups>
             <run>
                 <exclude name="encryption-provider" />
+                <exclude name="nightly" />
             </run>
         </groups>
         <packages>
@@ -63,6 +115,7 @@
         <groups>
             <run>
                 <exclude name="encryption-provider" />
+                <exclude name="nightly" />
             </run>
         </groups>
         <packages>
@@ -81,8 +134,14 @@
         </classes>
     </test>
     <test name="Manta Job Tests">
-        <packages>
-            <package name="com.joyent.manta.client.jobs.*"/>
-        </packages>
+        <groups>
+            <define name="jobs" />
+            <run>
+                <exclude name="nightly" />
+            </run>
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.jobs.MantaClientJobIT" />
+        </classes>
     </test>
 </suite>


### PR DESCRIPTION
# Overview

Adds a `it.dryRun` property that can be used to list the tests that would run with their respective TestNG params. TestNG unfortunately doesn't completely support filtering a test suite by groups so thorough detailing was required in suite definition.

Output of `mvn verify it.dryRun=true` using current `testng-it.xml` used with `TestListingInterceptor`:
```
[main] INFO  com.joyent.test.util.MantaPathSuiteListener [ ] - Base manta path for suite Java Manta SDK Integration Test Suite: ~~/stor/java-manta-integration-tests/-some UUID-

[main] INFO  com.joyent.test.util.MantaPathSuiteListener [ ] - Expected test count: 229

[main] WARN  com.joyent.test.util.MantaPathSuiteListener [ ] - Skipping suite cleanup since dry-run is enabled.

[main] INFO  com.joyent.test.util.TestListingInterceptor [ ] - DRY-RUN: Listing [229] tests that would have run

```

List for the output for [before](https://gist.github.com/tjcelaya/fa82e54bd4be55ec95e1146954d7bd1f) & [after](https://gist.github.com/nairashwin952013/ae0a4799525654588bcce24e9595fd6a)  `-Dit.dryRun=true` respectively . Note that`dry-run-after` list is accurate since it shows single value for `encryptionCipher` i.e `AES128/CTR/NoPadding`. Other testing groups include `cbc-cipher` and `gcm-cipher` are also defined. 

# Changes

- change `usingEncryption` (boolean) to just `encryptionCipher` (string). omission (null) disables encryption

- add a new constructor for `IntegrationTestConfigContext` which handles the above

- switch from `@BeforeClass` with `@Parameters` to test constructors with just `@Parameters`. Whenever `SkipException` was thrown or `putDirectory` was called in a test which needed `@Parameters` a minimal method was created for `@BeforeClass`. The goal here was to make it safe to instantiate test classes without incurring side-effects.

- remove encryption param from tests which don't actually perform any object PUTs or MPU uploads (e.g. `MantaClientDirectoriesIT`)

- change `<packages>` to `<classes>` and target specific classes. 

- document a new system property `it.dryrun` which can be used by the new interceptor. When this system property is truthy as defined by `BooleanUtils#toBooleanObject`, i.e. the following are all true: `y`, `Y`, `t`, `T`, `on`, `ON`, `yes`, `YES`, `true`, `TRUE` and all the mixed-case versions thereof

- added a test listener called `TestListingInterceptor` which is used to collect suite definitions and disable actually running tests in the event `it.dryrun` is `true`.

- defined new `testng-groups` and the **EXISTING** ones  in `testing-it.xml` more accurately using class-level specifications including `jobs`, `snaplinks`, `nightly`, `seekable`, `mtime`, `error`, `headers`, `directory`, `metadata`, `move`

- Following up on #492 which **had** to be closed due to ```dependency-vulnerabilities```.

- Changes are incorporated from the closed PR #364 by Tomas which is to remove redundancies in ```integration-test``` runs.