### PR TITLE
Instructions on improving encryption performance for SunPKCS11

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -113,6 +113,7 @@ Below is a table of available configuration parameters followed by detailed desc
 | manta.permit_unencrypted_downloads | MANTA_UNENCRYPTED_DOWNLOADS    | false                                |                          |
 | manta.encryption_auth_mode         | MANTA_ENCRYPTION_AUTH_MODE     | Mandatory                            |                          |
 | manta.encryption_key_path          | MANTA_ENCRYPTION_KEY_PATH      |                                      |                          |
+| manta.preferred.security.providers |                                |SunPKCS11-NSS,BC,SunJCE               |                          |
 | manta.encryption_key_bytes         |                                |                                      |                          |
 | manta.encryption_key_bytes_base64  | MANTA_ENCRYPTION_KEY_BYTES     |                                      |                          |
 
@@ -317,7 +318,9 @@ attributes = compatibility
 ```
 
 Make sure that the name field is `NSS` because the SDK will only use the library if that specific
-name is set. Next, edit the following file: `$JAVA_HOME/jre/lib/security/java.security`
+name is set. Next, edit the following file: `$JAVA_HOME/jre/lib/security/java.security`:
+
+##### For JAVA 8
 
 Find the lines specifying security providers. It should look something like:
 ```
@@ -348,6 +351,44 @@ security.provider.9=org.jcp.xml.dsig.internal.dom.XMLDSigRI
 security.provider.10=sun.security.smartcardio.SunPCSC
 ```
 
+##### For JAVA 11
+
+Find the lines specifying security providers. It should look something like:
+```
+security.provider.1=SUN
+security.provider.2=SunRsaSign
+security.provider.3=SunEC
+security.provider.4=SunJSSE
+security.provider.5=SunJCE
+security.provider.6=SunJGSS
+security.provider.7=SunSASL
+security.provider.8=XMLDSig
+security.provider.9=SunPCSC
+security.provider.10=JdkLDAP
+security.provider.11=JdkSASL
+security.provider.12=Apple
+security.provider.13=SunPKCS11
+```
+
+Now, add a line in front of the first provider and make it provider number one,
+then appropriately increment the other providers:
+
+```
+security.provider.1=SunPKCS11 /etc/nss.cfg
+security.provider.2=SUN
+security.provider.3=SunRsaSign
+security.provider.4=SunEC
+security.provider.5=SunJSSE
+security.provider.6=SunJCE
+security.provider.7=SunJGSS
+security.provider.8=SunSASL
+security.provider.9=XMLDSig
+security.provider.10=SunPCSC
+security.provider.11=JdkLDAP
+security.provider.12=JdkSASL
+security.provider.13=Apple
+```
+
 Once this is complete, you should now have libnss providing your cryptographic
 functions.
 
@@ -373,7 +414,9 @@ java <...> -Dmanta.preferred.security.providers=SunJCE,BC,SunPKCS11-NSS
 ```  
 
 You may want to change the ranking if you are unable to use the libnss provider
-and still want the performance benefits of AES-NI via the SunJCE provider.
+and still want the performance benefits of AES-NI via the SunJCE provider. The 
+default encryption-provider precedence for SDK is mentioned in the configuration table 
+above.
 
 #### Enabling Native FastMD5 Support
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -317,10 +317,10 @@ nssDbMode = noDb
 attributes = compatibility
 ```
 
+##### For JAVA 8
+
 Make sure that the name field is `NSS` because the SDK will only use the library if that specific
 name is set. Next, edit the following file: `$JAVA_HOME/jre/lib/security/java.security`:
-
-##### For JAVA 8
 
 Find the lines specifying security providers. It should look something like:
 ```
@@ -353,6 +353,7 @@ security.provider.10=sun.security.smartcardio.SunPCSC
 
 ##### For JAVA 11
 
+Edit the following file: `$JAVA_HOME/conf/security/java.security`:
 Find the lines specifying security providers. It should look something like:
 ```
 security.provider.1=SUN

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
 
         <!-- Maven plugin dependency versions -->
         <maven-plexus-compiler-javac-errorprone.version>2.8.5</maven-plexus-compiler-javac-errorprone.version>
-        <maven-error-prone-core.version>2.3.3</maven-error-prone-core.version>
+        <maven-error-prone-core.version>2.3.4</maven-error-prone-core.version>
 
         <!-- Dependency versions -->
         <dependency.http-client-signature.version>4.0.10</dependency.http-client-signature.version>


### PR DESCRIPTION
## Issue
Experiencing Slower upload times with encryption enabled while using Java 11.

## Solution
- We will have an incremental approach towards a solution within which this is the first step i.e to provide SDK user with documentation that could be leveraged to understand how to enable libnss support with SunPKCS11 as the encryption-provider
- This will be followed by a dependency upgrade on both projects starting with java-http-signature since these supporting libraries require periodic upgrades. Refer PR: [java-http-signature#58](https://github.com/joyent/java-http-signature/pull/58).

## Miscellaneous
Upgraded dependency for error-prone compiler to eliminate IntelliJ IDE issues. For more information visit: [IDEA#231506](https://youtrack.jetbrains.com/issue/IDEA-231506?_ga=2.38613546.883588815.1583368157-2064489178.1583186455)

## References: 

- [MANTA-5040](https://jira.joyent.us/browse/MANTA-5040).
- [PKCS11 Reference Guide for jdk 11.](https://docs.oracle.com/en/java/javase/11/security/pkcs11-reference-guide1.html#GUID-C4ABFACB-B2C9-4E71-A313-79F881488BB9)
- [Java Algorithms Supported by the SunPKCS11 Provider](https://docs.oracle.com/en/java/javase/11/security/pkcs11-reference-guide1.html#GUID-D3EF9023-7DDC-435D-9186-D2FD05674777).
- [SREM-56]()https://jira.joyent.us/browse/SREM-56