### PR TITLE
MANTA-5075 Refactor close() in MantaObjectInputStream

### DIFF
--- a/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaObjectInputStream.java
+++ b/java-manta-client-unshaded/src/main/java/com/joyent/manta/client/MantaObjectInputStream.java
@@ -206,7 +206,7 @@ public class MantaObjectInputStream extends InputStream implements MantaObject,
         }
 
         if (backingStream instanceof EofSensorInputStream) {
-                ((EofSensorInputStream) backingStream).close();
+                ((EofSensorInputStream) backingStream).abortConnection();
                 closeHttpResponse();
             } else {
             try {


### PR DESCRIPTION
Since the API behavior of the SDK historically wrt `InputStream` had similar implementations for `close()` and `abortConnection()`. These changes are made to revert to that.