### PR TITLE
Buckets Error Codes and Base Path for Buckets Integration-Tests

### DIFF
--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/exception/MantaErrorCode.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/exception/MantaErrorCode.java
@@ -335,6 +335,14 @@ public enum MantaErrorCode {
      */
     OPERATION_NOT_ALLOWED_ON_ROOT_DIRECTORY_ERROR("OperationNotAllowedOnRootDirectory"),
     /**
+     * Known component sources: muskie.
+     */
+    PARENT_NOT_BUCKET_ERROR("ParentNotBucket"),
+    /**
+     * Known component sources: muskie.
+     */
+    PARENT_NOT_BUCKET_ROOT_ERROR("ParentNotBucketRoot"),
+    /**
      * Known component sources: muskie, piranha.
      */
     PARENT_NOT_DIRECTORY_ERROR("ParentNotDirectory"),
@@ -513,6 +521,7 @@ public enum MantaErrorCode {
      * @param object object to read .toString() from, if null - it is passed on
      * @return Manta error code enum associated with serverCode parameter
      */
+    @SuppressWarnings("unused")
     public static MantaErrorCode valueOfCode(final Object object) {
         if (object == null) {
             return valueOfCode(null);

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/exception/MantaErrorCode.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/exception/MantaErrorCode.java
@@ -63,9 +63,28 @@ public enum MantaErrorCode {
      */
     AUTH_SCHEME_ERROR("AuthScheme"),
     /**
+     * @since 3.4.1
      * Known component sources: muppet, mahi, haproxy, sdc-cloudapi.
      */
     BAD_REQUEST_ERROR("BadRequest"),
+    /**
+     * @since 3.4.1
+     * Known component sources: muskie.
+     * statusCode: 409.
+     */
+    BUCKET_EXISTS_ERROR("BucketAlreadyExists"),
+    /**
+     * @since 3.4.1
+     * Known component sources: muskie.
+     * statusCode: 409.
+     */
+    BUCKET_NOT_EMPTY_ERROR("BucketNotEmpty"),
+    /**
+     * @since 3.4.1
+     * Known component sources: muskie.
+     * statusCode: 404.
+     */
+    BUCKET_NOT_FOUND_ERROR("BucketNotFound"),
     /**
      * @since 3.4.1
      * No known server-side code with that name, should be deprecated.
@@ -323,9 +342,11 @@ public enum MantaErrorCode {
      */
     NO_MATCHING_ROLE_TAG_ERROR("NoMatchingRoleTag"),
     /**
+     * @since 3.4.1, rest code for error corrected.
      * Known component sources: muskie, moray, electric-moray, marlin, manta-mako, manta-mola.
+     * statusCode: 404.
      */
-    OBJECT_NOT_FOUND_ERROR("ObjectNotFoundError"),
+    OBJECT_NOT_FOUND_ERROR("ObjectNotFound"),
     /**
      * Known component sources: muskie, piranha.
      */
@@ -335,11 +356,15 @@ public enum MantaErrorCode {
      */
     OPERATION_NOT_ALLOWED_ON_ROOT_DIRECTORY_ERROR("OperationNotAllowedOnRootDirectory"),
     /**
+     * @since 3.4.1
      * Known component sources: muskie.
+     * statusCode: 400.
      */
     PARENT_NOT_BUCKET_ERROR("ParentNotBucket"),
     /**
+     * @since 3.4.1
      * Known component sources: muskie.
+     * statusCode: 400.
      */
     PARENT_NOT_BUCKET_ROOT_ERROR("ParentNotBucketRoot"),
     /**

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/exception/MantaErrorCodeTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/exception/MantaErrorCodeTest.java
@@ -16,6 +16,7 @@ import static com.joyent.manta.exception.MantaErrorCode.NO_CODE_ERROR;
 import static com.joyent.manta.exception.MantaErrorCode.INVALID_LIMIT_ERROR;
 import static com.joyent.manta.exception.MantaErrorCode.NO_API_SERVERS_AVAILABLE;
 import static com.joyent.manta.exception.MantaErrorCode.OBJECT_NOT_FOUND_ERROR;
+import static com.joyent.manta.exception.MantaErrorCode.PARENT_NOT_BUCKET_ERROR;
 import static com.joyent.manta.exception.MantaErrorCode.ROOT_DIRECTORY_ERROR;
 
 /**
@@ -30,10 +31,12 @@ public class MantaErrorCodeTest {
         final MantaErrorCode actualLimitError = MantaErrorCode.valueOfCode("InvalidLimit");
         final MantaErrorCode actualNoApiError = MantaErrorCode.valueOfCode("NoApiServersAvailable");
         final MantaErrorCode actualObjectNotFoundError = MantaErrorCode.valueOfCode("ObjectNotFoundError");
+        final MantaErrorCode actualParentNotBucketError = MantaErrorCode.valueOfCode("ParentNotBucket");
 
         Assert.assertEquals(actualLimitError, INVALID_LIMIT_ERROR);
         Assert.assertEquals(actualNoApiError, NO_API_SERVERS_AVAILABLE);
         Assert.assertEquals(actualObjectNotFoundError, OBJECT_NOT_FOUND_ERROR);
+        Assert.assertEquals(actualParentNotBucketError, PARENT_NOT_BUCKET_ERROR);
     }
 
     public void valueOfCodeCanFindByNonmatching() {

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/exception/MantaErrorCodeTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/exception/MantaErrorCodeTest.java
@@ -30,7 +30,7 @@ public class MantaErrorCodeTest {
     public void valueOfCodeCanFindByMatchingCode() {
         final MantaErrorCode actualLimitError = MantaErrorCode.valueOfCode("InvalidLimit");
         final MantaErrorCode actualNoApiError = MantaErrorCode.valueOfCode("NoApiServersAvailable");
-        final MantaErrorCode actualObjectNotFoundError = MantaErrorCode.valueOfCode("ObjectNotFoundError");
+        final MantaErrorCode actualObjectNotFoundError = MantaErrorCode.valueOfCode("ObjectNotFound");
         final MantaErrorCode actualParentNotBucketError = MantaErrorCode.valueOfCode("ParentNotBucket");
 
         Assert.assertEquals(actualLimitError, INVALID_LIMIT_ERROR);

--- a/java-manta-it/src/test/java/com/joyent/manta/config/IntegrationTestConfigContext.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/config/IntegrationTestConfigContext.java
@@ -122,9 +122,12 @@ public class IntegrationTestConfigContext extends SystemSettingsConfigContext {
         return integrationTestBase;
     }
 
-
     public static String generateBasePath(final ConfigContext config, final String testBaseName) {
         return generateSuiteBasePath(config) + testBaseName + SEPARATOR;
+    }
+
+    public static String generateBucketsBasePath(final ConfigContext config, final String testBaseName) {
+        return generateSuiteBasePath(config) + testBaseName + SEPARATOR + "buckets" + SEPARATOR;
     }
 
     public static void cleanupTestDirectory(final MantaClient mantaClient, final String testPathPrefix) throws IOException {


### PR DESCRIPTION
- Added Muskie Error Codes for Buckets, Tests for checking the newly added `enums` in `MantaErrorCode`. 

- Refactored `OBJECT_NOT_FOUND_ERROR` rest-code value. 

- Added a new method `generateBucketsBasePath` in `IntegrationTestConfigContext`