### PR TITLE
MANTA-5075 close() function is working as expected

### DIFF
--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaObjectInputStream.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaObjectInputStream.java
@@ -55,8 +55,8 @@ public class MantaObjectInputStream extends InputStream implements MantaObject,
     /**
      * Create a new instance from the results of a GET HTTP call to the Manta API.
      *
-     * @param response      Metadata object built from request
-     * @param httpResponse  Response object created
+     * @param response Metadata object built from request
+     * @param httpResponse Response object created
      * @param backingStream Underlying stream being wrapped
      */
     public MantaObjectInputStream(final MantaObjectResponse response,
@@ -280,7 +280,6 @@ public class MantaObjectInputStream extends InputStream implements MantaObject,
      *
      * @throws IOException thrown when unable to abort connection
      */
-    @SuppressWarnings("unused")
     public void abortConnection() throws IOException {
         if (backingStream instanceof EofSensorInputStream) {
             ((EofSensorInputStream) backingStream).abortConnection();

--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaObjectInputStream.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaObjectInputStream.java
@@ -187,15 +187,14 @@ public class MantaObjectInputStream extends InputStream implements MantaObject,
     /**
      * <p>Closes this stream.</p>
      *
-     * <p>This is a special version of {@link #close close()} which prevents
-     * re-use of the underlying connection, if any. Calling this method
-     * indicates that there should be no attempt to read until the end of
-     * the stream.</p>
+     * <p>This is a special version of {@link AutoCloseable#close()}
+     * which allows re-use of the underlying connection,
+     * if any.</p>
      *
      * <p>If the backing stream of the connection is not a
-     * {@link EofSensorInputStream}, this method will call {@link #close()}.
-     * This subsequently closes the input stream and releases any system resources associated
-     * with the stream.</p>
+     * {@link EofSensorInputStream}, this method will call
+     * {@link InputStream#close()}. This subsequently closes the input stream
+     * and releases any system resources associated with the stream.</p>
      *
      * @throws IOException thrown when unable to close connection
      */
@@ -218,12 +217,14 @@ public class MantaObjectInputStream extends InputStream implements MantaObject,
                 /* Since we will be throwing an exception when closing the backing
                 * stream, we will only log the error thrown when closing the
                 * response because we can only throw up a single exception. */
-                closeHttpResponse();
+                MantaIOException mio = new MantaResourceCloseException(e);
+                LOGGER.error("Unable to close backing stream", mio);
             } finally {
                 closeHttpResponse();
             }
         }
     }
+
     /**
      * Closes the underlying response sent by Manta API and
      * releases any system resources associated with it.
@@ -273,10 +274,9 @@ public class MantaObjectInputStream extends InputStream implements MantaObject,
      * the stream.</p>
      *
      * <p>If the backing stream of the connection is not a
-     * {@link EofSensorInputStream}, this method with call {@link #close()}.</p>
-     *
-     * <p>This method is deprecated because we can't rely on the underlying
-     * backing stream to always be a {@link EofSensorInputStream}.</p>
+     * {@link EofSensorInputStream}, this method with call {@link #close()}.
+     * This method relies on the assumption positing backing stream to always
+     * be an instance of {@link EofSensorInputStream}.</p>
      *
      * @throws IOException thrown when unable to abort connection
      */

--- a/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
+++ b/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientIT.java
@@ -160,6 +160,38 @@ public class MantaClientIT {
     }
 
     @Test
+    public final void createMantaObjectStreamCloseInOneThreadAndAbortInAnother()
+            throws Exception {
+        final String name = UUID.randomUUID().toString();
+        final String path = testPathPrefix + name;
+
+        try (InputStream in = new RandomInputStream(10000)) {
+            mantaClient.put(path, in);
+        }
+
+        File temp = File.createTempFile("object-" + name, ".data");
+        FileUtils.forceDeleteOnExit(temp);
+        FileOutputStream out = new FileOutputStream(temp);
+        FileOutputStream out2 = new FileOutputStream(temp);
+
+        Callable<InputStream> callable = () -> mantaClient.getAsInputStream(path);
+
+        ExecutorService service = Executors.newFixedThreadPool(2);
+        MantaObjectInputStream in = (MantaObjectInputStream) service.submit(callable).get();
+        MantaObjectInputStream in2 = (MantaObjectInputStream) service.submit(callable).get();
+
+        try {
+            IOUtils.copyLarge(in, out);
+            IOUtils.copyLarge(in2, out2);
+        } finally {
+            in.abortConnection();
+            out.close();
+            in2.close();
+            out2.close();
+        }
+    }
+
+    @Test
     public final void testManyOperations() throws IOException {
         String dir = testPathPrefix + "multiple";
         mantaClient.putDirectory(dir);


### PR DESCRIPTION
**Investigate MANTA close() function is working as expected.** 

## Background:

Mex servers are downloading Manta object to read via inputStream. Once the inputStream is opened and read a few bytes on the head of the file, it closes using close() function. However, the traffic to MANTA seems not been closed, and the application will try to open the same file using inputStream again and close it a few times.

## Concerns Raised:

1. After inputStream close(), download traffic is triggered for a long time, please analyze the close() function is working as expected.
2. abortConnection() seems to be deprecated soon, please confirm if OK to use in production level.

## Test Application:

```
// test code 
try (InputStream is = client.getAsInputStream(mantaFile, header)){
Scanner scanner = new Scanner(is, StandardCharsets.UTF_8.name());
for (int i=0; i<1; i++) {
//while (scanner.hasNextLine()) {
System.out.println(scanner.nextLine());
}
//is.abortConnection();
//is.close();
}
////connection is not closed//////
```

## Analysis:

- The significant difference between `close()` and `abortConnection()` is that one permits reusing underlying streams once closing the stream is attempted while the other doesn't. 

- Historically they both implemented `IOUtils.closeQuietly()` which ended up violating the API definition on how streams are handled in Java and the reason why these changes were made in #485  but ever since that method got deprecated, we had to adopt alternate choices.

#### Reasons for that being as follows:-
The vast majority of closable(s) fell into two categories but I only mentioned the category that's relevant to this issue: 
> A readable; InputStream or Reader (in our case InputStream). The vast majority of implementations of any such streams never actually throw IOException, so the `close()` method does nothing of any use whatsoever. `closeQuietly` lets you dodge the need to formally handle the wont-actually-ever-happen IOException, but this is rarely needed as the close method is usually near the read methods, which can and do throw IOException. 
So what #485 essentially did was to pop the close() call into the try block. 

- It seems the customer wants to prematurely terminate connections to their server while downloading objects(s).

#### Q: Why abortConnection() works ?
Ans: Closables.close() does have a realistic use case (to facilitate the throwing of the first exception, and not the 'followup' usually less useful exception thrown by the close method once a write/read has already failed). This essentially means when the deprecated method is called its prevents reusing the underlying connection, that has been attempted to terminate, which essentially means there are no more attempts allowed to attempt reading the underlying stream once abortConnection() is called.

## Solution:

- After much deliberation undeprecating `abortConnection()` is a wise move given customer's usage of downloading objects.

- Reconfigured close to use underlying ` EofSensorInputStream.close()` which has a better implementation call since most usages seem to be pertinent to that condition.

- Introduced `null` check which was missing earlier and refactored code based on how we handle streams post Java 7. For more details visit the references listed below.

## References:

- [Oracle Docs on try-resource-close](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html).

- [Apache docs listing IOUtils as deprecated](https://commons.apache.org/proper/commons-io/apidocs/deprecated-list.html).

- [blog post on closing-streams-in-java](https://stackoverflow.com/questions/515975/closing-streams-in-java).
