### PR TITLE
MANTA-5143 Data integrity issue with Java SDK 3.4.2

### DIFF
--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/AesCtrCipherDetails.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/crypto/AesCtrCipherDetails.java
@@ -148,9 +148,9 @@ public final class AesCtrCipherDetails extends AbstractAesCipherDetails {
             // mask is used so that the addition is not performed on negative
             // values because all Java types are signed.
             int newIVByteAsInt = ((int)iv[ivIndex] & 0xff) + ((int)startingBlockArray[ivIndex] & 0xff) + carry;
-            byte newIVByte = (byte) newIVByteAsInt;
             carry = newIVByteAsInt >>> 8;
-            updatedIV[ivIndex] = (byte)newIVByte;
+            byte newIVByte = (byte) newIVByteAsInt;
+            updatedIV[ivIndex] = newIVByte;
         }
         return new IvParameterSpec(updatedIV);
     }

--- a/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/crypto/AesCtrCipherDetailsTest.java
+++ b/java-manta-client-unshaded/src/test/java/com/joyent/manta/client/crypto/AesCtrCipherDetailsTest.java
@@ -229,7 +229,7 @@ public class AesCtrCipherDetailsTest extends AbstractCipherDetailsTest {
 
             // Calculate BigInteger value of IV
             final BigInteger ivBigInt = new BigInteger(iv);
-            if (ivBigInt.compareTo(BigInteger.ZERO) == -1) {
+            if (ivBigInt.compareTo(BigInteger.ZERO) < 0) {
                 done = true;
             }
         }


### PR DESCRIPTION
This corrects a bug introduced in #562 that prevented correct decryption of some objects encrypted using AES CTR mode. The objects susceptible to this bug are ones where IV values generated during the encryption process are interpreted as negative `BigInteger` values. The calculation of applying the CTR mode offset to the initial, randomly-generated IV and the conversion back to a byte array yielded incorrect results in such cases and prevented correct decryption of the associated objects. This PR changes the method used to determine the IV value to use for decrypting the request to instead use operations directly on the byte array rather than converting the values to `BigInteger` values.

This PR also adds testing to ensure that the IV calculation when using an offset of zero results in an IV that is identical to the input IV. 