### PR TITLE
Added New Test Definitions error, seekable, etc. Remove redundant test runs & Introduce dry test runs

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -54,15 +54,23 @@ property or `MANTA_IT_NO_CLEANUP` environment variable.
 
 # Running Tests
 
-Run `mvn verify` from the project root to run all tests. Some Maven goals will
-not work
+Run `mvn verify` from the project root to run all tests. Some Maven goals will not work.
 
 While the Java Cryptography Extensions are expected to be installed, it is
-possible torun a subset of the test suite by adding
+possible to run a subset of the test suite by adding
 `-DexcludedGroups=unlimited-crypto`, e.g.:
 ```
 mvn test -DexcludedGroups=unlimited-crypto
 ```
+
+Also, if we are running a defined TestNG group, invoke
+`-Dgroups=groupname`, e.g:
+```
+mvn clean verify -Dgroups=headers
+```
+
+Note: Since we have transitioned from wildcard to explicit test definition, it is **essential**
+for engineers to add tests complying with the nature of their corresponding test-groups.
 
 ## Dry run
 	

--- a/TESTING.md
+++ b/TESTING.md
@@ -58,19 +58,30 @@ Run `mvn verify` from the project root to run all tests. Some Maven goals will n
 
 While the Java Cryptography Extensions are expected to be installed, it is
 possible to run a subset of the test suite by adding
-`-DexcludedGroups=unlimited-crypto`, e.g.:
+`-Dtestnames=Manta Client Error Tests,Manta Client Timeout Tests`, e.g
 ```
-mvn test -DexcludedGroups=unlimited-crypto
+mvn test -Dtestnames=Manta Client Error Tests,Manta Client Timeout Tests
 ```
 
-Also, if we are running a defined TestNG group, invoke
-`-Dgroups=groupname`, e.g:
+Also, if we are running a defined TestNG testname, invoke
+`-Dtestname=testname`, e.g:
+
 ```
-mvn clean verify -Dgroups=headers
+mvn clean verify -Dtestname=Manta Client Snaplinks Tests
 ```
 
 Note: Since we have transitioned from wildcard to explicit test definition, it is **essential**
-for engineers to add tests complying with the nature of their corresponding test-groups.
+for engineers to add integration-tests in `testng-it.xml` file complying with the nature of their 
+corresponding test-names. For instance, if we create a new integration-test `ExampleHttpHeadersIT.java` 
+for headers, that test will be defined under:
+```
+    <test name="Manta Client Http Headers Tests">
+        <classes>
+            <class name="com.joyent.manta.http.MantaHttpHeadersIT" />
+            <class name="com.joyent.manta.http.ExampleHttpHeadersIT" />
+        </classes>
+    </test>
+```
 
 ## Dry run
 	

--- a/TESTING.md
+++ b/TESTING.md
@@ -64,6 +64,17 @@ possible torun a subset of the test suite by adding
 mvn test -DexcludedGroups=unlimited-crypto
 ```
 
+## Dry run
+	
+The following invocation will print a list of which integration tests would run and their relevant
+parameters::
+	
+```
+mvn verify -Dit.dryRun=true
+```
+	
+Note: This has not yet been expanded to unit tests.
+	
 # Writing Tests
 
 The `java-manta-client` module contains unit tests. Integration tests generally

--- a/TESTING.md
+++ b/TESTING.md
@@ -71,10 +71,10 @@ Also, if we are running a defined TestNG group, invoke
 mvn clean verify -Dgroups=headers
 ```
 
-Note: Since we have transitioned from wildcard to explicit test definition, it is **essential**
-for engineers to add integration-tests in `testng-it.xml` file complying with the nature of their 
-corresponding TestNG groups. For instance, if we create a new integration-test `ExampleHttpHeadersIT.java` 
-for `headers`, that test will be defined under:
+Note: Since we have transitioned from wildcard to explicit test definition (i.e `package-level` 
+to `class-level` hierarchy), engineers are required to add integration-tests in `testng-it.xml` file 
+complying with the nature of their corresponding TestNG groups. For instance, if we create a new 
+integration-test `ExampleHttpHeadersIT.java` for `headers`, that test will be defined under:
 ```
     <test name="Manta Client Http Headers Tests">
         <groups>
@@ -96,7 +96,7 @@ parameters::
 mvn verify -Dit.dryRun=true
 ```
 	
-Note: This has not yet been expanded to unit tests.
+Note: This feature is invalid for unit tests.
 	
 # Writing Tests
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -58,24 +58,28 @@ Run `mvn verify` from the project root to run all tests. Some Maven goals will n
 
 While the Java Cryptography Extensions are expected to be installed, it is
 possible to run a subset of the test suite by adding
-`-Dtestnames=Manta Client Error Tests,Manta Client Timeout Tests`, e.g
+`-DexcludedGroups=unlimited-crypto` or `-Dgroups=headers,error`, e.g.
 ```
-mvn test -Dtestnames=Manta Client Error Tests,Manta Client Timeout Tests
+mvn test -DexcludedGroups=unlimited-crypto
+mvn verify -Dgroups=headers,error
 ```
 
-Also, if we are running a defined TestNG testname, invoke
-`-Dtestname=testname`, e.g:
+Also, if we are running a defined TestNG group, invoke
+`-Dgroups=headers`, e.g:
 
 ```
-mvn clean verify -Dtestname=Manta Client Snaplinks Tests
+mvn clean verify -Dgroups=headers
 ```
 
 Note: Since we have transitioned from wildcard to explicit test definition, it is **essential**
 for engineers to add integration-tests in `testng-it.xml` file complying with the nature of their 
-corresponding test-names. For instance, if we create a new integration-test `ExampleHttpHeadersIT.java` 
-for headers, that test will be defined under:
+corresponding TestNG groups. For instance, if we create a new integration-test `ExampleHttpHeadersIT.java` 
+for `headers`, that test will be defined under:
 ```
     <test name="Manta Client Http Headers Tests">
+        <groups>
+            <define name="headers" />
+        </groups>
         <classes>
             <class name="com.joyent.manta.http.MantaHttpHeadersIT" />
             <class name="com.joyent.manta.http.ExampleHttpHeadersIT" />

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientDirectoriesIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientDirectoriesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2015-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -32,7 +32,7 @@ import static com.joyent.manta.util.MantaUtils.writeablePrefixPaths;
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  */
-@Test(groups = { "directory" })
+@Test(groups = {"directory"})
 public class MantaClientDirectoriesIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(MantaClientDirectoriesIT.class);

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientDirectoriesIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientDirectoriesIT.java
@@ -29,8 +29,6 @@ import static com.joyent.manta.util.MantaUtils.writeablePrefixPaths;
 /**
  * Tests for verifying the correct functioning of making remote requests
  * against Manta directories.
- *
- * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  */
 @Test(groups = {"directory"})
 public class MantaClientDirectoriesIT {

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientErrorIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientErrorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2015-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -16,8 +16,6 @@ import com.joyent.test.util.MantaFunction;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Optional;
-import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -33,8 +31,9 @@ import static com.joyent.manta.exception.MantaErrorCode.RESOURCE_NOT_FOUND_ERROR
  * failures.
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
-@Test(groups = { "error" })
+@Test(groups = {"error"})
 public class MantaClientErrorIT {
     private MantaClient mantaClient;
 
@@ -43,11 +42,9 @@ public class MantaClientErrorIT {
     private String testPathPrefix;
 
     @BeforeClass
-    @Parameters({"usingEncryption"})
-    public void beforeClass(@Optional Boolean usingEncryption) throws IOException {
-
+    public void beforeClass() throws IOException {
         // Let TestNG configuration take precedence over environment variables
-        config = new IntegrationTestConfigContext(usingEncryption);
+        config = new IntegrationTestConfigContext();
 
         mantaClient = new MantaClient(config);
         testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientErrorIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientErrorIT.java
@@ -29,9 +29,6 @@ import static com.joyent.manta.exception.MantaErrorCode.RESOURCE_NOT_FOUND_ERROR
 /**
  * Tests for verifying the correct behavior of error handling from Manta API
  * failures.
- *
- * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
- * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
 @Test(groups = {"error"})
 public class MantaClientErrorIT {

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
@@ -47,10 +47,6 @@ import static com.joyent.manta.exception.MantaErrorCode.RESOURCE_NOT_FOUND_ERROR
 
 /**
  * Tests the basic functionality of the {@link MantaClient} class.
- *
- * @author <a href="https://github.com/yunong">Yunong Xiao</a>
- * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
- * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
 @Test(groups = {"encryptable"})
 public class MantaClientIT {

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
@@ -48,7 +48,7 @@ import static com.joyent.manta.exception.MantaErrorCode.RESOURCE_NOT_FOUND_ERROR
 /**
  * Tests the basic functionality of the {@link MantaClient} class.
  */
-@Test(groups = {"encryptable"})
+@Test(groups = {"encrypted"})
 public class MantaClientIT {
 
     private static final String TEST_DATA = "EPISODEII_IS_BEST_EPISODE";

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
@@ -52,24 +52,27 @@ import static com.joyent.manta.exception.MantaErrorCode.RESOURCE_NOT_FOUND_ERROR
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
-@Test
+@Test(groups = {"encryptable"})
 public class MantaClientIT {
 
     private static final String TEST_DATA = "EPISODEII_IS_BEST_EPISODE";
 
-    private MantaClient mantaClient;
+    private final MantaClient mantaClient;
 
-    private String testPathPrefix;
+    private final String testPathPrefix;
 
-    @BeforeClass
-    @Parameters({"usingEncryption"})
-    public void beforeClass(@Optional Boolean usingEncryption) throws IOException {
+    @Parameters({"encryptionCipher"})
+    public MantaClientIT(final @Optional String encryptionCipher) {
 
         // Let TestNG configuration take precedence over environment variables
-        ConfigContext config = new IntegrationTestConfigContext(usingEncryption);
+        ConfigContext config = new IntegrationTestConfigContext(encryptionCipher);
 
         mantaClient = new MantaClient(config);
         testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
+    }
+
+    @BeforeClass
+    public void beforeClass() throws IOException {
         mantaClient.putDirectory(testPathPrefix, true);
     }
 

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientMetadataIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientMetadataIT.java
@@ -178,7 +178,7 @@ public class MantaClientMetadataIT {
         }
     }
 
-    @Test(groups = "encryptable")
+    @Test(groups = "encrypted")
     public void verifyAddEncryptedMetadataToObjectOnPut() throws IOException {
         if (!mantaClient.getContext().isClientEncryptionEnabled()) {
             throw new SkipException("Test is only relevant when client-side encryption is enabled");
@@ -208,7 +208,7 @@ public class MantaClientMetadataIT {
         Assert.assertEquals(get.getHeaderAsString("e-force"), "true");
     }
 
-    @Test(groups = "encryptable")
+    @Test(groups = "encrypted")
     public final void verifyEncryptedMetadataCanBeAddedLater() throws IOException {
         if (!mantaClient.getContext().isClientEncryptionEnabled()) {
             throw new SkipException("Test is only relevant when client-side encryption is enabled");

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientMetadataIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientMetadataIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2015-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -26,8 +26,9 @@ import java.util.UUID;
  * Tests for verifying the behavior of metadata with {@link MantaClient}.
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
-@Test( groups = { "metadata" })
+@Test(groups = {"metadata"})
 public class MantaClientMetadataIT {
     private static final String TEST_DATA = "EPISODEII_IS_BEST_EPISODE";
 
@@ -35,15 +36,18 @@ public class MantaClientMetadataIT {
 
     private String testPathPrefix;
 
-    @BeforeClass
-    @Parameters({"usingEncryption"})
-    public void beforeClass(@Optional Boolean usingEncryption) throws IOException {
+    @Parameters({"encryptionCipher"})
+    public void beforeClass(final @Optional String encryptionCipher) throws IOException {
 
         // Let TestNG configuration take precedence over environment variables
-        ConfigContext config = new IntegrationTestConfigContext(usingEncryption);
+        ConfigContext config = new IntegrationTestConfigContext(encryptionCipher);
 
         mantaClient = new MantaClient(config);
         testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
+    }
+
+    @BeforeClass
+    public void beforeClass() throws IOException {
         mantaClient.putDirectory(testPathPrefix, true);
     }
 
@@ -177,7 +181,7 @@ public class MantaClientMetadataIT {
         }
     }
 
-    @Test(groups = "encrypted")
+    @Test(groups = "encryptable")
     public void verifyAddEncryptedMetadataToObjectOnPut() throws IOException {
         if (!mantaClient.getContext().isClientEncryptionEnabled()) {
             throw new SkipException("Test is only relevant when client-side encryption is enabled");
@@ -207,7 +211,7 @@ public class MantaClientMetadataIT {
         Assert.assertEquals(get.getHeaderAsString("e-force"), "true");
     }
 
-    @Test(groups = "encrypted")
+    @Test(groups = "encryptable")
     public final void verifyEncryptedMetadataCanBeAddedLater() throws IOException {
         if (!mantaClient.getContext().isClientEncryptionEnabled()) {
             throw new SkipException("Test is only relevant when client-side encryption is enabled");

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientMetadataIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientMetadataIT.java
@@ -24,20 +24,17 @@ import java.util.UUID;
 
 /**
  * Tests for verifying the behavior of metadata with {@link MantaClient}.
- *
- * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
- * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
 @Test(groups = {"metadata"})
 public class MantaClientMetadataIT {
     private static final String TEST_DATA = "EPISODEII_IS_BEST_EPISODE";
 
-    private MantaClient mantaClient;
+    private final MantaClient mantaClient;
 
-    private String testPathPrefix;
+    private final String testPathPrefix;
 
     @Parameters({"encryptionCipher"})
-    public void beforeClass(final @Optional String encryptionCipher) throws IOException {
+    public MantaClientMetadataIT(final @Optional String encryptionCipher) {
 
         // Let TestNG configuration take precedence over environment variables
         ConfigContext config = new IntegrationTestConfigContext(encryptionCipher);

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientMetadataIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientMetadataIT.java
@@ -149,7 +149,7 @@ public class MantaClientMetadataIT {
                 String.format("Actual metadata: %s", get.getMetadata()));
     }
 
-    @Test(groups = { "metadata", "directory" })
+    @Test
     public void canAddMetadataToDirectory() throws IOException {
         String dir = String.format("%s%s", testPathPrefix, UUID.randomUUID());
         mantaClient.putDirectory(dir);

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientPutIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientPutIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2016-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -42,7 +42,13 @@ import java.util.UUID;
 
 import static com.joyent.manta.exception.MantaErrorCode.RESOURCE_NOT_FOUND_ERROR;
 
-@Test
+/**
+ * Tests the basic functionality of the put operations in {@link MantaClient} class.
+ *
+ * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
+ */
+@Test(groups = {"put"})
 public class MantaClientPutIT {
 
     private static final String TEST_DATA = "EPISODEII_IS_BEST_EPISODE";

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientPutIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientPutIT.java
@@ -44,9 +44,6 @@ import static com.joyent.manta.exception.MantaErrorCode.RESOURCE_NOT_FOUND_ERROR
 
 /**
  * Tests the basic functionality of the put operations in {@link MantaClient} class.
- *
- * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
- * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
 @Test(groups = {"put"})
 public class MantaClientPutIT {

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientRangeIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientRangeIT.java
@@ -30,9 +30,6 @@ import java.util.UUID;
 /**
  * Tests for verifying the correct behavior of range operations performed by
  * the {@link MantaClient} class.
- *
- * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
- * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
 @Test
 public class MantaClientRangeIT {

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSeekableByteChannelIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSeekableByteChannelIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2015-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -37,21 +37,18 @@ import java.util.UUID;
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  */
-@Test(groups = { "seekable" })
+@Test(groups = {"seekable", "encryptable"})
 public class MantaClientSeekableByteChannelIT {
     private static final String TEST_DATA = "EPISODEII_IS_BEST_EPISODE";
 
-    private MantaClient mantaClient;
+    private final MantaClient mantaClient;
 
-    private String testPathPrefix;
+    private final String testPathPrefix;
 
-
-    @BeforeClass
-    @Parameters({"usingEncryption"})
-    public void beforeClass(@Optional Boolean usingEncryption) throws IOException {
-
+    @Parameters({"encryptionCipher"})
+    public MantaClientSeekableByteChannelIT(final @Optional String encryptionCipher) {
         // Let TestNG configuration take precedence over environment variables
-        SettableConfigContext<BaseChainedConfigContext> config = new IntegrationTestConfigContext(usingEncryption);
+        SettableConfigContext<BaseChainedConfigContext> config = new IntegrationTestConfigContext(encryptionCipher);
 
         // Range request have to be in optional authentication mode
         if (config.isClientEncryptionEnabled()) {
@@ -60,6 +57,10 @@ public class MantaClientSeekableByteChannelIT {
 
         mantaClient = new MantaClient(config);
         testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
+    }
+
+    @BeforeClass
+    public void beforeClass() throws IOException {
         mantaClient.putDirectory(testPathPrefix, true);
     }
 
@@ -68,7 +69,6 @@ public class MantaClientSeekableByteChannelIT {
         IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
-    @Test
     public final void seekableByteSize() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -82,7 +82,6 @@ public class MantaClientSeekableByteChannelIT {
         }
     }
 
-    @Test
     public final void getAllSeekableBytes() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -94,7 +93,6 @@ public class MantaClientSeekableByteChannelIT {
         }
     }
 
-    @Test
     public final void getAllSeekableBytesAtPosition() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -109,7 +107,6 @@ public class MantaClientSeekableByteChannelIT {
         }
     }
 
-    @Test
     public final void readFromDifferentPositions() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -133,7 +130,6 @@ public class MantaClientSeekableByteChannelIT {
         }
     }
 
-    @Test
     public final void readAllSeekableBytesFromPositionAsInputStream() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -157,7 +153,6 @@ public class MantaClientSeekableByteChannelIT {
         }
     }
 
-    @Test
     public final void skipUsingInputStream() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -223,7 +218,6 @@ public class MantaClientSeekableByteChannelIT {
         }
     }
 
-    @Test( groups = { "seekable" })
     public final void getFromForwardPosition() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -241,7 +235,6 @@ public class MantaClientSeekableByteChannelIT {
         }
     }
 
-    @Test( groups = { "seekable" } )
     public final void getFromBaseChannelThenForwardPosition() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -262,7 +255,6 @@ public class MantaClientSeekableByteChannelIT {
         }
     }
 
-    @Test( groups = { "seekable" } )
     public final void getFromForwardPositionThenBackwardPosition() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSeekableByteChannelIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSeekableByteChannelIT.java
@@ -34,8 +34,6 @@ import java.util.UUID;
 /**
  * Tests for verifying the behavior of {@link SeekableByteChannel} with
  * {@link MantaClient}.
- *
- * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  */
 @Test(groups = {"seekable", "encryptable"})
 public class MantaClientSeekableByteChannelIT {

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSeekableByteChannelIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSeekableByteChannelIT.java
@@ -35,7 +35,7 @@ import java.util.UUID;
  * Tests for verifying the behavior of {@link SeekableByteChannel} with
  * {@link MantaClient}.
  */
-@Test(groups = {"seekable", "encryptable"})
+@Test(groups = {"seekable", "encrypted"})
 public class MantaClientSeekableByteChannelIT {
     private static final String TEST_DATA = "EPISODEII_IS_BEST_EPISODE";
 

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSnapLinksIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientSnapLinksIT.java
@@ -37,7 +37,7 @@ import static com.joyent.manta.client.MantaClient.SEPARATOR;
  *
  * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
-@Test(groups = "snaplinks")
+@Test(groups = {"snaplinks"})
 public class MantaClientSnapLinksIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(MantaClientSnapLinksIT.class);

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2015-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -12,8 +12,6 @@ import com.joyent.manta.config.IntegrationTestConfigContext;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Optional;
-import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -27,7 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  */
-@Test
+@Test(groups={"directory"})
 public class MantaDirectoryListingIteratorIT {
     private static final String TEST_DATA = "EPISODEII_IS_BEST_EPISODE";
 
@@ -36,11 +34,10 @@ public class MantaDirectoryListingIteratorIT {
     private String testPathPrefix;
 
     @BeforeClass
-    @Parameters({"usingEncryption"})
-    public void beforeClass(@Optional Boolean usingEncryption) throws IOException {
+    public void beforeClass() throws IOException {
 
         // Let TestNG configuration take precedence over environment variables
-        final ConfigContext config = new IntegrationTestConfigContext(usingEncryption);
+        ConfigContext config = new IntegrationTestConfigContext();
 
         mantaClient = new MantaClient(config);
         testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorIT.java
@@ -22,8 +22,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Tests the proper functioning of the dynamically paging iterator.
- *
- * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  */
 @Test(groups={"directory"})
 public class MantaDirectoryListingIteratorIT {

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaObjectOutputStreamIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaObjectOutputStreamIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2016-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -29,23 +29,33 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.UUID;
 
-@Test
+/**
+ * Tests for verifying the behavior of {@link MantaObjectOutputStream} with
+ * {@link MantaClient}.
+ *
+ * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
+ */
+@Test(groups = {"encryptable"})
 public class MantaObjectOutputStreamIT {
     private static final String TEST_DATA = "EPISODEII_IS_BEST_EPISODE";
 
-    private MantaClient mantaClient;
+    private final MantaClient mantaClient;
 
-    private String testPathPrefix;
+    private final String testPathPrefix;
 
-    @BeforeClass()
-    @Parameters({"usingEncryption"})
-    public void beforeClass(@Optional Boolean usingEncryption) throws IOException {
+    @Parameters({"encryptionCipher"})
+    public MantaObjectOutputStreamIT(final @Optional String encryptionCipher) throws IOException {
 
         // Let TestNG configuration take precedence over environment variables
-        ConfigContext config = new IntegrationTestConfigContext(usingEncryption);
+        ConfigContext config = new IntegrationTestConfigContext(encryptionCipher);
 
         mantaClient = new MantaClient(config);
         testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
+    }
+
+    @BeforeClass()
+    public void beforeClass() throws IOException {
         mantaClient.putDirectory(testPathPrefix, true);
     }
 

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaObjectOutputStreamIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaObjectOutputStreamIT.java
@@ -33,7 +33,7 @@ import java.util.UUID;
  * Tests for verifying the behavior of {@link MantaObjectOutputStream} with
  * {@link MantaClient}.
  */
-@Test(groups = {"encryptable"})
+@Test(groups = {"encrypted"})
 public class MantaObjectOutputStreamIT {
     private static final String TEST_DATA = "EPISODEII_IS_BEST_EPISODE";
 

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaObjectOutputStreamIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaObjectOutputStreamIT.java
@@ -32,9 +32,6 @@ import java.util.UUID;
 /**
  * Tests for verifying the behavior of {@link MantaObjectOutputStream} with
  * {@link MantaClient}.
- *
- * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
- * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
 @Test(groups = {"encryptable"})
 public class MantaObjectOutputStreamIT {

--- a/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaClientJobIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaClientJobIT.java
@@ -168,7 +168,7 @@ public class MantaClientJobIT {
         }
     }
 
-    @Test(enabled = false, dependsOnMethods = { "createJob", "getJob" }, groups = { "nightly" })
+    @Test(enabled = false, dependsOnMethods = { "createJob", "getJob" }, groups = { "expensive" })
     public void canListAllJobIDs() throws IOException, InterruptedException {
         final MantaJob job1 = buildJob();
         final UUID job1id = mantaClient.createJob(job1);
@@ -198,7 +198,7 @@ public class MantaClientJobIT {
      * and development environments. The code path for testing job lists is
      * tested elsewhere, but not the specific operation of listing ALL jobs.
      */
-    @Test(enabled = false, dependsOnMethods = { "createJob", "getJob" }, groups = { "nightly" })
+    @Test(enabled = false, dependsOnMethods = { "createJob", "getJob" }, groups = { "expensive" })
     public void canListAllJobs() throws IOException, InterruptedException {
         final MantaJob job1 = buildJob();
         final UUID job1id = mantaClient.createJob(job1);
@@ -229,7 +229,7 @@ public class MantaClientJobIT {
         }
     }
 
-    @Test(enabled = false, dependsOnMethods = { "createJob", "getJob" }, groups = { "nightly" })
+    @Test(enabled = false, dependsOnMethods = { "createJob", "getJob" }, groups = { "expensive" })
     public void canListAllRunningJobIDs() throws IOException, InterruptedException {
         final MantaJob job1 = buildJob();
         final UUID job1id = mantaClient.createJob(job1);
@@ -262,7 +262,7 @@ public class MantaClientJobIT {
         }
     }
 
-    @Test(enabled = false, dependsOnMethods = { "createJob", "getJob" }, groups = { "nightly" })
+    @Test(enabled = false, dependsOnMethods = { "createJob", "getJob" }, groups = { "expensive" })
     public void canListAllRunningJobs() throws IOException, InterruptedException {
         final MantaJob job1 = buildJob();
         final UUID job1id = mantaClient.createJob(job1);

--- a/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaClientJobIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaClientJobIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2015-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -35,8 +35,9 @@ import java.util.stream.Stream;
  * Tests the execution of Manta compute jobs.
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @author <a href="https://github.com/nairashwin952013>Ashwin A Nair</a>
  */
-@Test(groups = { "job" }, retryAnalyzer = ThreeTriesRetryAnalyzer.class)
+@Test(groups = { "jobs" }, retryAnalyzer = ThreeTriesRetryAnalyzer.class)
 public class MantaClientJobIT {
     private static final Logger LOG = LoggerFactory.getLogger(MantaClientJobIT.class);
 
@@ -167,7 +168,7 @@ public class MantaClientJobIT {
         }
     }
 
-    @Test(dependsOnMethods = { "createJob", "getJob" })
+    @Test(enabled = false, dependsOnMethods = { "createJob", "getJob" }, groups = { "nightly" })
     public void canListAllJobIDs() throws IOException, InterruptedException {
         final MantaJob job1 = buildJob();
         final UUID job1id = mantaClient.createJob(job1);
@@ -197,7 +198,7 @@ public class MantaClientJobIT {
      * and development environments. The code path for testing job lists is
      * tested elsewhere, but not the specific operation of listing ALL jobs.
      */
-    @Test(enabled = false, dependsOnMethods = { "createJob", "getJob" })
+    @Test(enabled = false, dependsOnMethods = { "createJob", "getJob" }, groups = { "nightly" })
     public void canListAllJobs() throws IOException, InterruptedException {
         final MantaJob job1 = buildJob();
         final UUID job1id = mantaClient.createJob(job1);
@@ -228,7 +229,7 @@ public class MantaClientJobIT {
         }
     }
 
-    @Test(dependsOnMethods = { "createJob", "getJob" })
+    @Test(enabled = false, dependsOnMethods = { "createJob", "getJob" }, groups = { "nightly" })
     public void canListAllRunningJobIDs() throws IOException, InterruptedException {
         final MantaJob job1 = buildJob();
         final UUID job1id = mantaClient.createJob(job1);
@@ -261,7 +262,7 @@ public class MantaClientJobIT {
         }
     }
 
-    @Test(dependsOnMethods = { "createJob", "getJob" })
+    @Test(enabled = false, dependsOnMethods = { "createJob", "getJob" }, groups = { "nightly" })
     public void canListAllRunningJobs() throws IOException, InterruptedException {
         final MantaJob job1 = buildJob();
         final UUID job1id = mantaClient.createJob(job1);

--- a/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaClientJobIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaClientJobIT.java
@@ -34,7 +34,7 @@ import java.util.stream.Stream;
 /**
  * Tests the execution of Manta compute jobs.
  */
-@Test(groups = { "jobs" , "expensive" }, retryAnalyzer = ThreeTriesRetryAnalyzer.class)
+@Test(groups = { "jobs", "expensive" }, retryAnalyzer = ThreeTriesRetryAnalyzer.class)
 public class MantaClientJobIT {
     private static final Logger LOG = LoggerFactory.getLogger(MantaClientJobIT.class);
 

--- a/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaClientJobIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaClientJobIT.java
@@ -34,7 +34,7 @@ import java.util.stream.Stream;
 /**
  * Tests the execution of Manta compute jobs.
  */
-@Test(groups = { "jobs" }, retryAnalyzer = ThreeTriesRetryAnalyzer.class)
+@Test(groups = { "jobs" , "expensive" }, retryAnalyzer = ThreeTriesRetryAnalyzer.class)
 public class MantaClientJobIT {
     private static final Logger LOG = LoggerFactory.getLogger(MantaClientJobIT.class);
 
@@ -64,7 +64,7 @@ public class MantaClientJobIT {
         IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
-    @Test
+    @Test(groups = { "jobs", "expensive" })
     public void createJob() throws IOException {
         MantaJob job = buildJob();
         UUID jobId = mantaClient.createJob(job);
@@ -74,7 +74,7 @@ public class MantaClientJobIT {
         Assert.assertTrue(accepted, "Cancel request was not accepted");
     }
 
-    @Test(dependsOnMethods = { "createJob" })
+    @Test(groups = { "jobs", "expensive" }, dependsOnMethods = { "createJob" })
     public void getJob() throws IOException {
         MantaJob job = buildJob();
         UUID jobId = mantaClient.createJob(job);
@@ -98,7 +98,7 @@ public class MantaClientJobIT {
         mantaClient.cancelJob(jobId);
     }
 
-    @Test(dependsOnMethods = { "createJob", "getJob" })
+    @Test(groups = { "jobs" }, dependsOnMethods = { "createJob", "getJob" })
     public void cancelJob() throws IOException {
         MantaJob job = buildJob();
         UUID jobId = mantaClient.createJob(job);
@@ -121,7 +121,7 @@ public class MantaClientJobIT {
         Assert.assertNotNull(jobResponse.getTimeCreated());
     }
 
-    @Test(dependsOnMethods = {"createJob"}, successPercentage = 66)
+    @Test(groups = { "jobs" }, dependsOnMethods = {"createJob"}, successPercentage = 66)
     public void canAddAndGetInputsFromIterator() throws IOException {
         MantaJob job = buildJob();
         UUID jobId = mantaClient.createJob(job);
@@ -143,7 +143,7 @@ public class MantaClientJobIT {
         }
     }
 
-    @Test(dependsOnMethods = { "createJob" }, successPercentage = 66)
+    @Test(groups = { "jobs" }, dependsOnMethods = { "createJob" }, successPercentage = 66)
     public void canAddAndGetInputsFromStream() throws IOException {
         MantaJob job = buildJob();
         UUID jobId = mantaClient.createJob(job);
@@ -165,7 +165,7 @@ public class MantaClientJobIT {
         }
     }
 
-    @Test(enabled = false, dependsOnMethods = { "createJob", "getJob" }, groups = { "expensive" })
+    @Test(dependsOnMethods = { "createJob", "getJob" }, groups = { "expensive" })
     public void canListAllJobIDs() throws IOException, InterruptedException {
         final MantaJob job1 = buildJob();
         final UUID job1id = mantaClient.createJob(job1);
@@ -195,7 +195,7 @@ public class MantaClientJobIT {
      * and development environments. The code path for testing job lists is
      * tested elsewhere, but not the specific operation of listing ALL jobs.
      */
-    @Test(enabled = false, dependsOnMethods = { "createJob", "getJob" }, groups = { "expensive" })
+    @Test(dependsOnMethods = { "createJob", "getJob" }, groups = { "expensive" })
     public void canListAllJobs() throws IOException, InterruptedException {
         final MantaJob job1 = buildJob();
         final UUID job1id = mantaClient.createJob(job1);
@@ -226,7 +226,7 @@ public class MantaClientJobIT {
         }
     }
 
-    @Test(enabled = false, dependsOnMethods = { "createJob", "getJob" }, groups = { "expensive" })
+    @Test(dependsOnMethods = { "createJob", "getJob" }, groups = { "expensive" })
     public void canListAllRunningJobIDs() throws IOException, InterruptedException {
         final MantaJob job1 = buildJob();
         final UUID job1id = mantaClient.createJob(job1);
@@ -259,7 +259,7 @@ public class MantaClientJobIT {
         }
     }
 
-    @Test(enabled = false, dependsOnMethods = { "createJob", "getJob" }, groups = { "expensive" })
+    @Test(dependsOnMethods = { "createJob", "getJob" }, groups = { "expensive" })
     public void canListAllRunningJobs() throws IOException, InterruptedException {
         final MantaJob job1 = buildJob();
         final UUID job1id = mantaClient.createJob(job1);
@@ -292,7 +292,7 @@ public class MantaClientJobIT {
         }
     }
 
-    @Test(dependsOnMethods = { "createJob", "getJob" })
+    @Test(groups = { "jobs" }, dependsOnMethods = { "createJob", "getJob" })
     public void canListJobIdsByName() throws IOException {
         final String name = String.format("by_name_%s", UUID.randomUUID());
         final MantaJob job1 = buildJob(name, "cat");
@@ -316,7 +316,7 @@ public class MantaClientJobIT {
         }
     }
 
-    @Test
+    @Test(groups = { "jobs" })
     public void canListOutputsForJobWithNoInputs() throws IOException, InterruptedException {
         final MantaJob job = buildJob();
         final UUID jobId = mantaClient.createJob(job);
@@ -330,7 +330,7 @@ public class MantaClientJobIT {
         Assert.assertEquals(outputs.size(), 0);
     }
 
-    @Test
+    @Test(groups = { "jobs" })
     public void canListOutputsForJobWithOneInput() throws IOException, InterruptedException {
         String path = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
         mantaClient.put(path, TEST_DATA);
@@ -356,7 +356,7 @@ public class MantaClientJobIT {
                 "Output wasn't the same as input");
     }
 
-    @Test
+    @Test(groups = { "jobs" })
     public void canListOutputsForJobAsStreams() throws IOException, InterruptedException {
         String path1 = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
         mantaClient.put(path1, TEST_DATA);
@@ -392,7 +392,7 @@ public class MantaClientJobIT {
         Assert.assertEquals(count.get(), 2, "Missing both outputs");
     }
 
-    @Test
+    @Test(groups = { "jobs" })
     public void canListOutputsForJobAsStrings() throws IOException, InterruptedException {
         String path1 = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
         mantaClient.put(path1, TEST_DATA);
@@ -423,7 +423,7 @@ public class MantaClientJobIT {
         Assert.assertEquals(count.get(), 2, "Missing both outputs");
     }
 
-    @Test
+    @Test(groups = { "jobs" })
     public void canListFailedJobs() throws IOException, InterruptedException {
         String path = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
         mantaClient.put(path, TEST_DATA);
@@ -445,7 +445,7 @@ public class MantaClientJobIT {
         Assert.assertEquals(failures.size(), 1, "There should only be a single failure");
     }
 
-    @Test
+    @Test(groups = { "jobs" })
     public void canGetJobErrors() throws IOException, InterruptedException {
         String path1 = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
         mantaClient.put(path1, TEST_DATA);

--- a/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaClientJobIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaClientJobIT.java
@@ -33,9 +33,6 @@ import java.util.stream.Stream;
 
 /**
  * Tests the execution of Manta compute jobs.
- *
- * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
- * @author <a href="https://github.com/nairashwin952013>Ashwin A Nair</a>
  */
 @Test(groups = { "jobs" }, retryAnalyzer = ThreeTriesRetryAnalyzer.class)
 public class MantaClientJobIT {

--- a/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaClientJobIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaClientJobIT.java
@@ -34,7 +34,7 @@ import java.util.stream.Stream;
 /**
  * Tests the execution of Manta compute jobs.
  */
-@Test(groups = { "jobs", "expensive" }, retryAnalyzer = ThreeTriesRetryAnalyzer.class)
+@Test(groups = { "expensive" }, retryAnalyzer = ThreeTriesRetryAnalyzer.class)
 public class MantaClientJobIT {
     private static final Logger LOG = LoggerFactory.getLogger(MantaClientJobIT.class);
 
@@ -64,7 +64,7 @@ public class MantaClientJobIT {
         IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
-    @Test(groups = { "jobs", "expensive" })
+    @Test(groups = { "expensive" })
     public void createJob() throws IOException {
         MantaJob job = buildJob();
         UUID jobId = mantaClient.createJob(job);
@@ -74,7 +74,7 @@ public class MantaClientJobIT {
         Assert.assertTrue(accepted, "Cancel request was not accepted");
     }
 
-    @Test(groups = { "jobs", "expensive" }, dependsOnMethods = { "createJob" })
+    @Test(groups = { "expensive" }, dependsOnMethods = { "createJob" })
     public void getJob() throws IOException {
         MantaJob job = buildJob();
         UUID jobId = mantaClient.createJob(job);
@@ -98,7 +98,7 @@ public class MantaClientJobIT {
         mantaClient.cancelJob(jobId);
     }
 
-    @Test(groups = { "jobs" }, dependsOnMethods = { "createJob", "getJob" })
+    @Test(dependsOnMethods = { "createJob", "getJob" })
     public void cancelJob() throws IOException {
         MantaJob job = buildJob();
         UUID jobId = mantaClient.createJob(job);
@@ -121,7 +121,7 @@ public class MantaClientJobIT {
         Assert.assertNotNull(jobResponse.getTimeCreated());
     }
 
-    @Test(groups = { "jobs" }, dependsOnMethods = {"createJob"}, successPercentage = 66)
+    @Test(dependsOnMethods = {"createJob"}, successPercentage = 66)
     public void canAddAndGetInputsFromIterator() throws IOException {
         MantaJob job = buildJob();
         UUID jobId = mantaClient.createJob(job);
@@ -143,7 +143,7 @@ public class MantaClientJobIT {
         }
     }
 
-    @Test(groups = { "jobs" }, dependsOnMethods = { "createJob" }, successPercentage = 66)
+    @Test(dependsOnMethods = { "createJob" }, successPercentage = 66)
     public void canAddAndGetInputsFromStream() throws IOException {
         MantaJob job = buildJob();
         UUID jobId = mantaClient.createJob(job);
@@ -292,7 +292,7 @@ public class MantaClientJobIT {
         }
     }
 
-    @Test(groups = { "jobs" }, dependsOnMethods = { "createJob", "getJob" })
+    @Test(dependsOnMethods = { "createJob", "getJob" })
     public void canListJobIdsByName() throws IOException {
         final String name = String.format("by_name_%s", UUID.randomUUID());
         final MantaJob job1 = buildJob(name, "cat");
@@ -316,7 +316,7 @@ public class MantaClientJobIT {
         }
     }
 
-    @Test(groups = { "jobs" })
+    @Test
     public void canListOutputsForJobWithNoInputs() throws IOException, InterruptedException {
         final MantaJob job = buildJob();
         final UUID jobId = mantaClient.createJob(job);
@@ -330,7 +330,7 @@ public class MantaClientJobIT {
         Assert.assertEquals(outputs.size(), 0);
     }
 
-    @Test(groups = { "jobs" })
+    @Test
     public void canListOutputsForJobWithOneInput() throws IOException, InterruptedException {
         String path = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
         mantaClient.put(path, TEST_DATA);
@@ -356,7 +356,7 @@ public class MantaClientJobIT {
                 "Output wasn't the same as input");
     }
 
-    @Test(groups = { "jobs" })
+    @Test
     public void canListOutputsForJobAsStreams() throws IOException, InterruptedException {
         String path1 = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
         mantaClient.put(path1, TEST_DATA);
@@ -392,7 +392,7 @@ public class MantaClientJobIT {
         Assert.assertEquals(count.get(), 2, "Missing both outputs");
     }
 
-    @Test(groups = { "jobs" })
+    @Test
     public void canListOutputsForJobAsStrings() throws IOException, InterruptedException {
         String path1 = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
         mantaClient.put(path1, TEST_DATA);
@@ -423,7 +423,7 @@ public class MantaClientJobIT {
         Assert.assertEquals(count.get(), 2, "Missing both outputs");
     }
 
-    @Test(groups = { "jobs" })
+    @Test
     public void canListFailedJobs() throws IOException, InterruptedException {
         String path = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
         mantaClient.put(path, TEST_DATA);
@@ -445,7 +445,7 @@ public class MantaClientJobIT {
         Assert.assertEquals(failures.size(), 1, "There should only be a single failure");
     }
 
-    @Test(groups = { "jobs" })
+    @Test
     public void canGetJobErrors() throws IOException, InterruptedException {
         String path1 = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
         mantaClient.put(path1, TEST_DATA);

--- a/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaJobBuilderIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaJobBuilderIT.java
@@ -27,8 +27,6 @@ import java.util.stream.Collectors;
 
 /**
  * Tests the execution of Manta compute jobs using the builder fluent interface.
- *
- * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  */
 @Test(groups = "jobs")
 public class MantaJobBuilderIT {

--- a/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaJobBuilderIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaJobBuilderIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2015-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  */
-@Test(dependsOnGroups = "job")
+@Test(groups = "jobs")
 public class MantaJobBuilderIT {
     private static final String TEST_DATA =
               "line 01 aa\n"

--- a/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaJobBuilderIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaJobBuilderIT.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 /**
  * Tests the execution of Manta compute jobs using the builder fluent interface.
  */
-@Test(groups = "jobs")
+@Test
 public class MantaJobBuilderIT {
     private static final String TEST_DATA =
               "line 01 aa\n"

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedJobsMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedJobsMultipartManagerIT.java
@@ -55,7 +55,7 @@ import static org.testng.Assert.fail;
 /* Tests are disabled because functionality is obsolete and overall test runtime
  * is very long and expensive. */
 @Deprecated
-@Test(groups = { "nightly" }, enabled = false)
+@Test(groups = { "expensive" }, enabled = false)
 public class EncryptedJobsMultipartManagerIT {
     private MantaClient mantaClient;
     private EncryptedJobsMultipartManager multipart;

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedJobsMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedJobsMultipartManagerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -55,7 +55,7 @@ import static org.testng.Assert.fail;
 /* Tests are disabled because functionality is obsolete and overall test runtime
  * is very long and expensive. */
 @Deprecated
-@Test(groups = { "encrypted" }, enabled = false)
+@Test(groups = { "nightly" }, enabled = false)
 public class EncryptedJobsMultipartManagerIT {
     private MantaClient mantaClient;
     private EncryptedJobsMultipartManager multipart;

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
@@ -50,7 +50,7 @@ import static org.testng.Assert.assertTrue;
  * Tests for verifying the behavior of {@link EncryptedServerSideMultipartManager} with
  * {@link MantaClient}.
  */
-@Test(groups = {"encryptable", "multipart"})
+@Test(groups = {"encrypted", "multipart"})
 @SuppressWarnings("Duplicates")
 public class EncryptedServerSideMultipartManagerIT {
     private final MantaClient mantaClient;

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
@@ -49,9 +49,6 @@ import static org.testng.Assert.assertTrue;
 /**
  * Tests for verifying the behavior of {@link EncryptedServerSideMultipartManager} with
  * {@link MantaClient}.
- *
- * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
- * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
 @Test(groups = {"encryptable", "multipart"})
 @SuppressWarnings("Duplicates")

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerIT.java
@@ -50,7 +50,7 @@ import static org.testng.Assert.assertTrue;
  * Tests for verifying the behavior of {@link EncryptedServerSideMultipartManager} with
  * {@link MantaClient}.
  */
-@Test(groups = {"encrypted", "multipart"})
+@Test(groups = {"encrypted", "expensive"})
 @SuppressWarnings("Duplicates")
 public class EncryptedServerSideMultipartManagerIT {
     private final MantaClient mantaClient;
@@ -126,6 +126,7 @@ public class EncryptedServerSideMultipartManagerIT {
         }
     }
 
+    @Test(groups = {"expensive"})
     public final void canListUploadsInProgress() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerSerializationIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerSerializationIT.java
@@ -40,7 +40,7 @@ import static org.testng.Assert.fail;
  * Tests for verifying the behavior of {@link com.joyent.manta.serialization.EncryptedMultipartSerializer}
  * and {@link EncryptedServerSideMultipartManager} with {@link MantaClient}.
  */
-@Test(groups = {"encryptable", "multipart"})
+@Test(groups = {"encrypted", "multipart"})
 @SuppressWarnings("Duplicates")
 public class EncryptedServerSideMultipartManagerSerializationIT {
     private static final Logger LOGGER = LoggerFactory.getLogger(EncryptedServerSideMultipartManagerSerializationIT.class);

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerSerializationIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerSerializationIT.java
@@ -39,9 +39,6 @@ import static org.testng.Assert.fail;
 /**
  * Tests for verifying the behavior of {@link com.joyent.manta.serialization.EncryptedMultipartSerializer}
  * and {@link EncryptedServerSideMultipartManager} with {@link MantaClient}.
- *
- * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
- * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
 @Test(groups = {"encryptable", "multipart"})
 @SuppressWarnings("Duplicates")

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerSerializationIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/EncryptedServerSideMultipartManagerSerializationIT.java
@@ -40,7 +40,7 @@ import static org.testng.Assert.fail;
  * Tests for verifying the behavior of {@link com.joyent.manta.serialization.EncryptedMultipartSerializer}
  * and {@link EncryptedServerSideMultipartManager} with {@link MantaClient}.
  */
-@Test(groups = {"encrypted", "multipart"})
+@Test(groups = {"encrypted"})
 @SuppressWarnings("Duplicates")
 public class EncryptedServerSideMultipartManagerSerializationIT {
     private static final Logger LOGGER = LoggerFactory.getLogger(EncryptedServerSideMultipartManagerSerializationIT.class);

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/JobsMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/JobsMultipartManagerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2016-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -52,7 +52,7 @@ import static org.testng.Assert.fail;
 /* Tests are disabled because functionality is obsolete and overall test runtime
  * is very long and expensive. */
 @Deprecated
-@Test(enabled = false)
+@Test(groups = { "nightly" }, enabled = false)
 public class JobsMultipartManagerIT {
     private MantaClient mantaClient;
     private JobsMultipartManager multipart;

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/JobsMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/JobsMultipartManagerIT.java
@@ -52,7 +52,7 @@ import static org.testng.Assert.fail;
 /* Tests are disabled because functionality is obsolete and overall test runtime
  * is very long and expensive. */
 @Deprecated
-@Test(groups = { "nightly" }, enabled = false)
+@Test(groups = { "expensive" }, enabled = false)
 public class JobsMultipartManagerIT {
     private MantaClient mantaClient;
     private JobsMultipartManager multipart;

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/ServerSideMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/ServerSideMultipartManagerIT.java
@@ -91,7 +91,7 @@ public class ServerSideMultipartManagerIT {
         }
     }
 
-    @Test(groups = { "nightly" }, enabled = false)
+    @Test(groups = { "expensive" }, enabled = false)
     public final void canListUploadsInProgress() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/ServerSideMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/ServerSideMultipartManagerIT.java
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-@Test
+@Test(groups = { "multipart", "expensive" })
 @SuppressWarnings("Duplicates")
 public class ServerSideMultipartManagerIT {
     private MantaClient mantaClient;
@@ -69,6 +69,7 @@ public class ServerSideMultipartManagerIT {
         IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
+    @Test(groups = { "multipart" })
     public void nonExistentFileHasNotStarted() throws IOException {
         String path = testPathPrefix + UUID.randomUUID().toString();
         UUID unknownId = new UUID(0L, 3);
@@ -78,6 +79,7 @@ public class ServerSideMultipartManagerIT {
                 MantaMultipartStatus.UNKNOWN);
     }
 
+    @Test(groups = { "multipart" })
     public final void canAbortUpload() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -91,7 +93,7 @@ public class ServerSideMultipartManagerIT {
         }
     }
 
-    @Test(groups = { "expensive" }, enabled = false)
+    @Test(groups = { "expensive" })
     public final void canListUploadsInProgress() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -108,6 +110,7 @@ public class ServerSideMultipartManagerIT {
         }
     }
 
+    @Test(groups = { "multipart" })
     public final void canGetStatus() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -166,6 +169,7 @@ public class ServerSideMultipartManagerIT {
         }
     }
 
+    @Test(groups = { "multipart" })
     public final void canGetPart() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -187,6 +191,7 @@ public class ServerSideMultipartManagerIT {
         }
     }
 
+    @Test(groups = { "multipart" })
     public final void canListParts() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -212,6 +217,7 @@ public class ServerSideMultipartManagerIT {
         }
     }
 
+    @Test(groups = { "multipart" })
     public final void canUploadWithSinglePartByteArray() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -251,6 +257,7 @@ public class ServerSideMultipartManagerIT {
         }
     }
 
+    @Test(groups = { "multipart" })
     public final void canUploadWithByteArrayAndMultipleParts() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -282,6 +289,7 @@ public class ServerSideMultipartManagerIT {
         }
     }
 
+    @Test(groups = { "multipart" })
     public void errorWhenMissingPart() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -308,6 +316,7 @@ public class ServerSideMultipartManagerIT {
         assertTrue(thrown, "Exception wasn't thrown");
     }
 
+    @Test(groups = { "multipart" })
     public void cantUploadSmallMultipartString() throws IOException {
         String[] parts = new String[] {
                 "Hello ",

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/ServerSideMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/ServerSideMultipartManagerIT.java
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-@Test(groups = { "multipart", "expensive" })
+@Test(groups = {"expensive" })
 @SuppressWarnings("Duplicates")
 public class ServerSideMultipartManagerIT {
     private MantaClient mantaClient;
@@ -69,7 +69,6 @@ public class ServerSideMultipartManagerIT {
         IntegrationTestConfigContext.cleanupTestDirectory(mantaClient, testPathPrefix);
     }
 
-    @Test(groups = { "multipart" })
     public void nonExistentFileHasNotStarted() throws IOException {
         String path = testPathPrefix + UUID.randomUUID().toString();
         UUID unknownId = new UUID(0L, 3);
@@ -79,7 +78,6 @@ public class ServerSideMultipartManagerIT {
                 MantaMultipartStatus.UNKNOWN);
     }
 
-    @Test(groups = { "multipart" })
     public final void canAbortUpload() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -110,7 +108,6 @@ public class ServerSideMultipartManagerIT {
         }
     }
 
-    @Test(groups = { "multipart" })
     public final void canGetStatus() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -169,7 +166,6 @@ public class ServerSideMultipartManagerIT {
         }
     }
 
-    @Test(groups = { "multipart" })
     public final void canGetPart() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -191,7 +187,6 @@ public class ServerSideMultipartManagerIT {
         }
     }
 
-    @Test(groups = { "multipart" })
     public final void canListParts() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -217,7 +212,6 @@ public class ServerSideMultipartManagerIT {
         }
     }
 
-    @Test(groups = { "multipart" })
     public final void canUploadWithSinglePartByteArray() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -257,7 +251,6 @@ public class ServerSideMultipartManagerIT {
         }
     }
 
-    @Test(groups = { "multipart" })
     public final void canUploadWithByteArrayAndMultipleParts() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -289,7 +282,6 @@ public class ServerSideMultipartManagerIT {
         }
     }
 
-    @Test(groups = { "multipart" })
     public void errorWhenMissingPart() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;
@@ -316,7 +308,6 @@ public class ServerSideMultipartManagerIT {
         assertTrue(thrown, "Exception wasn't thrown");
     }
 
-    @Test(groups = { "multipart" })
     public void cantUploadSmallMultipartString() throws IOException {
         String[] parts = new String[] {
                 "Hello ",

--- a/java-manta-it/src/test/java/com/joyent/manta/client/multipart/ServerSideMultipartManagerIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/multipart/ServerSideMultipartManagerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -91,6 +91,7 @@ public class ServerSideMultipartManagerIT {
         }
     }
 
+    @Test(groups = { "nightly" }, enabled = false)
     public final void canListUploadsInProgress() throws IOException {
         final String name = UUID.randomUUID().toString();
         final String path = testPathPrefix + name;

--- a/java-manta-it/src/test/java/com/joyent/manta/config/IntegrationTestConfigContext.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/config/IntegrationTestConfigContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2015-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -28,6 +28,7 @@ import static com.joyent.manta.client.MantaClient.SEPARATOR;
  * and allows for TestNG parameters to be loaded.
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
  */
 public class IntegrationTestConfigContext extends SystemSettingsConfigContext {
 
@@ -50,6 +51,16 @@ public class IntegrationTestConfigContext extends SystemSettingsConfigContext {
         super(enableTestEncryption(new StandardConfigContext(),
                 (encryptionEnabled() && usingEncryption == null) ||
                         BooleanUtils.isTrue(usingEncryption), encryptionCipher()));
+    }
+
+    /**
+     * Populate configuration from defaults, environment variables, system
+     * properties and an addition context passed in. Assigns hard-coded
+     * client-side encryption cipher algorithm settings.
+     */
+    public IntegrationTestConfigContext(final String encryptionCipher) {
+        this(encryptionCipher != null, encryptionCipher);
+
     }
 
     /**
@@ -84,7 +95,10 @@ public class IntegrationTestConfigContext extends SystemSettingsConfigContext {
             SecretKey key = SecretKeyUtils.generate(cipherDetails);
             context.setEncryptionPrivateKeyBytes(key.getEncoded());
 
-            System.out.printf("Unique secret key used for test (base64):\n%s\n",
+            System.out.printf(
+                    "Integration test encryption enabled: %s\n"
+                            + "Unique secret key used for test (base64):\n%s\n",
+                    cipherDetails.getCipherId(),
                     Base64.getEncoder().encodeToString(key.getEncoded()));
         }
 

--- a/java-manta-it/src/test/java/com/joyent/manta/config/IntegrationTestConfigContext.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/config/IntegrationTestConfigContext.java
@@ -60,7 +60,6 @@ public class IntegrationTestConfigContext extends SystemSettingsConfigContext {
      */
     public IntegrationTestConfigContext(final String encryptionCipher) {
         this(encryptionCipher != null, encryptionCipher);
-
     }
 
     /**

--- a/java-manta-it/src/test/java/com/joyent/manta/http/ApacheHttpGetResponseEntityContentContinuatorIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/http/ApacheHttpGetResponseEntityContentContinuatorIT.java
@@ -124,7 +124,7 @@ import static org.testng.Assert.fail;
  * HTTP it provides no way to terminate in-flight requests.
  * </p>
  */
-@Test(singleThreaded = true)
+@Test(groups = {"range-downloads"}, singleThreaded = true)
 public class ApacheHttpGetResponseEntityContentContinuatorIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(ApacheHttpGetResponseEntityContentContinuatorIT.class);

--- a/java-manta-it/src/test/java/com/joyent/manta/http/TCPSocketConnectionTimeoutIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/http/TCPSocketConnectionTimeoutIT.java
@@ -32,7 +32,7 @@ import java.time.Instant;
  *
  * @author <a href="https://github.com/dekobon">Ashwin A Nair</a>
  */
-@Test
+@Test(groups = {"timeout"})
 public class TCPSocketConnectionTimeoutIT {
     private MantaClient mantaClient;
 

--- a/java-manta-it/src/test/java/com/joyent/test/util/MantaPathSuiteListener.java
+++ b/java-manta-it/src/test/java/com/joyent/test/util/MantaPathSuiteListener.java
@@ -10,6 +10,8 @@ package com.joyent.test.util;
 import com.joyent.manta.client.MantaClient;
 import com.joyent.manta.config.ConfigContext;
 import com.joyent.manta.config.IntegrationTestConfigContext;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.ISuite;
@@ -32,8 +34,18 @@ public class MantaPathSuiteListener implements ISuiteListener {
 
     @Override
     public void onFinish(ISuite suite) {
+        LOG.info("Expected test count: " + TestListingInterceptor.getObservedTestCount());
+
         MantaClient mantaClient = new MantaClient(config);
         String path = IntegrationTestConfigContext.generateSuiteBasePath(config);
+
+        if (ObjectUtils.firstNonNull(
+                BooleanUtils.toBoolean(System.getProperty("it.dryRun")),
+                false)) {
+            LOG.warn("Skipping suite cleanup since dry-run is enabled.");
+            return;
+        }
+
         try {
             if (mantaClient.isDirectoryEmpty(path)) {
                 LOG.info("Removing base suite path: {}", path);

--- a/java-manta-it/src/test/java/com/joyent/test/util/MantaPathSuiteListener.java
+++ b/java-manta-it/src/test/java/com/joyent/test/util/MantaPathSuiteListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017-2019, Joyent, Inc. All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/java-manta-it/src/test/java/com/joyent/test/util/TestListingInterceptor.java
+++ b/java-manta-it/src/test/java/com/joyent/test/util/TestListingInterceptor.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 /**
  * Test method listener for determining which tests will actually run
  * when we invoke mvn verify -Dit.dryRun=true. This test listener has
- * been introduced to leverage TestNG feature @since 6.8.21 of determining
+ * been introduced to leverage TestNG feature since version 6.8.21 of determining
  * order of tests without executing them.
  *
  * Enabled by: -Dit.dryRun=true

--- a/java-manta-it/src/test/java/com/joyent/test/util/TestListingInterceptor.java
+++ b/java-manta-it/src/test/java/com/joyent/test/util/TestListingInterceptor.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2019, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.test.util;
+
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.IMethodInstance;
+import org.testng.IMethodInterceptor;
+import org.testng.ISuite;
+import org.testng.ISuiteListener;
+import org.testng.ITestContext;
+import org.testng.ITestNGMethod;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * Test method listener for determining which tests will actually run.
+ *
+ * Enabled by: -Dit.dryRun=true
+ * @author <a href="https://github.com/nairashwin952013">Ashwin A Nair</a>
+ */
+public class TestListingInterceptor implements IMethodInterceptor, ISuiteListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TestListingInterceptor.class);
+
+    private static final List<IMethodInstance> EMPTY_LIST = new ArrayList<>(0);
+
+    private static final ConcurrentLinkedQueue<String> observedTests = new ConcurrentLinkedQueue<>();
+
+    private static final boolean DRY_RUN_ENABLED;
+
+    static {
+        DRY_RUN_ENABLED = ObjectUtils.firstNonNull(
+                BooleanUtils.toBoolean(System.getProperty("it.dryRun")),
+                false);
+    }
+
+    public static int getObservedTestCount() {
+        return observedTests.size();
+    }
+
+    @Override
+    public List<IMethodInstance> intercept(final List<IMethodInstance> methods, final ITestContext context) {
+        for (final IMethodInstance method : methods) {
+            final ITestNGMethod testNGMethod = method.getMethod();
+            final String testName = testNGMethod.getQualifiedName();
+            final Map<String, String> params = testNGMethod.findMethodParameters(testNGMethod.getXmlTest());
+            final String paramsDetails = !params.isEmpty() ? params.toString() : "";
+            observedTests.add(testName + ' ' + paramsDetails);
+        }
+
+        if (DRY_RUN_ENABLED) {
+            return EMPTY_LIST;
+        }
+
+        return methods;
+    }
+
+    @Override
+    public void onStart(final ISuite suite) {
+    }
+
+    @Override
+    public void onFinish(final ISuite suite) {
+        if (!DRY_RUN_ENABLED) {
+            return;
+        }
+
+        final String[] sortedTests = observedTests.toArray(new String[0]);
+        Arrays.sort(sortedTests);
+
+        LOG.info("DRY-RUN: Listing ["+ sortedTests.length +"] tests that would have run");
+
+        for (final String testNameAndParams : sortedTests) {
+            LOG.info(testNameAndParams);
+        }
+    }
+}

--- a/java-manta-it/src/test/resources/testng-it.xml
+++ b/java-manta-it/src/test/resources/testng-it.xml
@@ -16,33 +16,17 @@
         <classes>
             <class name="com.joyent.manta.client.MantaClientDirectoriesIT" />
             <class name="com.joyent.manta.client.MantaDirectoryListingIteratorIT" />
-            <class name="com.joyent.manta.client.MantaClientMetadataIT" />
         </classes>
     </test>
     <test name="Manta Client Http Headers Tests">
         <classes>
             <class name="com.joyent.manta.http.MantaHttpHeadersIT" />
-        </classes>
-    </test>
-    <test name="Manta Client Metadata Tests">
-        <groups>
-            <run>
-                <exclude name="directory" />
-                <exclude name="encrypted" />
-            </run>
-        </groups>
-        <classes>
-            <class name="com.joyent.manta.client.MantaClientMetadataIT" />
+            <class name="com.joyent.manta.http.TCPSocketConnectionTimeoutIT" />
         </classes>
     </test>
     <test name="Manta Client Error Tests">
         <classes>
             <class name="com.joyent.manta.client.MantaClientErrorIT" />
-        </classes>
-    </test>
-    <test name="Manta Client Integration Tests [Modified Time]">
-        <classes>
-            <class name="com.joyent.manta.client.MantaClientIT" />
         </classes>
     </test>
     <test name="Manta Client Integration Tests [Unencrypted]">
@@ -51,22 +35,20 @@
 	        EncryptedServerSideMultipartManagerSerializationIT by adding groups > run > exclude = "encrypted" group
 	        so we resort to listing all desired unencrypted tests. This also helps discoverability!
 	        -->
+        <groups>
+            <run>
+                <exclude name="expensive" />
+            </run>
+        </groups>
         <classes>
-            <class name="com.joyent.manta.client.MantaClientDirectoriesIT" />
-            <class name="com.joyent.manta.client.MantaClientErrorIT" />
             <class name="com.joyent.manta.client.MantaClientFindIT" />
-            <class name="com.joyent.manta.client.MantaClientIT" />
-            <class name="com.joyent.manta.client.MantaClientMetadataIT" />
-            <class name="com.joyent.manta.client.MantaClientPutIT" />
-            <class name="com.joyent.manta.client.MantaClientRangeIT" />
-            <class name="com.joyent.manta.client.MantaClientSeekableByteChannelIT" />
             <class name="com.joyent.manta.client.MantaClientSigningIT" />
-            <class name="com.joyent.manta.client.MantaDirectoryListingIteratorIT" />
-            <class name="com.joyent.manta.client.MantaObjectOutputStreamIT" />
-            <class name="com.joyent.manta.http.MantaHttpHeadersIT" />
+            <class name="com.joyent.manta.client.MantaClientSigningIT" />
 
             <!-- Jobs-based MPU tests-->
             <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
+            <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerIT" />
+            <class name="com.joyent.manta.client.jobs.MantaClientJobIT" />
         </classes>
     </test>
 
@@ -75,31 +57,31 @@
         <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
         <classes>
             <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
+            <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerIT" />
             <class name="com.joyent.manta.client.jobs.MantaClientJobIT" />
-        </classes>
-    </test>
-    <test name="Manta Client Encrypted Integration Tests">
-        <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
-        <classes>
-            <class name="com.joyent.manta.client.MantaClientIT" />
-            <class name="com.joyent.manta.client.MantaClientMetadataIT" />
-            <class name="com.joyent.manta.client.MantaObjectOutputStreamIT" />
-        </classes>
-    </test>
-    <test name="Manta Client Put Operations Integration Tests">
-        <parameter name="usingEncryption" value="true" />
-        <classes>
-            <class name="com.joyent.manta.client.MantaClientPutIT" />
         </classes>
     </test>
     <test name="Manta Client Seekable Channel Tests">
         <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
+        <groups>
+            <run>
+                <exclude name="expensive" />
+            </run>
+        </groups>
         <classes>
+            <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
+            <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerIT" />
+            <class name="com.joyent.manta.client.jobs.MantaClientJobIT" />
             <class name="com.joyent.manta.client.MantaClientSeekableByteChannelIT" />
         </classes>
     </test>
     <test name="Manta Client Integration Tests [AES128/CTR Encrypted]">
         <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
+        <groups>
+            <run>
+                <exclude name="expensive" />
+            </run>
+        </groups>
         <classes>
             <class name="com.joyent.manta.client.MantaClientIT" />
             <class name="com.joyent.manta.client.MantaClientPutIT" />
@@ -111,9 +93,10 @@
             <class name="com.joyent.manta.client.MantaClientSeekableByteChannelIT" />
 
             <!-- MPU only supports AES/CTR -->
-            <class name="com.joyent.manta.client.multipart.EncryptedJobsMultipartManagerIT" />
+            <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
             <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerIT" />
             <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerSerializationIT" />
+            <class name="com.joyent.manta.client.jobs.MantaClientJobIT" />
         </classes>
     </test>
     <test name="Manta Client Integration Tests [AES128/GCM Encrypted]">
@@ -138,20 +121,6 @@
         <parameter name="usingEncryption" value="true"/>
         <classes>
             <class name="com.joyent.manta.client.MantaClientSnapLinksIT" />
-        </classes>
-    </test>
-    <test name="Manta Client Encrypted Multipart Tests ">
-        <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
-        <classes>
-            <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
-            <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerIT" />
-            <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerSerializationIT" />
-        </classes>
-    </test>
-    <test name="Manta Job Tests">
-        <classes>
-            <class name="com.joyent.manta.client.jobs.MantaClientJobIT" />
-            <class name="com.joyent.manta.client.jobs.MantaJobBuilderIT" />
         </classes>
     </test>
 </suite>

--- a/java-manta-it/src/test/resources/testng-it.xml
+++ b/java-manta-it/src/test/resources/testng-it.xml
@@ -75,7 +75,7 @@
                 <include name="move" />
                 <include name="mtime" />
                 <include name="metadata" />
-                <exclude name="encryptable" />
+                <exclude name="encrypted" />
                 <exclude name="cbc-cipher" />
                 <exclude name="ctr-cipher" />
                 <exclude name="gcm-cipher" />
@@ -87,7 +87,7 @@
         </groups>
         <!--
 	          excluding tests by group only works if everything is in a group. e.g. we are currently unable to exclude
-	          EncryptedServerSideMultipartManagerSerializationIT by adding groups > run > exclude = "encryptable" group
+	          EncryptedServerSideMultipartManagerSerializationIT by adding groups > run > exclude = "encrypted" group
 	          so we resort to listing all desired unencrypted tests. This also helps discoverability!
 	          -->
         <classes>
@@ -98,31 +98,37 @@
             <class name="com.joyent.manta.client.MantaClientSeekableByteChannelIT" />
             <class name="com.joyent.manta.client.MantaClientSigningIT" />
             <class name="com.joyent.manta.client.MantaObjectOutputStreamIT" />
-
-            <!-- Jobs-based MPU tests-->
-            <class name="com.joyent.manta.client.multipart.JobsMultipartManagerIT" />
-            <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
         </classes>
     </test>
 
     <!-- We run many of the integration tests over again using client-side encryption -->
     <test name="Manta Client Heavyweight Tests">
-        <parameter name="usingEncryption" value="true" />
         <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
         <groups>
             <define name="expensive" />
         </groups>
         <classes>
-            <class name="com.joyent.manta.client.jobs.MantaClientJobIT" />
-            <class name="com.joyent.manta.client.multipart.EncryptedJobsMultipartManagerIT" />
-            <class name="com.joyent.manta.client.multipart.JobsMultipartManagerIT" />
-            <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
+            <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" >
+            <methods>
+                <include name="canListUploadsInProgress" />
+            </methods>
+            </class>
+            <class name="com.joyent.manta.client.jobs.MantaClientJobIT" >
+            <methods>
+                <include name="createJob" />
+                <include name="getJob" />
+                <include name="canListAllJobIDs" />
+                <include name="canListAllJobs" />
+                <include name="canListAllRunningJobIDs" />
+                <include name="canListAllRunningJobs" />
+            </methods>
+            </class>
         </classes>
     </test>
     <test name="Manta Client Encrypted Integration Tests">
         <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
         <groups>
-            <define name="encryptable" />
+            <define name="encrypted" />
             <run>
                 <include name="put" />
                 <exclude name="seekable" />
@@ -158,7 +164,7 @@
         <groups>
             <define name="ctr-cipher" />
             <run>
-                <include name="encryptable" />
+                <include name="encrypted" />
                 <include name="multipart" />
                 <exclude name="encryption-provider" />
                 <exclude name="expensive" />
@@ -171,6 +177,7 @@
             <!-- MPU only supports AES/CTR -->
             <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerIT" />
             <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerSerializationIT" />
+            <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
         </classes>
     </test>
     <test name="Manta Client Integration Tests [AES128/GCM Encrypted]">
@@ -178,24 +185,34 @@
         <groups>
             <define name="gcm-cipher" />
             <run>
-                <include name="encryptable" />
+                <include name="encrypted" />
                 <exclude name="encryption-provider" />
                 <exclude name="expensive" />
                 <exclude name="multipart" />
             </run>
         </groups>
+        <packages>
+            <package name="com.joyent.manta.client.*">
+                <exclude name="com.joyent.manta.client.jobs"/>
+            </package>
+        </packages>
     </test>
     <test name="Manta Client Integration Tests [AES128/CBC Encrypted]">
         <parameter name="encryptionCipher" value="AES128/CBC/PKCS5Padding"/>
         <groups>
             <define name="cbc-cipher" />
             <run>
-                <include name="encryptable"/>
+                <include name="encrypted"/>
                 <exclude name="encryption-provider" />
                 <exclude name="expensive" />
                 <exclude name="multipart" />
             </run>
         </groups>
+        <packages>
+            <package name="com.joyent.manta.client.*">
+                <exclude name="com.joyent.manta.client.jobs"/>
+            </package>
+        </packages>
     </test>
     <test name="Manta Client Snaplinks Tests ">
         <parameter name="usingEncryption" value="true"/>
@@ -210,24 +227,19 @@
         <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
         <groups>
             <define name="multipart" />
-        </groups>
-        <classes>
-            <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerIT" />
-            <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerSerializationIT" />
-        </classes>
-    </test>
-
-    <!-- Jobs tests not related to MPU -->
-    <test name="Manta Job Tests">
-        <groups>
-            <define name="jobs" />
             <run>
                 <exclude name="expensive" />
             </run>
         </groups>
         <classes>
-            <class name="com.joyent.manta.client.jobs.MantaClientJobIT" />
-            <class name="com.joyent.manta.client.jobs.MantaJobBuilderIT" />
+            <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
+            <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerIT" />
+            <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerSerializationIT" />
         </classes>
+    </test>
+    <test name="Manta Job Tests">
+    <packages>
+        <package name="com.joyent.manta.client.jobs.*"/>
+    </packages>
     </test>
 </suite>

--- a/java-manta-it/src/test/resources/testng-it.xml
+++ b/java-manta-it/src/test/resources/testng-it.xml
@@ -81,7 +81,7 @@
                 <exclude name="gcm-cipher" />
                 <exclude name="encryption-provider" />
                 <exclude name="jobs" />
-                <exclude name="nightly" />
+                <exclude name="expensive" />
                 <exclude name="seekable" />
             </run>
         </groups>
@@ -110,7 +110,7 @@
         <parameter name="usingEncryption" value="true" />
         <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
         <groups>
-            <define name="nightly" />
+            <define name="expensive" />
         </groups>
         <classes>
             <class name="com.joyent.manta.client.jobs.MantaClientJobIT" />
@@ -160,7 +160,7 @@
             <run>
                 <include name="encryptable" />
                 <exclude name="encryption-provider" />
-                <exclude name="nightly" />
+                <exclude name="expensive" />
             </run>
         </groups>
         <classes>
@@ -179,7 +179,7 @@
             <run>
                 <include name="encryptable" />
                 <exclude name="encryption-provider" />
-                <exclude name="nightly" />
+                <exclude name="expensive" />
                 <exclude name="multipart" />
             </run>
         </groups>
@@ -191,7 +191,7 @@
             <run>
                 <include name="encryptable"/>
                 <exclude name="encryption-provider" />
-                <exclude name="nightly" />
+                <exclude name="expensive" />
                 <exclude name="multipart" />
             </run>
         </groups>
@@ -221,7 +221,7 @@
         <groups>
             <define name="jobs" />
             <run>
-                <exclude name="nightly" />
+                <exclude name="expensive" />
             </run>
         </groups>
         <classes>

--- a/java-manta-it/src/test/resources/testng-it.xml
+++ b/java-manta-it/src/test/resources/testng-it.xml
@@ -159,6 +159,7 @@
             <define name="ctr-cipher" />
             <run>
                 <include name="encryptable" />
+                <include name="multipart" />
                 <exclude name="encryption-provider" />
                 <exclude name="expensive" />
             </run>

--- a/java-manta-it/src/test/resources/testng-it.xml
+++ b/java-manta-it/src/test/resources/testng-it.xml
@@ -101,7 +101,7 @@
             <!-- class name="com.joyent.manta.client.MantaObjectOutputStreamIT" -->
         </classes>
     </test>
-    <test name="Manta Client Snaplinks Tests ">
+    <test name="Manta Client Snaplinks Tests">
         <parameter name="usingEncryption" value="true"/>
         <classes>
             <class name="com.joyent.manta.client.MantaClientSnapLinksIT" />

--- a/java-manta-it/src/test/resources/testng-it.xml
+++ b/java-manta-it/src/test/resources/testng-it.xml
@@ -3,6 +3,7 @@
 
     <listeners>
         <listener class-name="com.joyent.test.util.MantaPathSuiteListener"/>
+        <listener class-name="com.joyent.test.util.TestListingInterceptor" />
     </listeners>
 
     <test name="Manta Client Integration Test Helper Class Tests">
@@ -11,65 +12,189 @@
             <class name="com.joyent.test.util.RandomInputStreamTest"/>
         </classes>
     </test>
-
+    <test name="Manta Client Directory Tests">
+        <groups>
+            <define name="directory" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientDirectoriesIT" />
+            <class name="com.joyent.manta.client.MantaDirectoryListingIteratorIT" />
+            <class name="com.joyent.manta.client.MantaClientMetadataIT" />
+        </classes>
+    </test>
+    <test name="Manta Client Http Headers Tests">
+        <groups>
+            <define name="headers" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.http.MantaHttpHeadersIT" />
+        </classes>
+    </test>
+    <test name="Manta Client Metadata Tests [Metadata Operations]">
+        <groups>
+            <define name="metadata" />
+            <run>
+                <exclude name="directory" />
+            </run>
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientMetadataIT" />
+        </classes>
+    </test>
+    <test name="Manta Client Integration Tests [Move Operations]">
+        <groups>
+            <define name="move" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientIT" />
+        </classes>
+    </test>
+    <test name="Manta Client Error Tests ">
+        <groups>
+            <define name="error" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientErrorIT" />
+        </classes>
+    </test>
+    <test name="Manta Client Integration Tests [Modified Time]">
+        <groups>
+            <define name="mtime" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientIT" />
+        </classes>
+    </test>
     <test name="Manta Client Integration Tests [Unencrypted]">
         <groups>
+            <define name="unencrypted" />
             <run>
-                <exclude name="encrypted"/>
+                <include name="directory" />
+                <include name="error" />
+                <include name="headers" />
+                <include name="move" />
+                <include name="mtime" />
+                <include name="metadata" />
+                <exclude name="encryptable" />
+                <exclude name="cbc-cipher" />
+                <exclude name="ctr-cipher" />
+                <exclude name="gcm-cipher" />
                 <exclude name="encryption-provider" />
+                <exclude name="jobs" />
+                <exclude name="nightly" />
+                <exclude name="seekable" />
             </run>
         </groups>
-        <packages>
-            <package name="com.joyent.manta.client.*">
-                <exclude name="com.joyent.manta.client.jobs"/>
-            </package>
-            <package name="com.joyent.manta.client.multipart.*"/>
-            <package name="com.joyent.manta.http.*"/>
-        </packages>
+        <!--
+	          excluding tests by group only works if everything is in a group. e.g. we are currently unable to exclude
+	          EncryptedServerSideMultipartManagerSerializationIT by adding groups > run > exclude = "encryptable" group
+	          so we resort to listing all desired unencrypted tests. This also helps discoverability!
+	          -->
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientFindIT" />
+            <class name="com.joyent.manta.client.MantaClientIT" />
+            <class name="com.joyent.manta.client.MantaClientMetadataIT" />
+            <class name="com.joyent.manta.client.MantaClientRangeIT" />
+            <class name="com.joyent.manta.client.MantaClientSeekableByteChannelIT" />
+            <class name="com.joyent.manta.client.MantaClientSigningIT" />
+            <class name="com.joyent.manta.client.MantaObjectOutputStreamIT" />
+
+            <!-- Jobs-based MPU tests-->
+            <class name="com.joyent.manta.client.multipart.JobsMultipartManagerIT" />
+            <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
+        </classes>
     </test>
+
     <!-- We run many of the integration tests over again using client-side encryption -->
-    <test name="Manta Client Integration Tests [AES128/CTR Encrypted]">
-        <parameter name="usingEncryption" value="true"/>
+    <test name="Manta Client Heavyweight Tests">
+        <parameter name="usingEncryption" value="true" />
         <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
         <groups>
+            <define name="nightly" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.jobs.MantaClientJobIT" />
+            <class name="com.joyent.manta.client.multipart.EncryptedJobsMultipartManagerIT" />
+            <class name="com.joyent.manta.client.multipart.JobsMultipartManagerIT" />
+            <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
+        </classes>
+    </test>
+    <test name="Manta Client Encrypted Integration Tests">
+        <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
+        <groups>
+            <define name="encryptable" />
             <run>
-                <exclude name="encryption-provider" />
+                <include name="put" />
+                <exclude name="seekable" />
+                <exclude name="multipart" />
             </run>
         </groups>
-        <packages>
-            <package name="com.joyent.manta.client.*">
-                <exclude name="com.joyent.manta.client.jobs"/>
-            </package>
-            <package name="com.joyent.manta.client.multipart.*"/>
-        </packages>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientIT" />
+            <class name="com.joyent.manta.client.MantaClientMetadataIT" />
+            <class name="com.joyent.manta.client.MantaObjectOutputStreamIT" />
+        </classes>
+    </test>
+    <test name="Manta Client Put Operations Integration Tests">
+        <parameter name="usingEncryption" value="true" />
+        <groups>
+            <define name="put" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientPutIT" />
+        </classes>
+    </test>
+    <test name="Manta Client Seekable Channel Tests">
+        <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
+        <groups>
+            <define name="seekable" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientSeekableByteChannelIT" />
+        </classes>
+    </test>
+    <test name="Manta Client Integration Tests [AES128/CTR Encrypted]">
+        <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
+        <groups>
+            <define name="ctr-cipher" />
+            <run>
+                <include name="encryptable" />
+                <exclude name="encryption-provider" />
+                <exclude name="nightly" />
+            </run>
+        </groups>
+        <classes>
+            <!-- Range Operations only support AES/CTR -->
+            <class name="com.joyent.manta.client.MantaClientRangeIT" />
+
+            <!-- MPU only supports AES/CTR -->
+            <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerIT" />
+            <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerSerializationIT" />
+        </classes>
     </test>
     <test name="Manta Client Integration Tests [AES128/GCM Encrypted]">
-        <parameter name="usingEncryption" value="true"/>
         <parameter name="encryptionCipher" value="AES128/GCM/NoPadding"/>
         <groups>
+            <define name="gcm-cipher" />
             <run>
+                <include name="encryptable" />
                 <exclude name="encryption-provider" />
+                <exclude name="nightly" />
+                <exclude name="multipart" />
             </run>
         </groups>
-        <packages>
-            <package name="com.joyent.manta.client.*">
-                <exclude name="com.joyent.manta.client.jobs"/>
-            </package>
-        </packages>
     </test>
     <test name="Manta Client Integration Tests [AES128/CBC Encrypted]">
-        <parameter name="usingEncryption" value="true"/>
         <parameter name="encryptionCipher" value="AES128/CBC/PKCS5Padding"/>
         <groups>
+            <define name="cbc-cipher" />
             <run>
+                <include name="encryptable"/>
                 <exclude name="encryption-provider" />
+                <exclude name="nightly" />
+                <exclude name="multipart" />
             </run>
         </groups>
-        <packages>
-            <package name="com.joyent.manta.client.*">
-                <exclude name="com.joyent.manta.client.jobs"/>
-            </package>
-        </packages>
     </test>
     <test name="Manta Client Snaplinks Tests ">
         <parameter name="usingEncryption" value="true"/>
@@ -80,9 +205,28 @@
             <class name="com.joyent.manta.client.MantaClientSnapLinksIT" />
         </classes>
     </test>
+    <test name="Manta Client Encrypted Multipart Tests ">
+        <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
+        <groups>
+            <define name="multipart" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerIT" />
+            <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerSerializationIT" />
+        </classes>
+    </test>
+
+    <!-- Jobs tests not related to MPU -->
     <test name="Manta Job Tests">
-        <packages>
-            <package name="com.joyent.manta.client.jobs.*"/>
-        </packages>
+        <groups>
+            <define name="jobs" />
+            <run>
+                <exclude name="nightly" />
+            </run>
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.client.jobs.MantaClientJobIT" />
+            <class name="com.joyent.manta.client.jobs.MantaJobBuilderIT" />
+        </classes>
     </test>
 </suite>

--- a/java-manta-it/src/test/resources/testng-it.xml
+++ b/java-manta-it/src/test/resources/testng-it.xml
@@ -13,22 +13,34 @@
         </classes>
     </test>
     <test name="Manta Client Directory Tests">
+        <groups>
+            <define name="directory" />
+        </groups>
         <classes>
             <class name="com.joyent.manta.client.MantaClientDirectoriesIT" />
             <class name="com.joyent.manta.client.MantaDirectoryListingIteratorIT" />
         </classes>
     </test>
     <test name="Manta Client Http Headers Tests">
+        <groups>
+            <define name="headers" />
+        </groups>
         <classes>
             <class name="com.joyent.manta.http.MantaHttpHeadersIT" />
         </classes>
     </test>
     <test name ="Manta Client Timeout Tests" >
-            <classes>
-                <class name="com.joyent.manta.http.TCPSocketConnectionTimeoutIT" />
-            </classes>
+        <groups>
+            <define name="timeout" />
+        </groups>
+        <classes>
+            <class name="com.joyent.manta.http.TCPSocketConnectionTimeoutIT" />
+        </classes>
     </test>
     <test name="Manta Client Error Tests">
+        <groups>
+            <define name="error" />
+        </groups>
         <classes>
             <class name="com.joyent.manta.client.MantaClientErrorIT" />
         </classes>
@@ -50,23 +62,24 @@
     <!-- We run many of the integration tests over again using client-side encryption -->
 
     <test name="Manta Client Range Encrypted Download Tests">
+        <groups>
+            <define name="range-downloads" />
+        </groups>
         <classes>
             <class name="com.joyent.manta.http.ApacheHttpGetResponseEntityContentContinuatorIT" />
         </classes>
     </test>
     <test name="Manta Client Seekable Channel Tests">
         <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
+        <groups>
+            <define name="seekable" />
+        </groups>
         <classes>
             <class name="com.joyent.manta.client.MantaClientSeekableByteChannelIT" />
         </classes>
     </test>
     <test name="Manta Client Integration Tests [AES128/CTR Encrypted]">
         <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
-        <groups>
-            <run>
-                <exclude name="expensive" />
-            </run>
-        </groups>
         <classes>
             <class name="com.joyent.manta.client.MantaClientIT" />
             <class name="com.joyent.manta.client.MantaClientPutIT" />
@@ -103,6 +116,9 @@
     </test>
     <test name="Manta Client Snaplinks Tests">
         <parameter name="usingEncryption" value="true"/>
+        <groups>
+            <define name="snaplinks" />
+        </groups>
         <classes>
             <class name="com.joyent.manta.client.MantaClientSnapLinksIT" />
         </classes>

--- a/java-manta-it/src/test/resources/testng-it.xml
+++ b/java-manta-it/src/test/resources/testng-it.xml
@@ -21,8 +21,12 @@
     <test name="Manta Client Http Headers Tests">
         <classes>
             <class name="com.joyent.manta.http.MantaHttpHeadersIT" />
-            <class name="com.joyent.manta.http.TCPSocketConnectionTimeoutIT" />
         </classes>
+    </test>
+    <test name ="Manta Client Timeout Tests" >
+            <classes>
+                <class name="com.joyent.manta.http.TCPSocketConnectionTimeoutIT" />
+            </classes>
     </test>
     <test name="Manta Client Error Tests">
         <classes>
@@ -38,12 +42,18 @@
         <classes>
             <class name="com.joyent.manta.client.MantaClientFindIT" />
             <class name="com.joyent.manta.client.MantaClientSigningIT" />
-            <class name="com.joyent.manta.client.MantaClientSigningIT" />
+            <class name="com.joyent.manta.client.MantaClientAuthenticationIT" />
             <class name="com.joyent.manta.client.MantaClientAuthenticationChangeIT" />
         </classes>
     </test>
 
     <!-- We run many of the integration tests over again using client-side encryption -->
+
+    <test name="Manta Client Range Encrypted Download Tests">
+        <classes>
+            <class name="com.joyent.manta.http.ApacheHttpGetResponseEntityContentContinuatorIT" />
+        </classes>
+    </test>
     <test name="Manta Client Seekable Channel Tests">
         <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
         <classes>
@@ -86,7 +96,9 @@
             <class name="com.joyent.manta.client.MantaClientIT" />
             <class name="com.joyent.manta.client.MantaClientPutIT" />
             <class name="com.joyent.manta.client.MantaClientMetadataIT" />
-            <class name="com.joyent.manta.client.MantaObjectOutputStreamIT" />
+
+            <!-- Disabled due to this particular test cases failing for the aforementioned cipher, Issue#530 -->
+            <!-- class name="com.joyent.manta.client.MantaObjectOutputStreamIT" -->
         </classes>
     </test>
     <test name="Manta Client Snaplinks Tests ">

--- a/java-manta-it/src/test/resources/testng-it.xml
+++ b/java-manta-it/src/test/resources/testng-it.xml
@@ -13,9 +13,6 @@
         </classes>
     </test>
     <test name="Manta Client Directory Tests">
-        <groups>
-            <define name="directory" />
-        </groups>
         <classes>
             <class name="com.joyent.manta.client.MantaClientDirectoriesIT" />
             <class name="com.joyent.manta.client.MantaDirectoryListingIteratorIT" />
@@ -23,118 +20,66 @@
         </classes>
     </test>
     <test name="Manta Client Http Headers Tests">
-        <groups>
-            <define name="headers" />
-        </groups>
         <classes>
             <class name="com.joyent.manta.http.MantaHttpHeadersIT" />
         </classes>
     </test>
-    <test name="Manta Client Metadata Tests [Metadata Operations]">
+    <test name="Manta Client Metadata Tests">
         <groups>
-            <define name="metadata" />
             <run>
                 <exclude name="directory" />
+                <exclude name="encrypted" />
             </run>
         </groups>
         <classes>
             <class name="com.joyent.manta.client.MantaClientMetadataIT" />
         </classes>
     </test>
-    <test name="Manta Client Integration Tests [Move Operations]">
-        <groups>
-            <define name="move" />
-        </groups>
-        <classes>
-            <class name="com.joyent.manta.client.MantaClientIT" />
-        </classes>
-    </test>
-    <test name="Manta Client Error Tests ">
-        <groups>
-            <define name="error" />
-        </groups>
+    <test name="Manta Client Error Tests">
         <classes>
             <class name="com.joyent.manta.client.MantaClientErrorIT" />
         </classes>
     </test>
     <test name="Manta Client Integration Tests [Modified Time]">
-        <groups>
-            <define name="mtime" />
-        </groups>
         <classes>
             <class name="com.joyent.manta.client.MantaClientIT" />
         </classes>
     </test>
     <test name="Manta Client Integration Tests [Unencrypted]">
-        <groups>
-            <define name="unencrypted" />
-            <run>
-                <include name="directory" />
-                <include name="error" />
-                <include name="headers" />
-                <include name="move" />
-                <include name="mtime" />
-                <include name="metadata" />
-                <exclude name="encrypted" />
-                <exclude name="cbc-cipher" />
-                <exclude name="ctr-cipher" />
-                <exclude name="gcm-cipher" />
-                <exclude name="encryption-provider" />
-                <exclude name="jobs" />
-                <exclude name="expensive" />
-                <exclude name="seekable" />
-            </run>
-        </groups>
         <!--
-	          excluding tests by group only works if everything is in a group. e.g. we are currently unable to exclude
-	          EncryptedServerSideMultipartManagerSerializationIT by adding groups > run > exclude = "encrypted" group
-	          so we resort to listing all desired unencrypted tests. This also helps discoverability!
-	          -->
+	        excluding tests by group only works if everything is in a group. e.g. we are currently unable to exclude
+	        EncryptedServerSideMultipartManagerSerializationIT by adding groups > run > exclude = "encrypted" group
+	        so we resort to listing all desired unencrypted tests. This also helps discoverability!
+	        -->
         <classes>
+            <class name="com.joyent.manta.client.MantaClientDirectoriesIT" />
+            <class name="com.joyent.manta.client.MantaClientErrorIT" />
             <class name="com.joyent.manta.client.MantaClientFindIT" />
             <class name="com.joyent.manta.client.MantaClientIT" />
             <class name="com.joyent.manta.client.MantaClientMetadataIT" />
+            <class name="com.joyent.manta.client.MantaClientPutIT" />
             <class name="com.joyent.manta.client.MantaClientRangeIT" />
             <class name="com.joyent.manta.client.MantaClientSeekableByteChannelIT" />
             <class name="com.joyent.manta.client.MantaClientSigningIT" />
+            <class name="com.joyent.manta.client.MantaDirectoryListingIteratorIT" />
             <class name="com.joyent.manta.client.MantaObjectOutputStreamIT" />
+            <class name="com.joyent.manta.http.MantaHttpHeadersIT" />
+
+            <!-- Jobs-based MPU tests-->
+            <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
         </classes>
     </test>
 
     <!-- We run many of the integration tests over again using client-side encryption -->
     <test name="Manta Client Heavyweight Tests">
         <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
-        <groups>
-            <define name="expensive" />
-        </groups>
         <classes>
-            <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" >
-            <methods>
-                <include name="canListUploadsInProgress" />
-            </methods>
-            </class>
-            <class name="com.joyent.manta.client.jobs.MantaClientJobIT" >
-            <methods>
-                <include name="createJob" />
-                <include name="getJob" />
-                <include name="canListAllJobIDs" />
-                <include name="canListAllJobs" />
-                <include name="canListAllRunningJobIDs" />
-                <include name="canListAllRunningJobs" />
-            </methods>
-            </class>
+            <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
+            <class name="com.joyent.manta.client.jobs.MantaClientJobIT" />
         </classes>
     </test>
     <test name="Manta Client Encrypted Integration Tests">
         <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
-        <groups>
-            <define name="encrypted" />
-            <run>
-                <include name="put" />
-                <exclude name="seekable" />
-                <exclude name="multipart" />
-            </run>
-        </groups>
         <classes>
             <class name="com.joyent.manta.client.MantaClientIT" />
             <class name="com.joyent.manta.client.MantaClientMetadataIT" />
@@ -143,94 +88,60 @@
     </test>
     <test name="Manta Client Put Operations Integration Tests">
         <parameter name="usingEncryption" value="true" />
-        <groups>
-            <define name="put" />
-        </groups>
         <classes>
             <class name="com.joyent.manta.client.MantaClientPutIT" />
         </classes>
     </test>
     <test name="Manta Client Seekable Channel Tests">
         <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
-        <groups>
-            <define name="seekable" />
-        </groups>
         <classes>
             <class name="com.joyent.manta.client.MantaClientSeekableByteChannelIT" />
         </classes>
     </test>
     <test name="Manta Client Integration Tests [AES128/CTR Encrypted]">
         <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
-        <groups>
-            <define name="ctr-cipher" />
-            <run>
-                <include name="encrypted" />
-                <include name="multipart" />
-                <exclude name="encryption-provider" />
-                <exclude name="expensive" />
-            </run>
-        </groups>
         <classes>
+            <class name="com.joyent.manta.client.MantaClientIT" />
+            <class name="com.joyent.manta.client.MantaClientPutIT" />
+            <class name="com.joyent.manta.client.MantaClientMetadataIT" />
+            <class name="com.joyent.manta.client.MantaObjectOutputStreamIT" />
+
             <!-- Range Operations only support AES/CTR -->
             <class name="com.joyent.manta.client.MantaClientRangeIT" />
+            <class name="com.joyent.manta.client.MantaClientSeekableByteChannelIT" />
 
             <!-- MPU only supports AES/CTR -->
+            <class name="com.joyent.manta.client.multipart.EncryptedJobsMultipartManagerIT" />
             <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerIT" />
             <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerSerializationIT" />
-            <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
         </classes>
     </test>
     <test name="Manta Client Integration Tests [AES128/GCM Encrypted]">
         <parameter name="encryptionCipher" value="AES128/GCM/NoPadding"/>
-        <groups>
-            <define name="gcm-cipher" />
-            <run>
-                <include name="encrypted" />
-                <exclude name="encryption-provider" />
-                <exclude name="expensive" />
-                <exclude name="multipart" />
-            </run>
-        </groups>
-        <packages>
-            <package name="com.joyent.manta.client.*">
-                <exclude name="com.joyent.manta.client.jobs"/>
-            </package>
-        </packages>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientIT" />
+            <class name="com.joyent.manta.client.MantaClientPutIT" />
+            <class name="com.joyent.manta.client.MantaClientMetadataIT" />
+            <class name="com.joyent.manta.client.MantaObjectOutputStreamIT" />
+        </classes>
     </test>
     <test name="Manta Client Integration Tests [AES128/CBC Encrypted]">
         <parameter name="encryptionCipher" value="AES128/CBC/PKCS5Padding"/>
-        <groups>
-            <define name="cbc-cipher" />
-            <run>
-                <include name="encrypted"/>
-                <exclude name="encryption-provider" />
-                <exclude name="expensive" />
-                <exclude name="multipart" />
-            </run>
-        </groups>
-        <packages>
-            <package name="com.joyent.manta.client.*">
-                <exclude name="com.joyent.manta.client.jobs"/>
-            </package>
-        </packages>
+        <classes>
+            <class name="com.joyent.manta.client.MantaClientIT" />
+            <class name="com.joyent.manta.client.MantaClientPutIT" />
+            <class name="com.joyent.manta.client.MantaClientMetadataIT" />
+            <class name="com.joyent.manta.client.MantaObjectOutputStreamIT" />
+        </classes>
     </test>
     <test name="Manta Client Snaplinks Tests ">
         <parameter name="usingEncryption" value="true"/>
-        <groups>
-            <define name="snaplinks" />
-        </groups>
         <classes>
             <class name="com.joyent.manta.client.MantaClientSnapLinksIT" />
         </classes>
     </test>
     <test name="Manta Client Encrypted Multipart Tests ">
         <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
-        <groups>
-            <define name="multipart" />
-            <run>
-                <exclude name="expensive" />
-            </run>
-        </groups>
         <classes>
             <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
             <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerIT" />
@@ -238,8 +149,9 @@
         </classes>
     </test>
     <test name="Manta Job Tests">
-    <packages>
-        <package name="com.joyent.manta.client.jobs.*"/>
-    </packages>
+        <classes>
+            <class name="com.joyent.manta.client.jobs.MantaClientJobIT" />
+            <class name="com.joyent.manta.client.jobs.MantaJobBuilderIT" />
+        </classes>
     </test>
 </suite>

--- a/java-manta-it/src/test/resources/testng-it.xml
+++ b/java-manta-it/src/test/resources/testng-it.xml
@@ -35,43 +35,18 @@
 	        EncryptedServerSideMultipartManagerSerializationIT by adding groups > run > exclude = "encrypted" group
 	        so we resort to listing all desired unencrypted tests. This also helps discoverability!
 	        -->
-        <groups>
-            <run>
-                <exclude name="expensive" />
-            </run>
-        </groups>
         <classes>
             <class name="com.joyent.manta.client.MantaClientFindIT" />
             <class name="com.joyent.manta.client.MantaClientSigningIT" />
             <class name="com.joyent.manta.client.MantaClientSigningIT" />
-
-            <!-- Jobs-based MPU tests-->
-            <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
-            <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerIT" />
-            <class name="com.joyent.manta.client.jobs.MantaClientJobIT" />
+            <class name="com.joyent.manta.client.MantaClientAuthenticationChangeIT" />
         </classes>
     </test>
 
     <!-- We run many of the integration tests over again using client-side encryption -->
-    <test name="Manta Client Heavyweight Tests">
-        <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
-        <classes>
-            <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
-            <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerIT" />
-            <class name="com.joyent.manta.client.jobs.MantaClientJobIT" />
-        </classes>
-    </test>
     <test name="Manta Client Seekable Channel Tests">
         <parameter name="encryptionCipher" value="AES128/CTR/NoPadding"/>
-        <groups>
-            <run>
-                <exclude name="expensive" />
-            </run>
-        </groups>
         <classes>
-            <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
-            <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerIT" />
-            <class name="com.joyent.manta.client.jobs.MantaClientJobIT" />
             <class name="com.joyent.manta.client.MantaClientSeekableByteChannelIT" />
         </classes>
     </test>
@@ -93,10 +68,7 @@
             <class name="com.joyent.manta.client.MantaClientSeekableByteChannelIT" />
 
             <!-- MPU only supports AES/CTR -->
-            <class name="com.joyent.manta.client.multipart.ServerSideMultipartManagerIT" />
-            <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerIT" />
             <class name="com.joyent.manta.client.multipart.EncryptedServerSideMultipartManagerSerializationIT" />
-            <class name="com.joyent.manta.client.jobs.MantaClientJobIT" />
         </classes>
     </test>
     <test name="Manta Client Integration Tests [AES128/GCM Encrypted]">


### PR DESCRIPTION
# Goals
- Resolves #336 .
- Eliminate redundant integration-test runs.
- Test-Suite Size Reduction obtained from `609` tests -> `250` tests. 
- Class-Level Definition for every new integration-test that will be added in the future.
- Incorporate dry run capability for the TestNG Suite of SDK to determine test-methods that are executed and the order in which they are run, without actually executing them.
- These changes will further help in setting up a new Jenkins job `java-manta-pre-it` or simply update the existing one `java-manta-it` for new PR's made against the `Java SDK`.

# Challenges
Unfortunately TestNG doesn't comprehensively support filtering a test suite by groups so we **had** to be more explicit about suite definition.

# Overview
Adds a `it.dryRun` property that can be used to list the tests that would run with their respective TestNG params. TestNG unfortunately doesn't completely support filtering a test suite by groups so thorough detailing was required in suite definition.

Output of `mvn verify it.dryRun=true` using current `testng-it.xml` used with `TestListingInterceptor`:
```
[main] INFO  com.joyent.test.util.MantaPathSuiteListener [ ] - Base manta path for suite Java Manta SDK Integration Test Suite: /ashwin.nair/stor/java-manta-integration-tests/8669c9af-b512-4ac6-b7be-2390b6a5e61c/
[main] INFO  com.joyent.test.util.TestListingInterceptor [ ] - DRY-RUN: Listing [250] tests that would have run
--------------------------ALL-TESTS----------------------------------------------------------
main] INFO  com.joyent.test.util.MantaPathSuiteListener [ ] - Expected test count: 250
[main] WARN  com.joyent.test.util.MantaPathSuiteListener [ ] - Skipping suite cleanup since dry-run is enabled.
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.952 s - in TestSuite
```

List for the output for [before](https://gist.github.com/tjcelaya/fa82e54bd4be55ec95e1146954d7bd1f) & [after](https://gist.github.com/nairashwin952013/ae0a4799525654588bcce24e9595fd6a)  `-Dit.dryRun=true` respectively . Note that`dry-run-after` list is accurate since it shows single value for `encryptionCipher` i.e `AES128/CTR/NoPadding`. Other testing groups include `cbc-cipher` and `gcm-cipher` are also defined. 

# Changes

- change `usingEncryption` (boolean) to just `encryptionCipher` (string). omission (null) disables encryption

- add a new constructor for `IntegrationTestConfigContext` which handles the above

- switch from `@BeforeClass` with `@Parameters` to test constructors with just `@Parameters`. Whenever `SkipException` was thrown or `putDirectory` was called in a test which needed `@Parameters` a minimal method was created for `@BeforeClass`. The goal here was to make it safe to instantiate test classes without incurring side-effects.

- remove encryption param from tests which don't actually perform any object PUTs or MPU uploads (e.g. `MantaClientDirectoriesIT`)

- change `<packages>` to `<classes>` and target specific classes. 

- document a new system property `it.dryRun` which can be used by the new interceptor. When this system property is truthy as defined by `BooleanUtils#toBooleanObject`, i.e. the following are all true: `y`, `Y`, `t`, `T`, `on`, `ON`, `yes`, `YES`, `true`, `TRUE` and all the mixed-case versions thereof

- added a test listener called `TestListingInterceptor` which is used to collect suite definitions and disable actually running tests in the event `it.dryrun` is `true`.

- defined new `<test name></test>` and the **EXISTING** ones  in `testing-it.xml` more accurately using class-level specifications including **TestNG Group Definitions** : `timeout`, `range-downloads`, `snaplinks`, `seekable`, `error`, `headers`, `directory`, `metadata`, etc.

- Following up on #492 which **had** to be closed due to ```dependency-vulnerabilities```.

- Changes are incorporated from the closed PR #364 by Tomas which is to remove redundancies in ```integration-test``` runs.