### PR TITLE
Removing the usage of an extra MantaClient.SEPARATOR from the test cases

### DIFF
--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/http/EncryptedHttpHelperTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/http/EncryptedHttpHelperTest.java
@@ -33,7 +33,6 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
 import static com.joyent.manta.config.DefaultsConfigContext.DEFAULT_MANTA_URL;
-import static com.joyent.manta.client.MantaClient.SEPARATOR;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -74,7 +73,7 @@ public class EncryptedHttpHelperTest {
 
         boolean caught = false;
         try {
-            URI uri = URI.create(DEFAULT_MANTA_URL + SEPARATOR + path);
+            URI uri = URI.create(DEFAULT_MANTA_URL + path);
             HttpGet get = new HttpGet(uri);
             MantaHttpHeaders headers = new MantaHttpHeaders();
             httpHelper.httpRequestAsInputStream(get, headers);

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientDirectoriesIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientDirectoriesIT.java
@@ -54,9 +54,8 @@ public class MantaClientDirectoriesIT {
     public void beforeClass() throws IOException {
         config = new IntegrationTestConfigContext();
         mantaClient = new MantaClient(config);
-        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
-        //Remove the extra '/' from the testPathPrefix
-        testPathPrefix = testPathPrefix.substring(0, testPathPrefix.lastIndexOf(SEPARATOR));
+        testPathPrefix = IntegrationTestConfigContext.generateBasePathWithoutSeparator(config,
+                this.getClass().getSimpleName());
     }
 
     @AfterClass

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientDirectoriesIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientDirectoriesIT.java
@@ -55,6 +55,8 @@ public class MantaClientDirectoriesIT {
         config = new IntegrationTestConfigContext();
         mantaClient = new MantaClient(config);
         testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
+        //Remove the extra '/' from the testPathPrefix
+        testPathPrefix = testPathPrefix.substring(0, testPathPrefix.lastIndexOf(SEPARATOR));
     }
 
     @AfterClass

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientErrorIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientErrorIT.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.util.Properties;
 import java.util.UUID;
 
-import static com.joyent.manta.client.MantaClient.SEPARATOR;
 import static com.joyent.manta.exception.MantaErrorCode.ACCOUNT_DOES_NOT_EXIST_ERROR;
 import static com.joyent.manta.exception.MantaErrorCode.NO_CODE_ERROR;
 import static com.joyent.manta.exception.MantaErrorCode.RESOURCE_NOT_FOUND_ERROR;

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientErrorIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientErrorIT.java
@@ -51,9 +51,8 @@ public class MantaClientErrorIT {
         config = new IntegrationTestConfigContext(usingEncryption);
 
         mantaClient = new MantaClient(config);
-        testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
-        //Remove the extra '/' from the testPathPrefix
-        testPathPrefix = testPathPrefix.substring(0, testPathPrefix.lastIndexOf(SEPARATOR));
+        testPathPrefix = IntegrationTestConfigContext.generateBasePathWithoutSeparator(config,
+                this.getClass().getSimpleName());
         mantaClient.putDirectory(testPathPrefix, true);
     }
 

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientErrorIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientErrorIT.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.Properties;
 import java.util.UUID;
 
+import static com.joyent.manta.client.MantaClient.SEPARATOR;
 import static com.joyent.manta.exception.MantaErrorCode.ACCOUNT_DOES_NOT_EXIST_ERROR;
 import static com.joyent.manta.exception.MantaErrorCode.NO_CODE_ERROR;
 import static com.joyent.manta.exception.MantaErrorCode.RESOURCE_NOT_FOUND_ERROR;
@@ -51,6 +52,8 @@ public class MantaClientErrorIT {
 
         mantaClient = new MantaClient(config);
         testPathPrefix = IntegrationTestConfigContext.generateBasePath(config, this.getClass().getSimpleName());
+        //Remove the extra '/' from the testPathPrefix
+        testPathPrefix = testPathPrefix.substring(0, testPathPrefix.lastIndexOf(SEPARATOR));
         mantaClient.putDirectory(testPathPrefix, true);
     }
 

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
@@ -415,7 +415,7 @@ public class MantaClientIT {
 
     @Test
     public final void testList() throws IOException {
-        final String pathPrefix = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+        final String pathPrefix = String.format("%s%s", testPathPrefix, UUID.randomUUID());
         mantaClient.putDirectory(pathPrefix, null);
 
         mantaClient.put(String.format("%s/%s", pathPrefix, UUID.randomUUID()), "");

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientMetadataIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientMetadataIT.java
@@ -150,7 +150,7 @@ public class MantaClientMetadataIT {
 
     @Test(groups = { "metadata", "directory" })
     public void canAddMetadataToDirectory() throws IOException {
-        String dir = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+        String dir = String.format("%s%s", testPathPrefix, UUID.randomUUID());
         mantaClient.putDirectory(dir);
 
         MantaMetadata metadata = new MantaMetadata();

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaDirectoryListingIteratorIT.java
@@ -53,7 +53,7 @@ public class MantaDirectoryListingIteratorIT {
     }
 
     public void isPagingCorrectly() throws IOException {
-        String dir = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+        String dir = String.format("%s%s", testPathPrefix, UUID.randomUUID());
         mantaClient.putDirectory(dir);
 
         final int MAX = 30;
@@ -101,7 +101,7 @@ public class MantaDirectoryListingIteratorIT {
 
     @Test
     public void isPagingConcurrentlyCorrectly() throws IOException {
-        String dir = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+        String dir = String.format("%s%s", testPathPrefix, UUID.randomUUID());
         mantaClient.putDirectory(dir);
 
         final int MAX = 300;
@@ -157,7 +157,7 @@ public class MantaDirectoryListingIteratorIT {
     }
 
     public void canListEmptyDirectory() throws IOException {
-        String dir = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+        String dir = String.format("%s%s", testPathPrefix, UUID.randomUUID());
         mantaClient.putDirectory(dir);
 
         try (MantaDirectoryListingIterator itr = mantaClient.streamingIterator(dir, 10)) {
@@ -198,13 +198,13 @@ public class MantaDirectoryListingIteratorIT {
     }
 
     public void canListDirectoryUsingSmallPagingSize() throws IOException {
-        String dir = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+        String dir = String.format("%s%s", testPathPrefix, UUID.randomUUID());
         listDirectoryUsingSmallPagingSize(dir);
     }
 
     @Test(enabled = false) // Triggers server side bug: MANTA-2409
     public void canListDirectoryUsingSmallPagingSizeAndErrorProneName() throws IOException {
-        String dir = String.format("%s/%s/%s", testPathPrefix, UUID.randomUUID(), "- -!@#$%^&*()");
+        String dir = String.format("%s%s/%s", testPathPrefix, UUID.randomUUID(), "- -!@#$%^&*()");
         listDirectoryUsingSmallPagingSize(dir);
     }
 }

--- a/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaClientJobIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaClientJobIT.java
@@ -129,7 +129,8 @@ public class MantaClientJobIT {
         UUID jobId = mantaClient.createJob(job);
 
         List<String> inputs = new ArrayList<>();
-        String objPath = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+        
+        String objPath = String.format("%s%s", testPathPrefix, UUID.randomUUID());
         mantaClient.put(objPath, TEST_DATA);
         inputs.add(objPath);
 
@@ -151,7 +152,8 @@ public class MantaClientJobIT {
         UUID jobId = mantaClient.createJob(job);
 
         List<String> inputs = new ArrayList<>();
-        String objPath = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+        
+        String objPath = String.format("%s%s", testPathPrefix, UUID.randomUUID());
         mantaClient.put(objPath, TEST_DATA);
         inputs.add(objPath);
 
@@ -334,7 +336,7 @@ public class MantaClientJobIT {
 
     @Test
     public void canListOutputsForJobWithOneInput() throws IOException, InterruptedException {
-        String path = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+        String path = String.format("%s%s", testPathPrefix, UUID.randomUUID());
         mantaClient.put(path, TEST_DATA);
 
         final MantaJob job = buildJob();
@@ -360,10 +362,10 @@ public class MantaClientJobIT {
 
     @Test
     public void canListOutputsForJobAsStreams() throws IOException, InterruptedException {
-        String path1 = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+        String path1 = String.format("%s%s", testPathPrefix, UUID.randomUUID());
         mantaClient.put(path1, TEST_DATA);
-
-        String path2 = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+        
+        String path2 = String.format("%s%s", testPathPrefix, UUID.randomUUID());
         mantaClient.put(path2, TEST_DATA);
 
         final MantaJob job = buildJob();
@@ -396,10 +398,10 @@ public class MantaClientJobIT {
 
     @Test
     public void canListOutputsForJobAsStrings() throws IOException, InterruptedException {
-        String path1 = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+        String path1 = String.format("%s%s", testPathPrefix, UUID.randomUUID());
         mantaClient.put(path1, TEST_DATA);
 
-        String path2 = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+        String path2 = String.format("%s%s", testPathPrefix, UUID.randomUUID());
         mantaClient.put(path2, TEST_DATA);
 
         final MantaJob job = buildJob();
@@ -427,7 +429,7 @@ public class MantaClientJobIT {
 
     @Test
     public void canListFailedJobs() throws IOException, InterruptedException {
-        String path = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+        String path = String.format("%s%s", testPathPrefix, UUID.randomUUID());
         mantaClient.put(path, TEST_DATA);
 
         final MantaJob job = buildJob("failed_job", "grep foo");
@@ -449,10 +451,10 @@ public class MantaClientJobIT {
 
     @Test
     public void canGetJobErrors() throws IOException, InterruptedException {
-        String path1 = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+        String path1 = String.format("%s%s", testPathPrefix, UUID.randomUUID());
         mantaClient.put(path1, TEST_DATA);
 
-        String path2 = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+        String path2 = String.format("%s%s", testPathPrefix, UUID.randomUUID());
         mantaClient.put(path2, TEST_DATA);
 
         final MantaJob job = buildJob("failed_job", "grep foo");

--- a/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaJobBuilderIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/jobs/MantaJobBuilderIT.java
@@ -70,10 +70,10 @@ public class MantaJobBuilderIT {
         final MantaJobBuilder builder = mantaClient.jobBuilder();
 
         String jobName = String.format("job_%s", UUID.randomUUID());
-
-        String path1 = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
-        String path2 = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
-        String path3 = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+       
+        String path1 = String.format("%s%s", testPathPrefix, UUID.randomUUID());
+        String path2 = String.format("%s%s", testPathPrefix, UUID.randomUUID());
+        String path3 = String.format("%s%s", testPathPrefix, UUID.randomUUID());
 
         mantaClient.put(path1, TEST_DATA);
         mantaClient.put(path2, TEST_DATA);
@@ -117,9 +117,9 @@ public class MantaJobBuilderIT {
 
         String jobName = String.format("job_%s", UUID.randomUUID());
 
-        String path1 = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
-        String path2 = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
-        String path3 = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+        String path1 = String.format("%s%s", testPathPrefix, UUID.randomUUID());
+        String path2 = String.format("%s%s", testPathPrefix, UUID.randomUUID());
+        String path3 = String.format("%s%s", testPathPrefix, UUID.randomUUID());
 
         mantaClient.put(path1, TEST_DATA);
         mantaClient.put(path2, TEST_DATA);
@@ -160,9 +160,9 @@ public class MantaJobBuilderIT {
 
         String jobName = String.format("job_%s", UUID.randomUUID());
 
-        String path1 = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
-        String path2 = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
-        String path3 = String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+        String path1 = String.format("%s%s", testPathPrefix, UUID.randomUUID());
+        String path2 = String.format("%s%s", testPathPrefix, UUID.randomUUID());
+        String path3 = String.format("%s%s", testPathPrefix, UUID.randomUUID());
 
         mantaClient.put(path1, TEST_DATA);
         mantaClient.put(path2, TEST_DATA);

--- a/java-manta-it/src/test/java/com/joyent/manta/config/IntegrationTestConfigContext.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/config/IntegrationTestConfigContext.java
@@ -127,6 +127,10 @@ public class IntegrationTestConfigContext extends SystemSettingsConfigContext {
         return generateSuiteBasePath(config) + testBaseName + SEPARATOR;
     }
 
+    public static String generateBasePathWithoutSeparator(final ConfigContext config, final String testBaseName) {
+        return generateSuiteBasePath(config) + testBaseName;
+    }
+
     public static void cleanupTestDirectory(final MantaClient mantaClient, final String testPathPrefix) throws IOException {
         final Boolean skipCleanup = Boolean.valueOf(
                 ObjectUtils.firstNonNull(System.getenv("MANTA_IT_NO_CLEANUP"), System.getProperty("manta.it.no_cleanup")));

--- a/java-manta-it/src/test/java/com/joyent/manta/http/ApacheHttpGetResponseEntityContentContinuatorIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/http/ApacheHttpGetResponseEntityContentContinuatorIT.java
@@ -338,7 +338,7 @@ public class ApacheHttpGetResponseEntityContentContinuatorIT {
     }
 
     private String generatePath() {
-        return String.format("%s/%s", this.testPathPrefix, UUID.randomUUID());
+        return String.format("%s%s", this.testPathPrefix, UUID.randomUUID());
     }
 
     private MantaClient prepareClient(final SupportedCipherDetails cipherDetails,

--- a/java-manta-it/src/test/java/com/joyent/manta/http/MantaHttpHeadersIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/http/MantaHttpHeadersIT.java
@@ -302,6 +302,6 @@ public class MantaHttpHeadersIT {
     }
 
     private String generatePath() {
-        return String.format("%s/%s", testPathPrefix, UUID.randomUUID());
+        return String.format("%s%s", testPathPrefix, UUID.randomUUID());
     }
 }


### PR DESCRIPTION
The purpose of this PR is to remove extraneous usage of '/' in the path of the directories created during the execution of various test cases. This will provide uniformity in the test directory path creation and help to extend and write newer test cases in the future. 